### PR TITLE
feat(shipments): add full shipment fulfillment flow (#35)

### DIFF
--- a/app/api/commitments/[id]/route.ts
+++ b/app/api/commitments/[id]/route.ts
@@ -1,0 +1,78 @@
+import { createClient } from "@/lib/supabase/server";
+import { NextResponse } from "next/server";
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await request.json();
+  const { action } = body;
+
+  if (action !== "mark_picked_up") {
+    return NextResponse.json({ error: "Unsupported action" }, { status: 400 });
+  }
+
+  // Fetch the commitment to get lot_id for hub ownership verification
+  const { data: commitment, error: fetchError } = await supabase
+    .from("commitments")
+    .select("id, lot_id, picked_up_at")
+    .eq("id", id)
+    .single();
+
+  if (fetchError || !commitment) {
+    return NextResponse.json({ error: "Commitment not found" }, { status: 404 });
+  }
+
+  if (commitment.picked_up_at) {
+    return NextResponse.json({ error: "Already marked as picked up" }, { status: 409 });
+  }
+
+  // Verify the caller is the hub owner for this lot's hub
+  const { data: lot } = await supabase
+    .from("lots")
+    .select("hub_id")
+    .eq("id", commitment.lot_id)
+    .single();
+
+  if (!lot?.hub_id) {
+    return NextResponse.json({ error: "Lot has no associated hub" }, { status: 400 });
+  }
+
+  const { data: hub } = await supabase
+    .from("hubs")
+    .select("owner_id")
+    .eq("id", lot.hub_id)
+    .single();
+
+  if (!hub || hub.owner_id !== user.id) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  // Mark as picked up — RLS UPDATE policy also enforces hub ownership at DB level
+  const { data: updated, error: updateError } = await supabase
+    .from("commitments")
+    .update({
+      picked_up_at: new Date().toISOString(),
+      picked_up_by: user.id,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", id)
+    .select()
+    .single();
+
+  if (updateError) {
+    return NextResponse.json({ error: updateError.message }, { status: 500 });
+  }
+
+  return NextResponse.json(updated);
+}

--- a/app/api/payments/settle-deadlines/route.ts
+++ b/app/api/payments/settle-deadlines/route.ts
@@ -4,6 +4,7 @@ import {
   sendLotClosedEmailsBatch,
   sendLotFailedEmail,
 } from "@/lib/email";
+import { createShipmentForLot } from "@/lib/shipments";
 import {
   createRefund,
   createTransfer,
@@ -964,8 +965,12 @@ async function settleDeadlines(request: Request) {
 
     // AC-6: notify all parties on successful settlement
     console.log("[settle-deadlines] campaign", campaign.id, "lot", lot.id, "— debug:", debug, "transferFailedCount:", transferFailedCount, "failedCount:", failedCount, "succeededCount:", succeededCount, "unpaidCount:", unpaidCount);
-    if (!debug && transferFailedCount === 0) void sendLotSuccessNotifications(admin, lot.id, campaign.hub_id);
-    else console.log("[settle-deadlines] skipping success emails — condition not met");
+    if (!debug && transferFailedCount === 0) {
+      void sendLotSuccessNotifications(admin, lot.id, campaign.hub_id);
+      void createShipmentForLot(lot.id, campaign.hub_id);
+    } else {
+      console.log("[settle-deadlines] skipping success emails and shipment creation — condition not met");
+    }
   }
 
   return NextResponse.json(

--- a/app/api/shipments/[id]/route.ts
+++ b/app/api/shipments/[id]/route.ts
@@ -1,4 +1,5 @@
 import { createClient } from "@/lib/supabase/server";
+import { sendLotShippedEmailsBatch, sendReadyForPickupEmailsBatch } from "@/lib/email";
 import { NextResponse } from "next/server";
 
 export async function PATCH(
@@ -16,27 +17,175 @@ export async function PATCH(
   }
 
   const body = await request.json();
-  const { status } = body;
+  const { status, carrier, tracking_number, notes, is_local_pickup } = body;
 
-  const updateData: Record<string, unknown> = {
-    status,
-    updated_at: new Date().toISOString(),
-  };
+  // Fetch current shipment to verify authorization and validate state transition
+  const { data: current, error: fetchError } = await supabase
+    .from("shipments")
+    .select("id, lot_id, hub_id, status")
+    .eq("id", id)
+    .single();
 
-  if (status === "delivered") {
-    updateData.delivered_at = new Date().toISOString();
+  if (fetchError || !current) {
+    return NextResponse.json({ error: "Shipment not found" }, { status: 404 });
   }
 
-  const { data, error } = await supabase
+  // Verify caller is seller or hub owner for this shipment
+  const [{ data: lot }, { data: hub }] = await Promise.all([
+    supabase.from("lots").select("seller_id").eq("id", current.lot_id).single(),
+    current.hub_id
+      ? supabase.from("hubs").select("owner_id").eq("id", current.hub_id).single()
+      : Promise.resolve({ data: null }),
+  ]);
+
+  const isSeller = lot?.seller_id === user.id;
+  const isHubOwner = (hub as { owner_id: string } | null)?.owner_id === user.id;
+  if (!isSeller && !isHubOwner) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  // Validate state transition
+  const validTransitions: Record<string, string[]> = {
+    pending: ["in_transit"],
+    in_transit: ["at_hub"],
+    at_hub: ["out_for_delivery", "delivered"],
+    out_for_delivery: ["delivered"],
+    delivered: [],
+    cancelled: [],
+  };
+
+  if (!status || !validTransitions[current.status]?.includes(status)) {
+    return NextResponse.json(
+      { error: `Cannot transition from '${current.status}' to '${status}'` },
+      { status: 400 }
+    );
+  }
+
+  // Validate tracking fields when transitioning pending → in_transit
+  if (status === "in_transit" && !is_local_pickup && !carrier) {
+    return NextResponse.json(
+      { error: "Carrier is required when not marking as local pickup" },
+      { status: 400 }
+    );
+  }
+
+  const now = new Date().toISOString();
+  const updateData: Record<string, unknown> = {
+    status,
+    updated_at: now,
+  };
+
+  if (status === "in_transit") {
+    updateData.shipped_at = now;
+    if (carrier) updateData.carrier = carrier;
+    if (tracking_number) updateData.tracking_number = tracking_number;
+    if (notes) updateData.notes = notes;
+  }
+
+  if (status === "at_hub" || status === "delivered") {
+    updateData.delivered_at = now;
+  }
+
+  const { data: shipment, error } = await supabase
     .from("shipments")
     .update(updateData)
     .eq("id", id)
-    .select()
+    .select("id, lot_id, hub_id, carrier, tracking_number, status")
     .single();
 
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
 
-  return NextResponse.json(data);
+  // Fire emails after confirmed DB update
+  if (status === "in_transit") {
+    void fireShippedEmails(supabase, shipment);
+  } else if (status === "at_hub") {
+    void firePickupEmails(supabase, shipment);
+  }
+
+  return NextResponse.json(shipment);
+}
+
+type SupabaseClient = Awaited<ReturnType<typeof import("@/lib/supabase/server").createClient>>;
+
+async function fireShippedEmails(
+  supabase: SupabaseClient,
+  shipment: { lot_id: string; hub_id: string | null; carrier: string | null; tracking_number: string | null }
+) {
+  try {
+    const [lotResult, commitmentsResult] = await Promise.all([
+      supabase.from("lots").select("id, title").eq("id", shipment.lot_id).single(),
+      supabase.from("commitments").select("buyer_id").eq("lot_id", shipment.lot_id).eq("status", "confirmed"),
+    ]);
+
+    if (lotResult.error || !lotResult.data) {
+      console.error("[shipments PATCH] Failed to fetch lot for shipped email:", lotResult.error);
+      return;
+    }
+    if (commitmentsResult.error) {
+      console.error("[shipments PATCH] Failed to fetch commitments for shipped email:", commitmentsResult.error);
+      return;
+    }
+
+    const lot = lotResult.data;
+    const buyerIds = (commitmentsResult.data ?? []).map((c) => c.buyer_id);
+    const { data: profiles } = await supabase
+      .from("profiles")
+      .select("email, contact_name")
+      .in("id", buyerIds);
+    const buyers = (profiles ?? []).map((p) => ({ buyer: p }));
+
+    let hubOwner: { email: string | null; contact_name: string | null } | null = null;
+    if (shipment.hub_id) {
+      const { data: hub } = await supabase
+        .from("hubs").select("owner_id").eq("id", shipment.hub_id).single();
+      if (hub?.owner_id) {
+        const { data: ownerProfile } = await supabase
+          .from("profiles").select("email, contact_name").eq("id", hub.owner_id).single();
+        hubOwner = ownerProfile ?? null;
+      }
+    }
+
+    await sendLotShippedEmailsBatch({ lot, buyers, hubOwner, carrier: shipment.carrier, trackingNumber: shipment.tracking_number });
+  } catch (err) {
+    console.error("[shipments PATCH] Failed to send shipped emails:", err);
+  }
+}
+
+async function firePickupEmails(
+  supabase: SupabaseClient,
+  shipment: { lot_id: string; hub_id: string | null }
+) {
+  if (!shipment.hub_id) return;
+
+  try {
+    const [lotResult, commitmentsResult, hubResult] = await Promise.all([
+      supabase.from("lots").select("id, title").eq("id", shipment.lot_id).single(),
+      supabase.from("commitments").select("buyer_id").eq("lot_id", shipment.lot_id).eq("status", "confirmed"),
+      supabase.from("hubs").select("name, address, city, state, country").eq("id", shipment.hub_id).single(),
+    ]);
+
+    if (lotResult.error || !lotResult.data) {
+      console.error("[shipments PATCH] Failed to fetch lot for pickup email:", lotResult.error);
+      return;
+    }
+    if (commitmentsResult.error) {
+      console.error("[shipments PATCH] Failed to fetch commitments for pickup email:", commitmentsResult.error);
+      return;
+    }
+    if (hubResult.error || !hubResult.data) {
+      console.error("[shipments PATCH] Failed to fetch hub for pickup email:", hubResult.error);
+      return;
+    }
+
+    const buyerIds = (commitmentsResult.data ?? []).map((c) => c.buyer_id);
+    const { data: profiles } = await supabase
+      .from("profiles").select("email, contact_name").in("id", buyerIds);
+    const buyers = (profiles ?? []).map((p) => ({ buyer: p }));
+
+    await sendReadyForPickupEmailsBatch({ lot: lotResult.data, buyers, hub: hubResult.data });
+  } catch (err) {
+    console.error("[shipments PATCH] Failed to send pickup emails:", err);
+  }
 }

--- a/app/dashboard/buyer/commitments/page.tsx
+++ b/app/dashboard/buyer/commitments/page.tsx
@@ -154,7 +154,7 @@ export default async function BuyerCommitmentsPage({
   const { data: commitments } = await supabase
     .from("commitments")
     .select(
-      "*, lot:lots!commitments_lot_id_fkey(id, title, origin_country, settlement_status, commitment_deadline, currency, committed_quantity_kg, price_per_kg)"
+      "*, picked_up_at, lot:lots!commitments_lot_id_fkey(id, title, origin_country, settlement_status, commitment_deadline, currency, committed_quantity_kg, price_per_kg)"
     )
     .eq("buyer_id", user.id)
     .not("stripe_payment_intent_id", "is", null)
@@ -163,6 +163,23 @@ export default async function BuyerCommitmentsPage({
   const items = (commitments || []) as Commitment[];
 
   const lotIds = Array.from(new Set(items.map((c) => c.lot_id).filter(Boolean)));
+
+  // Fetch shipment status for each lot to drive commitment badges
+  let shipmentByLotId: Record<string, { status: string; carrier: string | null; tracking_number: string | null }> = {};
+  if (lotIds.length > 0) {
+    const { data: shipments } = await supabase
+      .from("shipments")
+      .select("lot_id, status, carrier, tracking_number")
+      .in("lot_id", lotIds)
+      .neq("status", "cancelled")
+      .order("created_at", { ascending: false });
+
+    for (const s of shipments || []) {
+      if (!shipmentByLotId[s.lot_id]) {
+        shipmentByLotId[s.lot_id] = s;
+      }
+    }
+  }
   let tiersByLotId: Record<string, any[]> = {};
 
   if (lotIds.length > 0) {
@@ -238,6 +255,8 @@ export default async function BuyerCommitmentsPage({
         securedKg > 0 ? paidAmount / securedKg : addPlatformFee(currentPricePerKg);
       const refundedAmount = Math.max(0, paidAtCommitmentAmount - paidAmount);
 
+      const shipment = shipmentByLotId[group.lotId] ?? null;
+
       return {
         ...group,
         activeCommitments,
@@ -251,6 +270,7 @@ export default async function BuyerCommitmentsPage({
         securedKg,
         finalBuyerPricePerKg,
         refundedAmount,
+        shipment,
       };
     })
     .sort((a, b) => {
@@ -302,6 +322,31 @@ export default async function BuyerCommitmentsPage({
                       <Badge variant="outline" className="text-xs">
                         {group.activeCommitments.length} commitment{group.activeCommitments.length === 1 ? "" : "s"}
                       </Badge>
+                      {group.shipment && (() => {
+                        const anyPickedUp = group.commitments.some((c: any) => c.picked_up_at);
+                        if (anyPickedUp) {
+                          return (
+                            <Badge variant="outline" className="text-xs bg-emerald-50 text-emerald-700 border-emerald-200">
+                              Picked Up
+                            </Badge>
+                          );
+                        }
+                        if (group.shipment.status === "at_hub") {
+                          return (
+                            <Badge variant="outline" className="text-xs bg-sun/20 text-yellow-800 border-yellow-300">
+                              Landed at Hub
+                            </Badge>
+                          );
+                        }
+                        if (group.shipment.status === "in_transit") {
+                          return (
+                            <Badge variant="outline" className="text-xs bg-blue-50 text-blue-700 border-blue-200">
+                              En Route to Hub
+                            </Badge>
+                          );
+                        }
+                        return null;
+                      })()}
                     </div>
                   </div>
 

--- a/app/dashboard/hub/shipments/[id]/page.tsx
+++ b/app/dashboard/hub/shipments/[id]/page.tsx
@@ -1,0 +1,178 @@
+import { createClient } from "@/lib/supabase/server";
+import { redirect } from "next/navigation";
+import { Card, CardContent } from "@/components/mernin/Card";
+import { Badge } from "@/components/mernin/Badge";
+import { UnitWeightText } from "@/components/unit-value";
+import { CommitmentPickupButton } from "@/components/commitment-pickup-button";
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+
+export default async function HubShipmentDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/auth/login");
+
+  const { data: shipment } = await supabase
+    .from("shipments")
+    .select("*, lot:lots!shipments_lot_id_fkey(id, title), hub:hubs!shipments_hub_id_fkey(id, name, owner_id, address, city, state, country)")
+    .eq("id", id)
+    .single();
+
+  if (!shipment) redirect("/dashboard/hub/shipments");
+
+  // Verify hub ownership
+  const hub = shipment.hub as { id: string; owner_id: string; name: string; address: string | null; city: string | null; state: string | null; country: string | null } | null;
+  if (!hub || hub.owner_id !== user.id) redirect("/dashboard/hub/shipments");
+
+  const lot = shipment.lot as { id: string; title: string } | null;
+  if (!lot) redirect("/dashboard/hub/shipments");
+
+  // Fetch commitments for this lot (hub owner RLS policy grants access)
+  const { data: commitments } = await supabase
+    .from("commitments")
+    .select("id, buyer_id, quantity_kg, status, picked_up_at")
+    .eq("lot_id", shipment.lot_id)
+    .eq("status", "confirmed")
+    .order("created_at", { ascending: true });
+
+  const buyerIds = (commitments || []).map((c) => c.buyer_id);
+  const { data: profiles } = buyerIds.length > 0
+    ? await supabase
+        .from("profiles")
+        .select("id, contact_name, company_name, email")
+        .in("id", buyerIds)
+    : { data: [] };
+
+  const profileMap = Object.fromEntries((profiles || []).map((p) => [p.id, p]));
+
+  const hubAddress = [hub.address, hub.city, hub.state, hub.country]
+    .filter(Boolean)
+    .join(", ");
+
+  const arrivedAt = shipment.delivered_at
+    ? new Date(shipment.delivered_at).toLocaleDateString(undefined, {
+        month: "short",
+        day: "numeric",
+        year: "numeric",
+      })
+    : null;
+
+  const pickedUpCount = (commitments || []).filter((c) => c.picked_up_at).length;
+  const totalCount = (commitments || []).length;
+
+  return (
+    <div>
+      <div className="mb-6">
+        <Link
+          href="/dashboard/hub/shipments"
+          className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors mb-4"
+        >
+          <ArrowLeft className="h-3.5 w-3.5" />
+          Back to Shipments
+        </Link>
+
+        <h1 className="text-2xl font-semibold tracking-tight text-foreground">
+          Pickup Management
+        </h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          {lot?.title || "Unknown Lot"} — {hub.name}
+        </p>
+      </div>
+
+      {/* Shipment meta */}
+      <Card className="shadow-sm mb-6">
+        <CardContent className="p-4">
+          <div className="grid grid-cols-2 gap-4 text-sm sm:grid-cols-4">
+            {shipment.carrier && (
+              <div>
+                <p className="text-xs text-muted-foreground">Carrier</p>
+                <p className="font-medium text-foreground">{shipment.carrier}</p>
+              </div>
+            )}
+            {shipment.tracking_number && (
+              <div>
+                <p className="text-xs text-muted-foreground">Tracking</p>
+                <p className="font-medium text-foreground">{shipment.tracking_number}</p>
+              </div>
+            )}
+            {arrivedAt && (
+              <div>
+                <p className="text-xs text-muted-foreground">Arrived</p>
+                <p className="font-medium text-foreground">{arrivedAt}</p>
+              </div>
+            )}
+            {hubAddress && (
+              <div>
+                <p className="text-xs text-muted-foreground">Hub Address</p>
+                <p className="font-medium text-foreground">{hubAddress}</p>
+              </div>
+            )}
+          </div>
+          <div className="mt-3 flex items-center gap-2">
+            <p className="text-xs text-muted-foreground">
+              {pickedUpCount} of {totalCount} picked up
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Buyer pickup list */}
+      <div className="space-y-2">
+        {(commitments || []).length === 0 ? (
+          <p className="text-sm text-muted-foreground">No confirmed commitments for this lot.</p>
+        ) : (
+          (commitments || []).map((c) => {
+            const profile = profileMap[c.buyer_id];
+            const name = profile?.contact_name || profile?.company_name || profile?.email || "Unknown buyer";
+            const pickedUp = !!c.picked_up_at;
+
+            return (
+              <Card key={c.id} className="shadow-sm">
+                <CardContent className="p-4">
+                  <div className="flex items-center justify-between gap-3">
+                    <div className="min-w-0 flex-1">
+                      <p className="text-sm font-medium text-foreground">{name}</p>
+                      <p className="text-xs text-muted-foreground mt-0.5">
+                        <UnitWeightText kg={Number(c.quantity_kg)} />
+                      </p>
+                    </div>
+                    <div className="flex items-center gap-2 shrink-0">
+                      {pickedUp ? (
+                        <Badge
+                          variant="outline"
+                          className="text-xs bg-emerald-50 text-emerald-700 border-emerald-200"
+                        >
+                          Picked Up
+                        </Badge>
+                      ) : (
+                        <>
+                          <Badge
+                            variant="outline"
+                            className="text-xs bg-amber-50 text-amber-700 border-amber-200"
+                          >
+                            Awaiting Pickup
+                          </Badge>
+                          <CommitmentPickupButton
+                            commitmentId={c.id}
+                            alreadyPickedUp={false}
+                          />
+                        </>
+                      )}
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            );
+          })
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/dashboard/seller/shipments/page.tsx
+++ b/app/dashboard/seller/shipments/page.tsx
@@ -1,13 +1,18 @@
+"use server";
+
 import { createClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
 import { Card, CardContent } from "@/components/mernin/Card";
 import { Badge } from "@/components/mernin/Badge";
 import { Truck } from "lucide-react";
 import { UnitWeightText } from "@/components/unit-value";
+import { SellerShipmentForm } from "@/components/seller-shipment-form";
 
 const statusStyles: Record<string, string> = {
   pending: "bg-amber-50 text-amber-700 border-amber-200",
   in_transit: "bg-blue-50 text-blue-700 border-blue-200",
+  at_hub: "bg-emerald-50 text-emerald-700 border-emerald-200",
+  out_for_delivery: "bg-orange-50 text-orange-700 border-orange-200",
   delivered: "bg-emerald-50 text-emerald-700 border-emerald-200",
   cancelled: "bg-red-50 text-red-700 border-red-200",
 };
@@ -21,11 +26,25 @@ export default async function SellerShipmentsPage() {
 
   const { data: lots } = await supabase
     .from("lots")
-    .select("id, title")
+    .select("id, title, hub_id")
     .eq("seller_id", user.id);
 
   const lotIds = (lots || []).map((l) => l.id);
-  const lotMap = Object.fromEntries((lots || []).map((l) => [l.id, l.title]));
+  const lotMap = Object.fromEntries((lots || []).map((l) => [l.id, l]));
+
+  // Fetch hub addresses for pending shipments
+  const hubIds = Array.from(
+    new Set((lots || []).map((l) => l.hub_id).filter(Boolean))
+  ) as string[];
+
+  const { data: hubs } = hubIds.length > 0
+    ? await supabase
+        .from("hubs")
+        .select("id, name, address, city, state, country")
+        .in("id", hubIds)
+    : { data: [] };
+
+  const hubMap = Object.fromEntries((hubs || []).map((h) => [h.id, h]));
 
   const { data: shipments } = await supabase
     .from("shipments")
@@ -39,7 +58,7 @@ export default async function SellerShipmentsPage() {
     <div>
       <div className="mb-8">
         <h1 className="text-2xl font-semibold tracking-tight text-foreground">Shipments</h1>
-        <p className="text-sm text-muted-foreground mt-1">Track shipments for your lots.</p>
+        <p className="text-sm text-muted-foreground mt-1">Track and fulfill shipments for your lots.</p>
       </div>
 
       {items.length === 0 ? (
@@ -48,27 +67,41 @@ export default async function SellerShipmentsPage() {
             <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-secondary text-muted-foreground mb-4">
               <Truck className="h-6 w-6" />
             </div>
-            <p className="text-sm text-muted-foreground">No shipments yet.</p>
+            <p className="text-sm text-muted-foreground">No shipments yet. They&apos;ll appear here when a lot closes.</p>
           </CardContent>
         </Card>
       ) : (
         <div className="space-y-3">
           {items.map((s: any) => {
-            const statusLabel = s.status.replace("_", " ").charAt(0).toUpperCase() + s.status.replace("_", " ").slice(1);
+            const lot = lotMap[s.lot_id];
+            const hub = lot?.hub_id ? hubMap[lot.hub_id] : null;
+            const hubAddress = hub
+              ? [hub.address, hub.city, hub.state, hub.country].filter(Boolean).join(", ")
+              : null;
+            const statusLabel = s.status
+              .replace(/_/g, " ")
+              .replace(/\b\w/g, (c: string) => c.toUpperCase());
+
             return (
               <Card key={s.id} className="shadow-sm">
                 <CardContent className="p-4">
                   <div className="flex items-start justify-between gap-3">
                     <div className="min-w-0 flex-1">
-                      <p className="text-sm font-semibold text-foreground">{lotMap[s.lot_id] || "Unknown"}</p>
+                      <p className="text-sm font-semibold text-foreground">
+                        {lot?.title || "Unknown Lot"}
+                      </p>
                       <p className="text-xs text-muted-foreground mt-0.5">
-                        {s.carrier || "No carrier"} {s.tracking_number ? `- ${s.tracking_number}` : ""}
+                        {s.carrier || "No carrier"}{s.tracking_number ? ` — ${s.tracking_number}` : ""}
                       </p>
                     </div>
-                    <Badge variant="outline" className={`shrink-0 text-xs ${statusStyles[s.status] || ""}`}>
+                    <Badge
+                      variant="outline"
+                      className={`shrink-0 text-xs ${statusStyles[s.status] || ""}`}
+                    >
                       {statusLabel}
                     </Badge>
                   </div>
+
                   <div className="mt-3 flex items-center gap-4 text-sm">
                     {s.weight_kg && (
                       <div>
@@ -81,10 +114,26 @@ export default async function SellerShipmentsPage() {
                     <div>
                       <p className="text-xs text-muted-foreground">Date</p>
                       <p className="font-medium text-foreground">
-                        {new Date(s.created_at).toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" })}
+                        {new Date(s.created_at).toLocaleDateString(undefined, {
+                          month: "short",
+                          day: "numeric",
+                          year: "numeric",
+                        })}
                       </p>
                     </div>
+                    {hubAddress && (
+                      <div>
+                        <p className="text-xs text-muted-foreground">Ship to</p>
+                        <p className="font-medium text-foreground">{hubAddress}</p>
+                      </div>
+                    )}
                   </div>
+
+                  {s.status === "pending" && (
+                    <div className="mt-4 border-t pt-4">
+                      <SellerShipmentForm shipmentId={s.id} hubAddress={hubAddress} />
+                    </div>
+                  )}
                 </CardContent>
               </Card>
             );

--- a/components/commitment-pickup-button.tsx
+++ b/components/commitment-pickup-button.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Button } from "@/components/mernin/Button";
+
+export function CommitmentPickupButton({
+  commitmentId,
+  alreadyPickedUp,
+}: {
+  commitmentId: string;
+  alreadyPickedUp: boolean;
+}) {
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+
+  if (alreadyPickedUp) return null;
+
+  const handlePickup = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/commitments/${commitmentId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "mark_picked_up" }),
+      });
+      if (!res.ok) throw new Error("Failed to mark as picked up");
+      toast.success("Marked as picked up");
+      router.refresh();
+    } catch {
+      toast.error("Something went wrong");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Button size="sm" variant="outline" onClick={handlePickup} disabled={loading}>
+      {loading ? "Saving..." : "Mark Picked Up"}
+    </Button>
+  );
+}

--- a/components/seller-shipment-form.tsx
+++ b/components/seller-shipment-form.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Button } from "@/components/mernin/Button";
+import { Input } from "@/components/mernin/Input";
+
+interface SellerShipmentFormProps {
+  shipmentId: string;
+  hubAddress: string | null;
+}
+
+export function SellerShipmentForm({ shipmentId, hubAddress }: SellerShipmentFormProps) {
+  const router = useRouter();
+  const [carrier, setCarrier] = useState("");
+  const [trackingNumber, setTrackingNumber] = useState("");
+  const [isLocalPickup, setIsLocalPickup] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!isLocalPickup && !carrier.trim()) {
+      toast.error("Carrier is required unless marking as local pickup");
+      return;
+    }
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/shipments/${shipmentId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          status: "in_transit",
+          carrier: isLocalPickup ? null : carrier.trim(),
+          tracking_number: trackingNumber.trim() || null,
+          is_local_pickup: isLocalPickup,
+        }),
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || "Failed to update shipment");
+      }
+      toast.success("Shipment marked as shipped. Hub owner and buyers have been notified.");
+      router.refresh();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Something went wrong");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleLocalPickup = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/shipments/${shipmentId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          status: "in_transit",
+          carrier: null,
+          tracking_number: null,
+          is_local_pickup: true,
+        }),
+      });
+      if (!res.ok) throw new Error("Failed to update shipment");
+      toast.success("Marked as picked up. Hub owner and buyers have been notified.");
+      router.refresh();
+    } catch {
+      toast.error("Something went wrong");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      {hubAddress && (
+        <p className="text-xs text-muted-foreground">
+          <span className="font-medium text-foreground">Shipping to:</span> {hubAddress}
+        </p>
+      )}
+
+      <form onSubmit={handleSubmit} className="space-y-3">
+        <div className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            id={`local-pickup-${shipmentId}`}
+            checked={isLocalPickup}
+            onChange={(e) => setIsLocalPickup(e.target.checked)}
+            className="h-4 w-4 rounded border-gray-300"
+          />
+          <label
+            htmlFor={`local-pickup-${shipmentId}`}
+            className="text-xs text-muted-foreground"
+          >
+            Local pickup / no carrier
+          </label>
+        </div>
+
+        {!isLocalPickup && (
+          <div className="flex gap-2">
+            <Input
+              placeholder="Carrier (e.g. FedEx)"
+              value={carrier}
+              onChange={(e) => setCarrier(e.target.value)}
+              className="flex-1 text-sm"
+              disabled={loading}
+            />
+            <Input
+              placeholder="Tracking number (optional)"
+              value={trackingNumber}
+              onChange={(e) => setTrackingNumber(e.target.value)}
+              className="flex-1 text-sm"
+              disabled={loading}
+            />
+          </div>
+        )}
+
+        <div className="flex gap-2">
+          {isLocalPickup ? (
+            <Button
+              type="button"
+              size="sm"
+              onClick={handleLocalPickup}
+              disabled={loading}
+            >
+              {loading ? "Saving..." : "Mark as Picked Up"}
+            </Button>
+          ) : (
+            <Button type="submit" size="sm" disabled={loading}>
+              {loading ? "Saving..." : "Mark as Shipped"}
+            </Button>
+          )}
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/components/shipment-status-buttons.tsx
+++ b/components/shipment-status-buttons.tsx
@@ -3,10 +3,11 @@
 import { Button } from "@/components/mernin/Button";
 import { toast } from "sonner";
 import { useRouter } from "next/navigation";
+import Link from "next/link";
 
 const nextStatus: Record<string, { label: string; status: string }> = {
+  pending: { label: "Mark Shipped", status: "in_transit" },
   in_transit: { label: "Mark Received", status: "at_hub" },
-  at_hub: { label: "Out for Delivery", status: "out_for_delivery" },
   out_for_delivery: { label: "Mark Delivered", status: "delivered" },
 };
 
@@ -19,6 +20,15 @@ export function ShipmentStatusButtons({
 }) {
   const router = useRouter();
   const next = nextStatus[currentStatus];
+
+  // at_hub: hub owner manages per-commitment pickup on the detail page
+  if (currentStatus === "at_hub") {
+    return (
+      <Button size="sm" variant="outline" asChild>
+        <Link href={`/dashboard/hub/shipments/${shipmentId}`}>Manage Pickups</Link>
+      </Button>
+    );
+  }
 
   if (!next) return <span className="text-xs text-muted-foreground">-</span>;
 

--- a/lib/email/index.ts
+++ b/lib/email/index.ts
@@ -28,6 +28,8 @@ import { renderHubAccessRequestHtml } from "./templates/HubAccessRequest";
 import { renderHubAccessApprovedHtml } from "./templates/HubAccessApproved";
 import { renderHubAccessDeniedHtml } from "./templates/HubAccessDenied";
 import { renderBuyerHubInviteHtml } from "./templates/BuyerHubInvite";
+import { renderLotShippedHtml } from "./templates/LotShipped";
+import { renderReadyForPickupHtml } from "./templates/ReadyForPickup";
 import type { Profile, Hub, Lot, Commitment } from "@/lib/types";
 
 const APP_URL = process.env.NEXT_PUBLIC_APP_URL || "https://crowdroast.com";
@@ -570,6 +572,98 @@ export async function sendHubAccessApprovedEmail(
     subject: `You're in — welcome to ${params.hubName}`,
     html,
   });
+}
+
+// ---------------------------------------------------------------------------
+// Lot shipped — seller added tracking (buyers + hub owner)
+// ---------------------------------------------------------------------------
+
+export interface LotShippedBatchParams {
+  lot: Pick<Lot, "id" | "title">;
+  buyers: Array<{ buyer: Pick<Profile, "email" | "contact_name"> }>;
+  hubOwner: Pick<Profile, "email" | "contact_name"> | null;
+  carrier: string | null;
+  trackingNumber: string | null;
+}
+
+export async function sendLotShippedEmailsBatch(
+  params: LotShippedBatchParams
+): Promise<SendEmailResult> {
+  const payloads: { to: string; subject: string; html: string }[] = [];
+  const subject = `${params.lot.title} has shipped`;
+
+  for (const { buyer } of params.buyers) {
+    if (!buyer.email) continue;
+    payloads.push({
+      to: buyer.email,
+      subject,
+      html: await renderLotShippedHtml({
+        recipientName: buyer.contact_name || "there",
+        recipientRole: "buyer",
+        lotTitle: params.lot.title,
+        carrier: params.carrier,
+        trackingNumber: params.trackingNumber,
+        shipmentUrl: `${APP_URL}/dashboard/buyer/commitments`,
+      }),
+    });
+  }
+
+  if (params.hubOwner?.email) {
+    payloads.push({
+      to: params.hubOwner.email,
+      subject,
+      html: await renderLotShippedHtml({
+        recipientName: params.hubOwner.contact_name || "Hub Owner",
+        recipientRole: "hub_owner",
+        lotTitle: params.lot.title,
+        carrier: params.carrier,
+        trackingNumber: params.trackingNumber,
+        shipmentUrl: `${APP_URL}/dashboard/hub/shipments`,
+      }),
+    });
+  }
+
+  if (payloads.length === 0) return { success: true };
+  return sendEmailBatch(payloads);
+}
+
+// ---------------------------------------------------------------------------
+// Ready for pickup — hub owner marked shipment received (buyers)
+// ---------------------------------------------------------------------------
+
+export interface ReadyForPickupBatchParams {
+  lot: Pick<Lot, "id" | "title">;
+  buyers: Array<{ buyer: Pick<Profile, "email" | "contact_name"> }>;
+  hub: Pick<Hub, "name" | "address" | "city" | "state" | "country">;
+}
+
+export async function sendReadyForPickupEmailsBatch(
+  params: ReadyForPickupBatchParams
+): Promise<SendEmailResult> {
+  const hubAddress =
+    [params.hub.address, params.hub.city, params.hub.state, params.hub.country]
+      .filter(Boolean)
+      .join(", ") || "See your dashboard for hub details";
+
+  const payloads: { to: string; subject: string; html: string }[] = [];
+
+  for (const { buyer } of params.buyers) {
+    if (!buyer.email) continue;
+    payloads.push({
+      to: buyer.email,
+      subject: `Your coffee is ready for pickup at ${params.hub.name}`,
+      html: await renderReadyForPickupHtml({
+        buyerName: buyer.contact_name || "there",
+        lotTitle: params.lot.title,
+        hubName: params.hub.name,
+        hubAddress,
+        pickupUrl: `${APP_URL}/dashboard/buyer/commitments`,
+      }),
+    });
+  }
+
+  if (payloads.length === 0) return { success: true };
+  return sendEmailBatch(payloads);
 }
 
 // ---------------------------------------------------------------------------

--- a/lib/email/templates/LotShipped.tsx
+++ b/lib/email/templates/LotShipped.tsx
@@ -1,0 +1,156 @@
+import {
+  Body,
+  Button,
+  Container,
+  Head,
+  Heading,
+  Hr,
+  Html,
+  Preview,
+  Section,
+  Text,
+} from "@react-email/components";
+import { render } from "@react-email/render";
+import React from "react";
+
+export interface LotShippedProps {
+  recipientName: string;
+  recipientRole: "buyer" | "hub_owner";
+  lotTitle: string;
+  carrier: string | null;
+  trackingNumber: string | null;
+  shipmentUrl: string;
+}
+
+export function LotShipped({
+  recipientName,
+  recipientRole,
+  lotTitle,
+  carrier,
+  trackingNumber,
+  shipmentUrl,
+}: LotShippedProps) {
+  const isHubOwner = recipientRole === "hub_owner";
+
+  const previewText = isHubOwner
+    ? `Incoming shipment — ${lotTitle} is on its way to your hub`
+    : `Your coffee is on its way — ${lotTitle} has shipped`;
+
+  const headingText = isHubOwner ? "Incoming shipment" : "Your coffee is on its way";
+
+  const ctaLabel = isHubOwner ? "View shipment" : "View your order";
+
+  return (
+    <Html>
+      <Head />
+      <Preview>{previewText}</Preview>
+      <Body style={body}>
+        <Container style={container}>
+          <Heading style={heading}>{headingText}</Heading>
+          {isHubOwner ? (
+            <Text style={text}>
+              Hi {recipientName}, the seller has shipped <strong>{lotTitle}</strong> and
+              it&apos;s heading to your hub. Once it arrives, mark it as received so
+              buyers know to come pick up their coffee.
+            </Text>
+          ) : (
+            <Text style={text}>
+              Hi {recipientName}, great news — <strong>{lotTitle}</strong> has been
+              shipped and is on its way to your hub. You&apos;ll receive another
+              notification when it arrives and is ready for pickup.
+            </Text>
+          )}
+
+          {(carrier || trackingNumber) && (
+            <Section style={summaryBox}>
+              {carrier && (
+                <Text style={summaryItem}>
+                  <strong>Carrier:</strong> {carrier}
+                </Text>
+              )}
+              {trackingNumber && (
+                <Text style={summaryItem}>
+                  <strong>Tracking number:</strong> {trackingNumber}
+                </Text>
+              )}
+            </Section>
+          )}
+
+          <Section style={ctaSection}>
+            <Button href={shipmentUrl} style={button}>
+              {ctaLabel}
+            </Button>
+          </Section>
+
+          <Hr style={hr} />
+          <Text style={footer}>
+            You&apos;re receiving this because you&apos;re involved in a lot on CrowdRoast.
+          </Text>
+        </Container>
+      </Body>
+    </Html>
+  );
+}
+
+export async function renderLotShippedHtml(props: LotShippedProps): Promise<string> {
+  return render(<LotShipped {...props} />);
+}
+
+// Styles
+const body: React.CSSProperties = {
+  backgroundColor: "#f6f9f6",
+  fontFamily: "-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+};
+const container: React.CSSProperties = {
+  backgroundColor: "#ffffff",
+  margin: "40px auto",
+  padding: "40px",
+  borderRadius: "8px",
+  maxWidth: "560px",
+};
+const heading: React.CSSProperties = {
+  fontSize: "24px",
+  fontWeight: "700",
+  color: "#111827",
+  margin: "0 0 16px",
+};
+const text: React.CSSProperties = {
+  fontSize: "15px",
+  lineHeight: "1.6",
+  color: "#374151",
+  margin: "0 0 12px",
+};
+const summaryBox: React.CSSProperties = {
+  backgroundColor: "#f9fafb",
+  borderRadius: "6px",
+  padding: "16px",
+  margin: "16px 0",
+};
+const summaryItem: React.CSSProperties = {
+  fontSize: "14px",
+  color: "#374151",
+  margin: "0 0 6px",
+};
+const ctaSection: React.CSSProperties = {
+  textAlign: "center",
+  margin: "32px 0",
+};
+const button: React.CSSProperties = {
+  backgroundColor: "#e8442a",
+  color: "#f5f0d8",
+  padding: "12px 28px",
+  borderRadius: "6px",
+  fontSize: "15px",
+  fontWeight: "600",
+  textDecoration: "none",
+  display: "inline-block",
+};
+const hr: React.CSSProperties = {
+  borderColor: "#e5e7eb",
+  margin: "32px 0 16px",
+};
+const footer: React.CSSProperties = {
+  fontSize: "12px",
+  color: "#9ca3af",
+  margin: "0",
+};

--- a/lib/email/templates/ReadyForPickup.tsx
+++ b/lib/email/templates/ReadyForPickup.tsx
@@ -1,0 +1,130 @@
+import {
+  Body,
+  Button,
+  Container,
+  Head,
+  Heading,
+  Hr,
+  Html,
+  Preview,
+  Section,
+  Text,
+} from "@react-email/components";
+import { render } from "@react-email/render";
+import React from "react";
+
+export interface ReadyForPickupProps {
+  buyerName: string;
+  lotTitle: string;
+  hubName: string;
+  hubAddress: string;
+  pickupUrl: string;
+}
+
+export function ReadyForPickup({
+  buyerName,
+  lotTitle,
+  hubName,
+  hubAddress,
+  pickupUrl,
+}: ReadyForPickupProps) {
+  return (
+    <Html>
+      <Head />
+      <Preview>Your coffee has landed at {hubName} — come pick it up</Preview>
+      <Body style={body}>
+        <Container style={container}>
+          <Heading style={heading}>Your coffee is ready for pickup</Heading>
+          <Text style={text}>
+            Hi {buyerName}, <strong>{lotTitle}</strong> has arrived at{" "}
+            <strong>{hubName}</strong>. Head over to pick up your coffee whenever
+            you&apos;re ready.
+          </Text>
+
+          <Section style={summaryBox}>
+            <Text style={summaryItem}>
+              <strong>Hub:</strong> {hubName}
+            </Text>
+            <Text style={summaryItem}>
+              <strong>Address:</strong> {hubAddress}
+            </Text>
+          </Section>
+
+          <Section style={ctaSection}>
+            <Button href={pickupUrl} style={button}>
+              View your order
+            </Button>
+          </Section>
+
+          <Hr style={hr} />
+          <Text style={footer}>
+            You&apos;re receiving this because you have a commitment on CrowdRoast.
+          </Text>
+        </Container>
+      </Body>
+    </Html>
+  );
+}
+
+export async function renderReadyForPickupHtml(props: ReadyForPickupProps): Promise<string> {
+  return render(<ReadyForPickup {...props} />);
+}
+
+// Styles
+const body: React.CSSProperties = {
+  backgroundColor: "#f6f9f6",
+  fontFamily: "-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+};
+const container: React.CSSProperties = {
+  backgroundColor: "#ffffff",
+  margin: "40px auto",
+  padding: "40px",
+  borderRadius: "8px",
+  maxWidth: "560px",
+};
+const heading: React.CSSProperties = {
+  fontSize: "24px",
+  fontWeight: "700",
+  color: "#111827",
+  margin: "0 0 16px",
+};
+const text: React.CSSProperties = {
+  fontSize: "15px",
+  lineHeight: "1.6",
+  color: "#374151",
+  margin: "0 0 12px",
+};
+const summaryBox: React.CSSProperties = {
+  backgroundColor: "#f9fafb",
+  borderRadius: "6px",
+  padding: "16px",
+  margin: "16px 0",
+};
+const summaryItem: React.CSSProperties = {
+  fontSize: "14px",
+  color: "#374151",
+  margin: "0 0 6px",
+};
+const ctaSection: React.CSSProperties = {
+  textAlign: "center",
+  margin: "32px 0",
+};
+const button: React.CSSProperties = {
+  backgroundColor: "#e8442a",
+  color: "#f5f0d8",
+  padding: "12px 28px",
+  borderRadius: "6px",
+  fontSize: "15px",
+  fontWeight: "600",
+  textDecoration: "none",
+  display: "inline-block",
+};
+const hr: React.CSSProperties = {
+  borderColor: "#e5e7eb",
+  margin: "32px 0 16px",
+};
+const footer: React.CSSProperties = {
+  fontSize: "12px",
+  color: "#9ca3af",
+  margin: "0",
+};

--- a/lib/shipments.ts
+++ b/lib/shipments.ts
@@ -1,0 +1,45 @@
+import { createAdminClient } from "@/lib/supabase/admin";
+
+/**
+ * Creates a pending shipment record for a lot when it successfully settles.
+ * Idempotent — if a non-cancelled shipment already exists for this lot/hub
+ * pair, returns it without inserting a duplicate.
+ *
+ * Never throws. Returns null on error so callers can fire-and-forget safely.
+ */
+export async function createShipmentForLot(
+  lotId: string,
+  hubId: string | null
+): Promise<{ id: string } | null> {
+  const admin = createAdminClient();
+
+  try {
+    // Idempotency check: return existing shipment if one already exists
+    const { data: existing } = await admin
+      .from("shipments")
+      .select("id")
+      .eq("lot_id", lotId)
+      .neq("status", "cancelled")
+      .maybeSingle();
+
+    if (existing) {
+      return existing;
+    }
+
+    const { data, error } = await admin
+      .from("shipments")
+      .insert({ lot_id: lotId, hub_id: hubId, status: "pending" })
+      .select("id")
+      .single();
+
+    if (error) {
+      console.error("[createShipmentForLot] Insert failed:", error);
+      return null;
+    }
+
+    return data;
+  } catch (err) {
+    console.error("[createShipmentForLot] Unexpected error:", err);
+    return null;
+  }
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -145,6 +145,8 @@ export interface Commitment {
   payment_error: string | null;
   charged_at: string | null;
   notes: string | null;
+  picked_up_at: string | null;
+  picked_up_by: string | null;
   created_at: string;
   updated_at: string;
   // Joined fields

--- a/scripts/020_shipment_fulfillment.sql
+++ b/scripts/020_shipment_fulfillment.sql
@@ -1,0 +1,38 @@
+-- 020: Shipment fulfillment flow
+-- Adds picked_up_at/picked_up_by to commitments and grants hub owners
+-- read + update access to commitments for lots at their hubs.
+
+-- 1. Add pickup columns to commitments
+alter table public.commitments
+  add column if not exists picked_up_at timestamptz,
+  add column if not exists picked_up_by uuid references public.profiles(id);
+
+-- 2. Index: fast lookup for "which commitments have been picked up for this lot?"
+create index if not exists idx_commitments_picked_up
+  on public.commitments (lot_id)
+  where picked_up_at is not null;
+
+-- 3. RLS SELECT: hub owners can read commitments for lots assigned to their hub
+create policy "commitments_select_hub_owner"
+  on public.commitments for select
+  using (
+    auth.uid() in (
+      select h.owner_id
+      from public.hubs h
+      join public.lots l on l.hub_id = h.id
+      where l.id = lot_id
+    )
+  );
+
+-- 4. RLS UPDATE: hub owners can update commitments for lots at their hub
+--    (used to set picked_up_at / picked_up_by)
+create policy "commitments_update_hub_owner"
+  on public.commitments for update
+  using (
+    auth.uid() in (
+      select h.owner_id
+      from public.hubs h
+      join public.lots l on l.hub_id = h.id
+      where l.id = lot_id
+    )
+  );


### PR DESCRIPTION
Auto-creates a pending shipment when a lot settles. Seller adds carrier/tracking (or marks as local pickup) from their shipments tab, triggering shipped emails to hub owner and buyers. Hub owner marks shipment received, sending pickup-ready emails to buyers. Hub owner manages per-commitment pickup at /dashboard/hub/shipments/[id]. Buyer commitments tab shows En Route / Landed at Hub / Picked Up badges.

- scripts/020: add picked_up_at to commitments, hub owner RLS policies
- lib/shipments: createShipmentForLot helper with idempotency guard
- lib/email: LotShipped + ReadyForPickup templates and batch functions
- api/shipments/[id]: auth, state transition validation, email triggers
- api/commitments/[id]: new PATCH endpoint for hub pickup marking
- cron/settle-deadlines: hook in shipment creation on settlement
- ui: seller tracking form, ShipmentStatusButtons, hub detail page, buyer commitment badges