### PR TITLE
feat: redesign seller commitments page with lot-grouped cards and det…

### DIFF
--- a/app/dashboard/seller/commitments/[lotId]/page.tsx
+++ b/app/dashboard/seller/commitments/[lotId]/page.tsx
@@ -1,0 +1,262 @@
+import { createClient } from "@/lib/supabase/server";
+import { redirect, notFound } from "next/navigation";
+import Link from "next/link";
+import { ArrowLeft, ShoppingCart } from "lucide-react";
+import { Card, CardContent } from "@/components/mernin/Card";
+import { Badge } from "@/components/mernin/Badge";
+import { UnitWeightText, UnitPriceText } from "@/components/unit-value";
+
+function getCurrentLotPrice(
+  lot: { committed_quantity_kg: number; price_per_kg: number },
+  tiers: { min_quantity_kg: number; price_per_kg: number }[]
+): number {
+  const basePrice = Number(lot.price_per_kg || 0);
+  if (tiers.length === 0) return basePrice;
+  const committedQty = Number(lot.committed_quantity_kg || 0);
+  const sortedDesc = [...tiers].sort(
+    (a, b) => Number(b.min_quantity_kg) - Number(a.min_quantity_kg)
+  );
+  for (const tier of sortedDesc) {
+    if (committedQty >= Number(tier.min_quantity_kg)) return Number(tier.price_per_kg);
+  }
+  return basePrice;
+}
+
+const statusBadge: Record<
+  "Open / At Risk" | "Open / Guaranteed" | "Successful",
+  { variant: "hot" | "fresh" | "outline"; className?: string }
+> = {
+  "Open / At Risk": { variant: "hot" },
+  "Open / Guaranteed": { variant: "outline", className: "bg-sky/20 text-sky border-sky" },
+  Successful: { variant: "fresh" },
+};
+
+const statusDescription: Record<"Open / At Risk" | "Open / Guaranteed" | "Successful", string> = {
+  "Open / At Risk":
+    "This campaign is active but hasn't reached its minimum commitment. Your payout depends on enough buyers committing before the deadline.",
+  "Open / Guaranteed":
+    "The minimum commitment has been reached — this lot will sell. The final price may still change as more buyers commit.",
+  Successful: "This campaign closed successfully. Your payout is based on the final price below.",
+};
+
+function formatMoney(amount: number, currency: string) {
+  return new Intl.NumberFormat(undefined, {
+    style: "currency",
+    currency: currency.toUpperCase(),
+    maximumFractionDigits: 2,
+  }).format(amount);
+}
+
+export default async function SellerLotCommitmentsPage({
+  params,
+}: {
+  params: Promise<{ lotId: string }>;
+}) {
+  const { lotId } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/auth/login");
+
+  const { data: lot } = await supabase
+    .from("lots")
+    .select("id, title, committed_quantity_kg, min_commitment_kg, currency, price_per_kg, seller_id")
+    .eq("id", lotId)
+    .eq("seller_id", user.id)
+    .single();
+
+  if (!lot) notFound();
+
+  const [{ data: campaign }, { data: pricingTiers }] = await Promise.all([
+    supabase
+      .from("campaigns")
+      .select("id, status, deadline, hub:hubs(id, name)")
+      .eq("lot_id", lotId)
+      .in("status", ["active", "settled"])
+      .order("created_at", { ascending: false })
+      .limit(1)
+      .maybeSingle(),
+    supabase
+      .from("pricing_tiers")
+      .select("lot_id, min_quantity_kg, price_per_kg")
+      .eq("lot_id", lotId)
+      .order("min_quantity_kg", { ascending: true }),
+  ]);
+
+  const tiers = pricingTiers || [];
+  const currentPricePerKg = getCurrentLotPrice(lot, tiers);
+
+  let commitments: {
+    id: string;
+    quantity_kg: number;
+    created_at: string;
+    buyer: { company_name: string | null; contact_name: string | null } | null;
+  }[] = [];
+
+  if (campaign) {
+    const { data } = await supabase
+      .from("commitments")
+      .select(
+        "id, quantity_kg, created_at, buyer:profiles!commitments_buyer_id_fkey(company_name, contact_name)"
+      )
+      .eq("campaign_id", campaign.id)
+      .neq("status", "cancelled")
+      .order("created_at", { ascending: false });
+    commitments = (data || []) as unknown as typeof commitments;
+  }
+
+  const hub = (campaign?.hub as unknown) as { id: string; name: string } | null;
+
+  let statusLabel: "Open / At Risk" | "Open / Guaranteed" | "Successful" | null = null;
+  if (campaign) {
+    if (campaign.status === "settled") {
+      statusLabel = "Successful";
+    } else if (Number(lot.committed_quantity_kg) >= Number(lot.min_commitment_kg)) {
+      statusLabel = "Open / Guaranteed";
+    } else {
+      statusLabel = "Open / At Risk";
+    }
+  }
+
+  const totalCommittedKg = commitments.reduce(
+    (sum, c) => sum + Number(c.quantity_kg || 0),
+    0
+  );
+  const projectedRevenue = totalCommittedKg * currentPricePerKg;
+
+  const badge = statusLabel ? statusBadge[statusLabel] : null;
+
+  return (
+    <div>
+      <div className="mb-6">
+        <Link
+          href="/dashboard/seller/commitments"
+          className="mb-4 inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <ArrowLeft className="h-3.5 w-3.5" />
+          Back to Commitments
+        </Link>
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h1 className="text-2xl font-semibold tracking-tight text-foreground">{lot.title}</h1>
+            {hub && <p className="mt-1 text-sm text-muted-foreground">{hub.name}</p>}
+          </div>
+          {badge && statusLabel && (
+            <Badge variant={badge.variant} className={badge.className}>
+              {statusLabel}
+            </Badge>
+          )}
+        </div>
+        {statusLabel && (
+          <p className="mt-2 text-sm text-muted-foreground">{statusDescription[statusLabel]}</p>
+        )}
+        {campaign?.status === "active" && campaign.deadline && (
+          <p className="mt-1 text-xs text-muted-foreground">
+            Deadline:{" "}
+            {new Date(campaign.deadline).toLocaleDateString(undefined, {
+              month: "long",
+              day: "numeric",
+              year: "numeric",
+            })}
+          </p>
+        )}
+      </div>
+
+      {/* Revenue summary */}
+      {commitments.length > 0 && (
+        <Card className="mb-6 shadow-sm">
+          <CardContent className="p-4">
+            <p className="mb-3 text-xs font-bold uppercase tracking-widest text-muted-foreground">
+              Revenue Summary
+            </p>
+            <div className="grid grid-cols-3 gap-4 text-sm">
+              <div>
+                <p className="text-xs text-muted-foreground">Total Committed</p>
+                <p className="font-semibold text-foreground">
+                  <UnitWeightText kg={totalCommittedKg} />
+                </p>
+              </div>
+              <div>
+                <p className="text-xs text-muted-foreground">Current Price</p>
+                <p className="font-semibold text-foreground">
+                  <UnitPriceText pricePerKg={currentPricePerKg} currency={lot.currency || "USD"} />
+                </p>
+              </div>
+              <div>
+                <p className="text-xs text-muted-foreground">
+                  {statusLabel === "Successful" ? "Total Revenue" : "Projected Revenue"}
+                </p>
+                <p className="font-semibold text-foreground">
+                  {formatMoney(projectedRevenue, lot.currency || "USD")}
+                </p>
+              </div>
+            </div>
+            {tiers.length > 0 && (
+              <p className="mt-3 text-xs text-muted-foreground">
+                Buyer pricing includes the 10% platform fee. Your payout is based on the seller
+                price shown above.
+              </p>
+            )}
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Commitment list */}
+      <div className="mb-3 flex items-center justify-between">
+        <h2 className="text-sm font-semibold text-foreground">
+          Commitments ({commitments.length})
+        </h2>
+      </div>
+
+      {commitments.length === 0 ? (
+        <Card className="shadow-sm">
+          <CardContent className="flex flex-col items-center px-4 py-10">
+            <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-secondary text-muted-foreground">
+              <ShoppingCart className="h-6 w-6" />
+            </div>
+            <p className="text-sm text-muted-foreground">No commitments on this lot yet.</p>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="space-y-2">
+          {commitments.map((c) => {
+            const buyerName =
+              c.buyer?.company_name || c.buyer?.contact_name || "Unknown Buyer";
+            const sellerAmount = Number(c.quantity_kg || 0) * currentPricePerKg;
+            return (
+              <Card key={c.id} className="shadow-sm">
+                <CardContent className="p-4">
+                  <div className="flex items-center justify-between gap-3">
+                    <p className="text-sm font-semibold text-foreground">{buyerName}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {new Date(c.created_at).toLocaleDateString(undefined, {
+                        month: "short",
+                        day: "numeric",
+                        year: "numeric",
+                      })}
+                    </p>
+                  </div>
+                  <div className="mt-3 grid grid-cols-2 gap-3 text-sm">
+                    <div>
+                      <p className="text-xs text-muted-foreground">Weight</p>
+                      <p className="font-medium text-foreground">
+                        <UnitWeightText kg={Number(c.quantity_kg)} />
+                      </p>
+                    </div>
+                    <div>
+                      <p className="text-xs text-muted-foreground">Your Amount</p>
+                      <p className="font-semibold text-foreground">
+                        {formatMoney(sellerAmount, lot.currency || "USD")}
+                      </p>
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/dashboard/seller/commitments/page.tsx
+++ b/app/dashboard/seller/commitments/page.tsx
@@ -1,18 +1,22 @@
 import { createClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
-import { Card, CardContent } from "@/components/mernin/Card";
-import { Badge } from "@/components/mernin/Badge";
-import { ShoppingCart } from "lucide-react";
-import type { Commitment } from "@/lib/types";
-import { UnitPriceText, UnitWeightText } from "@/components/unit-value";
+import { SellerCommitmentsClient, type LotCampaignCard } from "@/components/seller-commitments-client";
 
-const statusStyles: Record<string, string> = {
-  pending: "bg-amber-50 text-amber-700 border-amber-200",
-  confirmed: "bg-emerald-50 text-emerald-700 border-emerald-200",
-  cancelled: "bg-red-50 text-red-700 border-red-200",
-  shipped: "bg-blue-50 text-blue-700 border-blue-200",
-  delivered: "bg-emerald-50 text-emerald-700 border-emerald-200",
-};
+function getCurrentLotPrice(
+  lot: { committed_quantity_kg: number; price_per_kg: number },
+  tiers: { min_quantity_kg: number; price_per_kg: number }[]
+): number {
+  const basePrice = Number(lot.price_per_kg || 0);
+  if (tiers.length === 0) return basePrice;
+  const committedQty = Number(lot.committed_quantity_kg || 0);
+  const sortedDesc = [...tiers].sort(
+    (a, b) => Number(b.min_quantity_kg) - Number(a.min_quantity_kg)
+  );
+  for (const tier of sortedDesc) {
+    if (committedQty >= Number(tier.min_quantity_kg)) return Number(tier.price_per_kg);
+  }
+  return basePrice;
+}
 
 export default async function SellerCommitmentsPage() {
   const supabase = await createClient();
@@ -23,88 +27,101 @@ export default async function SellerCommitmentsPage() {
 
   const { data: lots } = await supabase
     .from("lots")
-    .select("id, title")
+    .select("id, title, committed_quantity_kg, min_commitment_kg, currency, price_per_kg")
     .eq("seller_id", user.id);
 
   const lotIds = (lots || []).map((l) => l.id);
-  const lotMap = Object.fromEntries((lots || []).map((l) => [l.id, l.title]));
 
-  const { data: commitments } = await supabase
-    .from("commitments")
-    .select("*, buyer:profiles!commitments_buyer_id_fkey(company_name, contact_name)")
-    .in("lot_id", lotIds.length > 0 ? lotIds : ["00000000-0000-0000-0000-000000000000"])
-    .order("created_at", { ascending: false });
+  const lotMap = Object.fromEntries((lots || []).map((l) => [l.id, l]));
 
-  const items = (commitments || []) as (Commitment & {
-    buyer: { company_name: string | null; contact_name: string | null } | null;
-  })[];
+  let cards: LotCampaignCard[] = [];
+
+  if (lotIds.length > 0) {
+    const { data: campaigns } = await supabase
+      .from("campaigns")
+      .select("id, lot_id, status, created_at, hub:hubs(id, name)")
+      .in("lot_id", lotIds)
+      .in("status", ["active", "settled"])
+      .order("created_at", { ascending: false });
+
+    const campaignIds = (campaigns || []).map((c) => c.id);
+
+    const [{ data: commitments }, { data: pricingTiers }] = await Promise.all([
+      campaignIds.length > 0
+        ? supabase
+            .from("commitments")
+            .select("id, campaign_id, lot_id, quantity_kg")
+            .in("campaign_id", campaignIds)
+            .neq("status", "cancelled")
+        : Promise.resolve({ data: [] }),
+      supabase
+        .from("pricing_tiers")
+        .select("lot_id, min_quantity_kg, price_per_kg")
+        .in("lot_id", lotIds)
+        .order("min_quantity_kg", { ascending: true }),
+    ]);
+
+    const commitmentsByCampaignId: Record<string, { quantity_kg: number }[]> = {};
+    for (const c of commitments || []) {
+      if (!c.campaign_id) continue;
+      if (!commitmentsByCampaignId[c.campaign_id]) commitmentsByCampaignId[c.campaign_id] = [];
+      commitmentsByCampaignId[c.campaign_id].push(c);
+    }
+
+    const tiersByLotId: Record<string, { min_quantity_kg: number; price_per_kg: number }[]> = {};
+    for (const t of pricingTiers || []) {
+      if (!tiersByLotId[t.lot_id]) tiersByLotId[t.lot_id] = [];
+      tiersByLotId[t.lot_id].push(t);
+    }
+
+    // One card per campaign (one active/settled campaign per lot at a time)
+    for (const campaign of campaigns || []) {
+      const lot = lotMap[campaign.lot_id];
+      if (!lot) continue;
+
+      const lotCommitments = commitmentsByCampaignId[campaign.id] || [];
+      if (lotCommitments.length === 0) continue;
+
+      const totalCommittedKg = lotCommitments.reduce(
+        (sum, c) => sum + Number(c.quantity_kg || 0),
+        0
+      );
+
+      const tiers = tiersByLotId[lot.id] || [];
+      const currentPricePerKg = getCurrentLotPrice(lot, tiers);
+
+      const hub = (campaign.hub as unknown) as { id: string; name: string } | null;
+
+      let statusLabel: LotCampaignCard["statusLabel"];
+      if (campaign.status === "settled") {
+        statusLabel = "Successful";
+      } else if (Number(lot.committed_quantity_kg) >= Number(lot.min_commitment_kg)) {
+        statusLabel = "Open / Guaranteed";
+      } else {
+        statusLabel = "Open / At Risk";
+      }
+
+      cards.push({
+        lotId: lot.id,
+        lotTitle: lot.title,
+        hubName: hub?.name ?? null,
+        statusLabel,
+        totalCommittedKg,
+        currentPricePerKg,
+        currency: lot.currency || "USD",
+      });
+    }
+  }
 
   return (
     <div>
       <div className="mb-8">
-        <h1 className="text-2xl font-semibold tracking-tight text-foreground">Incoming Commitments</h1>
-        <p className="text-sm text-muted-foreground mt-1">Commitments received from buyers across your lots.</p>
+        <h1 className="text-2xl font-semibold tracking-tight text-foreground">Commitments</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Buyer commitments grouped by lot and campaign.
+        </p>
       </div>
-
-      {items.length === 0 ? (
-        <Card className="shadow-sm">
-          <CardContent className="flex flex-col items-center py-10 px-4">
-            <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-secondary text-muted-foreground mb-4">
-              <ShoppingCart className="h-6 w-6" />
-            </div>
-            <p className="text-sm text-muted-foreground">No commitments received yet.</p>
-          </CardContent>
-        </Card>
-      ) : (
-        <div className="space-y-3">
-          {items.map((c) => {
-            const sellerTotal = Number(c.quantity_kg || 0) * Number(c.price_per_kg || 0);
-            return (
-            <Card key={c.id} className="shadow-sm">
-              <CardContent className="p-4">
-                <div className="flex items-start justify-between gap-3">
-                  <div className="min-w-0 flex-1">
-                    <p className="text-sm font-semibold text-foreground">
-                      {lotMap[c.lot_id] || "Unknown"}
-                    </p>
-                    <p className="text-xs text-muted-foreground mt-0.5">
-                      {c.buyer?.company_name || c.buyer?.contact_name || "Buyer"}
-                    </p>
-                  </div>
-                  <Badge variant="outline" className={`shrink-0 text-xs ${statusStyles[c.status] || ""}`}>
-                    {c.status.charAt(0).toUpperCase() + c.status.slice(1)}
-                  </Badge>
-                </div>
-                <div className="mt-3 grid grid-cols-3 gap-3 text-sm">
-                  <div>
-                    <p className="text-xs text-muted-foreground">Quantity</p>
-                    <p className="font-medium text-foreground">
-                      <UnitWeightText kg={c.quantity_kg} />
-                    </p>
-                  </div>
-                  <div>
-                    <p className="text-xs text-muted-foreground">Your Price</p>
-                    <p className="font-medium text-foreground">
-                      <UnitPriceText pricePerKg={c.price_per_kg} />
-                    </p>
-                  </div>
-                  <div>
-                    <p className="text-xs text-muted-foreground">Your Total</p>
-                    <p className="font-semibold text-foreground">${sellerTotal.toLocaleString()}</p>
-                  </div>
-                </div>
-                <p className="mt-2 text-xs text-muted-foreground">
-                  Buyer pricing includes the 10% platform fee. Your payout is based on the seller price above.
-                </p>
-                <p className="mt-2 text-xs text-muted-foreground">
-                  {new Date(c.created_at).toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" })}
-                </p>
-              </CardContent>
-            </Card>
-            );
-          })}
-        </div>
-      )}
+      <SellerCommitmentsClient cards={cards} />
     </div>
   );
 }

--- a/components/seller-commitments-client.tsx
+++ b/components/seller-commitments-client.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { Search, ShoppingCart } from "lucide-react";
+import { Input } from "@/components/mernin/Input";
+import { Card, CardContent } from "@/components/mernin/Card";
+import { Badge } from "@/components/mernin/Badge";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { UnitWeightText, UnitPriceText } from "@/components/unit-value";
+
+export type LotCampaignCard = {
+  lotId: string;
+  lotTitle: string;
+  hubName: string | null;
+  statusLabel: "Open / At Risk" | "Open / Guaranteed" | "Successful";
+  totalCommittedKg: number;
+  currentPricePerKg: number;
+  currency: string;
+};
+
+type StatusFilter = LotCampaignCard["statusLabel"] | "all";
+
+const statusBadge: Record<
+  LotCampaignCard["statusLabel"],
+  { variant: "hot" | "fresh" | "outline"; className?: string }
+> = {
+  "Open / At Risk": { variant: "hot" },
+  "Open / Guaranteed": { variant: "outline", className: "bg-sky/20 text-sky border-sky" },
+  Successful: { variant: "fresh" },
+};
+
+export function SellerCommitmentsClient({ cards }: { cards: LotCampaignCard[] }) {
+  const [search, setSearch] = useState("");
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
+
+  const filtered = cards.filter((card) => {
+    if (statusFilter !== "all" && card.statusLabel !== statusFilter) return false;
+    if (!search.trim()) return true;
+    const q = search.toLowerCase();
+    return (
+      card.lotTitle.toLowerCase().includes(q) ||
+      (card.hubName?.toLowerCase().includes(q) ?? false)
+    );
+  });
+
+  const hasFilters = search.trim() || statusFilter !== "all";
+
+  return (
+    <div>
+      <div className="mb-4 flex flex-col gap-2 sm:flex-row">
+        <div className="relative flex-1">
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-espresso/40" />
+          <Input
+            placeholder="Search by lot or hub..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="pl-9"
+          />
+        </div>
+        <Select value={statusFilter} onValueChange={(v) => setStatusFilter(v as StatusFilter)}>
+          <SelectTrigger className="h-10 w-full rounded-[12px] border-3 border-espresso bg-chalk font-body text-sm text-espresso shadow-flat-sm focus:ring-0 focus:ring-offset-0 focus:-translate-x-[1px] focus:-translate-y-[1px] focus:shadow-[4px_4px_0px_theme(colors.tomato)] focus:border-tomato sm:w-48">
+            <SelectValue placeholder="All statuses" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All statuses</SelectItem>
+            <SelectItem value="Open / At Risk">Open / At Risk</SelectItem>
+            <SelectItem value="Open / Guaranteed">Open / Guaranteed</SelectItem>
+            <SelectItem value="Successful">Successful</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      {filtered.length === 0 ? (
+        <Card className="shadow-sm">
+          <CardContent className="flex flex-col items-center px-4 py-10">
+            <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-secondary text-muted-foreground">
+              <ShoppingCart className="h-6 w-6" />
+            </div>
+            <p className="text-sm text-muted-foreground">
+              {hasFilters ? "No lots match your filters." : "No commitments yet."}
+            </p>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="space-y-4">
+          {filtered.map((card) => {
+            const badge = statusBadge[card.statusLabel];
+            return (
+              <Link key={card.lotId} href={`/dashboard/seller/commitments/${card.lotId}`}>
+                <Card className="cursor-pointer shadow-sm transition-all duration-150 hover:-translate-x-[2px] hover:-translate-y-[2px] hover:shadow-flat-md mb-2">
+                  <CardContent className="p-4">
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0 flex-1">
+                        <p className="text-sm font-semibold text-foreground">{card.lotTitle}</p>
+                        {card.hubName && (
+                          <p className="mt-0.5 text-xs text-muted-foreground">{card.hubName}</p>
+                        )}
+                      </div>
+                      <Badge variant={badge.variant} className={`shrink-0 ${badge.className ?? ""}`}>
+                        {card.statusLabel}
+                      </Badge>
+                    </div>
+                    <div className="mt-3 grid grid-cols-2 gap-3 text-sm">
+                      <div>
+                        <p className="text-xs text-muted-foreground">Total Committed</p>
+                        <p className="font-semibold text-foreground">
+                          <UnitWeightText kg={card.totalCommittedKg} />
+                        </p>
+                      </div>
+                      <div>
+                        <p className="text-xs text-muted-foreground">Current Price</p>
+                        <p className="font-semibold text-foreground">
+                          <UnitPriceText pricePerKg={card.currentPricePerKg} currency={card.currency} />
+                        </p>
+                      </div>
+                    </div>
+                  </CardContent>
+                </Card>
+              </Link>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/specs/seller-commitments-page-redesign.md
+++ b/specs/seller-commitments-page-redesign.md
@@ -1,0 +1,145 @@
+# Spec: Seller Commitments Page Redesign
+
+Date: 2026-04-05
+
+## Feature Summary
+
+The seller commitments page on the seller dashboard needs to be redesigned to group commitments by lot rather than presenting them as a flat, unfiltered list. Sellers currently cannot distinguish between commitments tied to active campaigns and those already settled, making it difficult to understand where each lot stands. The new design presents a searchable list of lot cards — each showing campaign status and total committed weight — with failed campaigns hidden entirely. Clicking a lot card navigates to a detail page with a full breakdown of individual commitments for that lot and the seller's projected revenue at the current price tier.
+
+## Acceptance Criteria
+
+1. Given a seller is on the commitments page, when the page loads, then they will see a card for each lot that has at least one active or settled campaign with at least one commitment, sorted by most recent campaign activity.
+2. Given a seller is viewing the lot list, when they type in the search field, then the list will filter in real time to show only lots whose name, campaign status label, or hub name matches the search term (case-insensitive).
+3. Given a lot card is displayed, then it will show: lot title, hub name, campaign status label (one of: Open / At Risk, Open / Guaranteed, Successful), and total committed weight.
+4. Given a campaign has `status = "failed"` or `status = "cancelled"`, then no card for that lot will appear on the commitments page.
+5. Given a seller clicks a lot card, then they will be navigated to `/dashboard/seller/commitments/[lotId]`.
+6. Given a seller is on a lot detail page, then they will see a list of all non-cancelled commitments on that lot, each row showing: buyer company name, weight committed, and seller amount (seller price only — does not include the 10% platform fee).
+7. Given a seller is on a lot detail page, then they will see the current effective price per kg (resolved from pricing tiers against total committed weight, or the base `price_per_kg` if no tiers exist) and the total projected seller revenue.
+8. Given the lot detail page is accessed directly via URL with a `lotId` that does not belong to the logged-in seller, then the page will return a 404.
+
+## Non-Goals
+
+- Sellers will not be able to take any action on commitments from either page (read-only).
+- No email or notification functionality will be triggered from these pages.
+- No export or download functionality.
+
+## Test Spec
+
+### Criterion 1: Lot cards appear only for active/settled campaigns with commitments
+
+- Happy path: Seller has 3 lots — 2 with active campaigns and commitments, 1 with only a failed campaign. Page renders 2 cards.
+- Failure path: The failed-campaign lot appears in the list. Test fails if card count does not match.
+- False positive check: A lot with both a failed campaign and a separate active campaign should still appear (filtering is per campaign status, not per lot).
+
+### Criterion 2: Search filters in real time
+
+- Happy path: Typing the hub name into the search field reduces the visible cards to only those tied to that hub.
+- Failure path: The card list does not update when a search term is entered.
+- False positive check: Search is case-insensitive — entering "SINGLE ORIGIN HUB" and "single origin hub" must produce identical results.
+
+### Criterion 3: Lot card displays correct status label
+
+- Happy path: A lot with `campaign.status = "active"` and `committed_quantity_kg >= minimum threshold` shows "Open / Guaranteed."
+- Failure path: Card displays wrong status label or is missing hub name.
+- False positive check: If `hub` is not joined or hub name is null, the card still renders without crashing.
+
+### Criterion 4: Failed and cancelled campaigns are hidden
+
+- Happy path: A lot whose only campaign is failed shows no card on the page.
+- Failure path: Failed lot card appears on page.
+- False positive check: Ensure the filter does not accidentally hide active campaigns when a lot has both active and failed campaigns.
+
+### Criterion 5: Clicking a lot card navigates to the detail page
+
+- Happy path: Clicking a card navigates to `/dashboard/seller/commitments/[lotId]` and the detail page loads with commitment data.
+- Failure path: Click does nothing, or the route 404s unexpectedly.
+- False positive check: Navigating to the detail page for a lot that belongs to a different seller must 404, not expose data.
+
+### Criterion 6: Detail page shows correct per-commitment rows
+
+- Happy path: A lot with 3 commitments shows 3 rows. Each row displays buyer company name, weight committed, and seller amount calculated as `commitment.price_per_kg × commitment.quantity_kg`.
+- Failure path: Rows show buyer-facing price (i.e., `commitment.total_price` which includes the 10% platform fee) instead of the seller price.
+- False positive check: `total_price` on a commitment may include platform fees — confirm the calculation explicitly uses `price_per_kg × quantity_kg`, not `total_price`.
+
+### Criterion 7: Detail page shows current tier price and projected revenue
+
+- Happy path: Lot has 2 pricing tiers. Total committed weight falls in tier 2. Detail page shows the tier 2 price per kg and projected revenue = tier 2 price × total committed kg.
+- Failure path: Page shows wrong tier price or no projected revenue.
+- False positive check: If committed weight equals exactly a tier boundary value, define and test which tier applies (e.g., the higher tier).
+
+### Criterion 8: Direct URL access to another seller's lot returns 404
+
+- Happy path: Seller A cannot see Seller B's lot detail page; accessing `/dashboard/seller/commitments/[sellerB-lotId]` returns a 404.
+- Failure path: The page renders Seller B's commitment data.
+- False positive check: Ensure the auth check is on `lot.seller_id = user.id`, not just that the lot exists.
+
+## Architecture Sketch
+
+### Files changed
+
+| File | Action |
+|---|---|
+| `app/dashboard/seller/commitments/page.tsx` | Replace — new lot-grouped card list |
+| `app/dashboard/seller/commitments/[lotId]/page.tsx` | New — lot commitment detail page |
+
+### Data flow — list page
+
+```
+auth: user.id → seller
+
+lots WHERE seller_id = user.id
+  JOIN campaigns WHERE status IN ('active', 'settled')
+    JOIN hubs (for hub.name)
+  JOIN commitments WHERE status != 'cancelled'
+    JOIN profiles (buyer company_name)
+  JOIN pricing_tiers
+
+→ Group by lot
+→ Derive campaign status label per lot (see below)
+→ Compute total committed weight per lot
+→ Filter: exclude lots where all campaigns are failed/cancelled
+→ Render as searchable card list (client component for search state)
+```
+
+### Data flow — detail page
+
+```
+param: lotId
+
+lot WHERE id = lotId AND seller_id = user.id  ← 404 if not found
+  JOIN campaigns
+  JOIN commitments WHERE status != 'cancelled'
+    JOIN profiles (buyer company_name)
+  JOIN pricing_tiers
+
+→ Resolve active pricing tier (see below)
+→ Compute projected seller revenue
+→ Render commitment rows
+```
+
+### Campaign status label logic
+
+```
+campaign.status = 'settled'  →  Successful
+campaign.status = 'active'
+  AND lot.committed_quantity_kg >= lot.total_quantity_kg  →  Open / Guaranteed
+  AND lot.committed_quantity_kg < lot.total_quantity_kg   →  Open / At Risk
+```
+
+### Pricing tier resolution
+
+```
+Sort pricing_tiers by min_quantity_kg ASC
+Find highest tier where lot.committed_quantity_kg >= tier.min_quantity_kg
+If no tier matched → fall back to lot.price_per_kg
+```
+
+## Open Questions
+
+- **Search scope:** Client-side filtering is assumed. If a seller has many lots (50+), confirm that client-side filtering is acceptable performance-wise, or whether server-side filtering with URL query params is preferred.
+
+## Resolved Questions
+
+- **Guaranteed threshold:** A campaign is "Open / Guaranteed" when `lot.committed_quantity_kg >= lot.total_quantity_kg`. This is derived from lot fields, not a campaign-level field.
+- **Multiple campaigns per lot:** Only one campaign can be active at a time. The detail page filters commitments to only those belonging to the current active or settled campaign (`campaign_id` match). Failed campaigns and their commitments are hidden entirely.
+- **Price per commitment row:** Detail rows show the current active tier price (resolved from total committed weight against pricing tiers), not `commitment.price_per_kg` locked at commit time. All rows use the same current tier price.


### PR DESCRIPTION
…ail view

Replaces the flat commitment list with a lot-grouped view showing campaign status (Open / At Risk, Open / Guaranteed, Successful), searchable by lot name and hub with a status dropdown filter. Clicking a lot navigates to a detail page with a full commitment breakdown and projected seller revenue at the current pricing tier. Failed/cancelled campaigns are hidden.