### PR TITLE
fix(buyer): featured roast hero shows live tier price + platform fee

### DIFF
--- a/app/dashboard/buyer/page.tsx
+++ b/app/dashboard/buyer/page.tsx
@@ -265,6 +265,7 @@ export default async function BuyerOverview({
             lot={featuredCampaign?.lot ?? null}
             campaignId={featuredCampaign?.id ?? null}
             hubId={featuredCampaign?.hub_id ?? null}
+            tiers={featuredCampaign ? tiersMap[featuredCampaign.lot_id] : undefined}
           />
         </div>
       )}

--- a/components/featured-roast-hero.tsx
+++ b/components/featured-roast-hero.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
-import type { Lot } from "@/lib/types";
+import type { Lot, PricingTier } from "@/lib/types";
+import { addPlatformFee } from "@/lib/pricing";
 import { CountdownTimer } from "./countdown-timer";
 import { UnitWeightText } from "./unit-value";
 import { HeroPrice, HeroCommitLabel } from "./hero-price";
@@ -8,15 +9,25 @@ interface FeaturedRoastHeroProps {
   lot: Lot & { campaign_deadline?: string | null } | null;
   campaignId?: string | null;
   hubId?: string | null;
+  tiers?: Pick<PricingTier, "min_quantity_kg" | "price_per_kg">[];
 }
 
-export function FeaturedRoastHero({ lot, campaignId, hubId }: FeaturedRoastHeroProps) {
+export function FeaturedRoastHero({ lot, campaignId, hubId, tiers = [] }: FeaturedRoastHeroProps) {
   if (!lot) return null;
 
   const commitPct =
     lot.total_quantity_kg > 0
       ? Math.round((lot.committed_quantity_kg / lot.total_quantity_kg) * 100)
       : 0;
+
+  // Resolve the live tier price based on how much has been committed.
+  const activeSellerPricePerKg = (() => {
+    const sortedDesc = [...tiers].sort((a, b) => b.min_quantity_kg - a.min_quantity_kg);
+    for (const tier of sortedDesc) {
+      if (lot.committed_quantity_kg >= tier.min_quantity_kg) return tier.price_per_kg;
+    }
+    return lot.price_per_kg;
+  })();
 
   const altitudeLabel =
     lot.altitude_min && lot.altitude_max
@@ -340,7 +351,7 @@ export function FeaturedRoastHero({ lot, campaignId, hubId }: FeaturedRoastHeroP
                   <div style={{ fontFamily: "'Cal Sans', system-ui, sans-serif", fontSize: 9.5, fontWeight: 800, letterSpacing: "0.16em", textTransform: "uppercase", color: "#F5C842", marginBottom: 4 }}>
                     Price locked
                   </div>
-                  <HeroPrice pricePerKg={lot.price_per_kg} currency={lot.currency} />
+                  <HeroPrice pricePerKg={addPlatformFee(activeSellerPricePerKg)} currency={lot.currency} />
                 </div>
                 <Link
                   href={`/dashboard/buyer/lot/${lot.id}${hubId ? `?hub=${hubId}` : ""}`}

--- a/components/lot-card.tsx
+++ b/components/lot-card.tsx
@@ -13,6 +13,7 @@ import { MapPin, Mountain, Star } from "lucide-react";
 import type { Lot } from "@/lib/types";
 import { useUnitPreference } from "@/components/unit-provider";
 import { formatUnitPrice, formatUnitWeight } from "@/lib/units";
+import { addPlatformFee } from "@/lib/pricing";
 
 export function LotCard({ lot }: { lot: Lot }) {
   const { unit } = useUnitPreference();
@@ -94,7 +95,7 @@ export function LotCard({ lot }: { lot: Lot }) {
         <CardFooter className="flex items-center justify-between border-t bg-muted/30 px-6 py-3">
           <div>
             <p className="text-lg font-bold text-foreground">
-              {formatUnitPrice(lot.price_per_kg, unit, lot.currency || "USD")}
+              {formatUnitPrice(addPlatformFee(lot.price_per_kg), unit, lot.currency || "USD")}
               <span className="text-xs font-normal text-muted-foreground">
                 /{unit}
               </span>


### PR DESCRIPTION
## Summary

- The Featured Roast hero's "Price locked" was showing the **starting** seller-net price (`lot.price_per_kg`), so it disagreed with the lot detail page on two counts:
  1. **Missing the 10% platform fee** that every other buyer surface applies via `addPlatformFee()`.
  2. **Ignoring tier discounts** — once `committed_quantity_kg` crossed a tier's `min_quantity_kg`, the lot detail page dropped to the tier price but the hero kept showing the starting price.
- Fix: `FeaturedRoastHero` now accepts a `tiers` prop, resolves the active seller price using the same descending-tier walk as `lot-detail-view.tsx`, and wraps it in `addPlatformFee()`. The buyer dashboard passes `tiersMap[featuredCampaign.lot_id]` from its existing `pricing_tiers` query (no extra fetch).
- Bonus: same raw-price bug fixed in `components/lot-card.tsx` (currently unmounted — `/marketplace/*` routes redirect — but a landmine if reused).

## Test plan

- [ ] Open a featured lot whose `committed_quantity_kg` is below all tier thresholds → hero matches lot detail page (`addPlatformFee(lot.price_per_kg)`).
- [ ] Open a featured lot whose `committed_quantity_kg` has crossed at least one tier → hero matches lot detail page's discounted active price.
- [ ] Featured lot with no `pricing_tiers` row → hero falls back to `addPlatformFee(lot.price_per_kg)` (no crash).
- [ ] Lot with `committed_quantity_kg = 0` and tiers present → hero shows starting price + fee.
- [ ] `npx tsc --noEmit` clean (only the pre-existing `vitest.config.ts` error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)