### PR TITLE
feat(buyer): redesign commitments page around lifecycle stage (closes #42)

### DIFF
--- a/app/api/commitments/[id]/route.ts
+++ b/app/api/commitments/[id]/route.ts
@@ -22,10 +22,9 @@ export async function PATCH(
     return NextResponse.json({ error: "Unsupported action" }, { status: 400 });
   }
 
-  // Fetch the commitment to get lot_id for hub ownership verification
   const { data: commitment, error: fetchError } = await supabase
     .from("commitments")
-    .select("id, lot_id, picked_up_at")
+    .select("id, lot_id, buyer_id, picked_up_at")
     .eq("id", id)
     .single();
 
@@ -37,24 +36,29 @@ export async function PATCH(
     return NextResponse.json({ error: "Already marked as picked up" }, { status: 409 });
   }
 
-  // Verify the caller is the hub owner for this lot's hub
-  const { data: lot } = await supabase
-    .from("lots")
-    .select("hub_id")
-    .eq("id", commitment.lot_id)
-    .single();
+  // The caller is allowed if they are either:
+  //   (a) the buyer who placed the commitment (self-pickup at hub), or
+  //   (b) the hub owner for the lot's hub (hub-side confirmation).
+  let allowed = commitment.buyer_id === user.id;
 
-  if (!lot?.hub_id) {
-    return NextResponse.json({ error: "Lot has no associated hub" }, { status: 400 });
+  if (!allowed) {
+    const { data: lot } = await supabase
+      .from("lots")
+      .select("hub_id")
+      .eq("id", commitment.lot_id)
+      .single();
+
+    if (lot?.hub_id) {
+      const { data: hub } = await supabase
+        .from("hubs")
+        .select("owner_id")
+        .eq("id", lot.hub_id)
+        .single();
+      if (hub?.owner_id === user.id) allowed = true;
+    }
   }
 
-  const { data: hub } = await supabase
-    .from("hubs")
-    .select("owner_id")
-    .eq("id", lot.hub_id)
-    .single();
-
-  if (!hub || hub.owner_id !== user.id) {
+  if (!allowed) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 

--- a/app/dashboard/buyer/commitments/page.tsx
+++ b/app/dashboard/buyer/commitments/page.tsx
@@ -311,13 +311,13 @@ export default async function BuyerCommitmentsPage({
 
 function PageHeader() {
   return (
-    <div className="mb-5 flex items-end justify-between gap-4">
+    <div className="mb-5 flex flex-col items-start gap-3 sm:flex-row sm:items-end sm:justify-between sm:gap-4">
       <div>
         <div className="font-headline text-[11px] font-extrabold uppercase tracking-[0.22em] text-espresso/55">
           Your portfolio
         </div>
         {/* "Commitments" is intentionally the only Adore Cats moment on this page. */}
-        <h1 className="mt-1.5 font-display text-[44px] leading-[0.95] tracking-tight text-espresso">
+        <h1 className="mt-1.5 font-display text-[34px] leading-[0.95] tracking-tight text-espresso sm:text-[44px]">
           Commitments
         </h1>
       </div>
@@ -348,8 +348,8 @@ function SectionHead({
   note?: string;
 }) {
   return (
-    <div className="flex items-end justify-between gap-4 border-b-2 border-espresso/80 pb-2.5">
-      <div className="flex items-baseline gap-3">
+    <div className="flex flex-col items-start gap-2 border-b-2 border-espresso/80 pb-2.5 sm:flex-row sm:items-end sm:justify-between sm:gap-4">
+      <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1.5">
         <span
           className={`rounded-md border-2 border-espresso px-2.5 py-[3px] font-headline text-[10px] font-extrabold uppercase tracking-[0.18em] ${sectionAccent[accent]}`}
         >

--- a/app/dashboard/buyer/commitments/page.tsx
+++ b/app/dashboard/buyer/commitments/page.tsx
@@ -239,11 +239,9 @@ export default async function BuyerCommitmentsPage({
       {buckets.needsAttention.length > 0 && (
         <section className="mb-9">
           <SectionHead
-            eyebrow="Needs Attention"
-            title="Charge issues"
+            title="Needs Attention"
             count={buckets.needsAttention.length}
             accent="tomato"
-            note="payment retries"
           />
           <div className="mt-4 flex flex-col gap-3">
             {buckets.needsAttention.map((g) => (
@@ -256,11 +254,9 @@ export default async function BuyerCommitmentsPage({
       {buckets.raising.length > 0 && (
         <section className="mb-9">
           <SectionHead
-            eyebrow="Open commits"
             title="Still Raising"
             count={buckets.raising.length}
             accent="tomato"
-            note={`${stats.liveCount} lots live`}
           />
           <div className="mt-4 flex flex-col gap-4">
             {buckets.raising.map((g) => (
@@ -277,7 +273,6 @@ export default async function BuyerCommitmentsPage({
       {buckets.inMotion.length > 0 && (
         <section className="mb-9">
           <SectionHead
-            eyebrow="Underway"
             title="In Motion"
             count={buckets.inMotion.length}
             accent="sky"
@@ -294,7 +289,6 @@ export default async function BuyerCommitmentsPage({
       {buckets.closed.length > 0 && (
         <section>
           <SectionHead
-            eyebrow="In the books"
             title="Closed Lots"
             count={buckets.closed.length}
             accent="fog"
@@ -329,37 +323,32 @@ function PageHeader() {
 }
 
 const sectionAccent: Record<"tomato" | "sky" | "fog", string> = {
-  tomato: "bg-tomato text-cream",
-  sky:    "bg-sky text-espresso",
-  fog:    "bg-fog text-espresso",
+  tomato: "bg-tomato",
+  sky:    "bg-sky",
+  fog:    "bg-fog",
 };
 
 function SectionHead({
-  eyebrow,
   title,
   count,
   accent,
   note,
 }: {
-  eyebrow: string;
   title: string;
   count: number;
   accent: "tomato" | "sky" | "fog";
   note?: string;
 }) {
   return (
-    <div className="flex flex-col items-start gap-2 border-b-2 border-espresso/80 pb-2.5 sm:flex-row sm:items-end sm:justify-between sm:gap-4">
-      <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1.5">
-        <span
-          className={`rounded-md border-2 border-espresso px-2.5 py-[3px] font-headline text-[10px] font-extrabold uppercase tracking-[0.18em] ${sectionAccent[accent]}`}
-        >
-          {eyebrow.toUpperCase()}
-        </span>
-        <h2 className="m-0 font-headline text-[22px] font-bold leading-none text-espresso">{title}</h2>
-        <span className="font-headline text-[16px] font-bold leading-none text-espresso/50">{count}</span>
-      </div>
+    <div className="flex flex-wrap items-baseline gap-x-2.5 gap-y-1 border-b-2 border-espresso/80 pb-2">
+      <span
+        className={`mb-px inline-block h-2.5 w-2.5 self-center rounded-full border-2 border-espresso ${sectionAccent[accent]}`}
+        aria-hidden
+      />
+      <h2 className="m-0 font-headline text-[18px] font-bold leading-none text-espresso">{title}</h2>
+      <span className="font-headline text-[14px] font-bold leading-none text-espresso/45">{count}</span>
       {note && (
-        <span className="font-headline text-[11px] font-bold lowercase text-espresso/55">{note}</span>
+        <span className="ml-auto font-headline text-[11px] font-bold lowercase text-espresso/55">{note}</span>
       )}
     </div>
   );

--- a/app/dashboard/buyer/commitments/page.tsx
+++ b/app/dashboard/buyer/commitments/page.tsx
@@ -1,74 +1,21 @@
 import { createClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
-import { Card, CardContent } from "@merninos/ui";
-import { Badge } from "@merninos/ui";
-import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import Link from "next/link";
 import { ShoppingCart } from "lucide-react";
-import type { Commitment, CommitmentPaymentStatus, CommitmentStatus } from "@/lib/types";
+import { Button } from "@merninos/ui";
+import type { Commitment, ShipmentStatus } from "@/lib/types";
 import { getCheckoutSession, getPaymentIntent } from "@/lib/stripe";
-import { UnitPriceText, UnitWeightText } from "@/components/unit-value";
 import { addPlatformFee } from "@/lib/pricing";
-
-const statusStyles: Record<string, string> = {
-  pending: "bg-amber-50 text-amber-700 border-amber-200",
-  confirmed: "bg-emerald-50 text-emerald-700 border-emerald-200",
-  cancelled: "bg-red-50 text-red-700 border-red-200",
-  shipped: "bg-blue-50 text-blue-700 border-blue-200",
-  delivered: "bg-emerald-50 text-emerald-700 border-emerald-200",
-};
-
-const paymentStatusStyles: Record<CommitmentPaymentStatus, string> = {
-  pending_setup: "bg-amber-50 text-amber-700 border-amber-200",
-  setup_complete: "bg-blue-50 text-blue-700 border-blue-200",
-  charge_succeeded: "bg-emerald-50 text-emerald-700 border-emerald-200",
-  charge_failed: "bg-red-50 text-red-700 border-red-200",
-  cancelled: "bg-zinc-100 text-zinc-700 border-zinc-200",
-};
-
-const paymentStatusLabels: Record<CommitmentPaymentStatus, string> = {
-  pending_setup: "Payment Pending",
-  setup_complete: "Payment Method Saved",
-  charge_succeeded: "Funds Held",
-  charge_failed: "Payment Failed",
-  cancelled: "Cancelled",
-};
-
-function formatMoney(amount: number, currency: string) {
-  return new Intl.NumberFormat(undefined, {
-    style: "currency",
-    currency: currency.toUpperCase(),
-    maximumFractionDigits: 2,
-  }).format(amount);
-}
-
-function getCurrentLotPrice(lot: any, tiers: any[]) {
-  const basePrice = Number(lot?.price_per_kg || 0);
-  if (tiers.length === 0) return basePrice;
-
-  const committedQty = Number(lot?.committed_quantity_kg || 0);
-  const sortedDesc = [...tiers].sort(
-    (a: any, b: any) => Number(b.min_quantity_kg) - Number(a.min_quantity_kg)
-  );
-
-  for (const tier of sortedDesc) {
-    if (committedQty >= Number(tier.min_quantity_kg)) {
-      return Number(tier.price_per_kg);
-    }
-  }
-
-  return basePrice;
-}
-
-function summarizePaymentStatus(statuses: CommitmentPaymentStatus[]) {
-  if (statuses.length === 0) return "pending_setup" as CommitmentPaymentStatus;
-  const unique = Array.from(new Set(statuses));
-  if (unique.length === 1) return unique[0];
-  if (unique.includes("charge_failed")) return "charge_failed";
-  if (unique.includes("charge_succeeded")) return "charge_succeeded";
-  if (unique.includes("setup_complete")) return "setup_complete";
-  return "pending_setup";
-}
+import {
+  bucketByLifecycle,
+  derivePortfolioStats,
+  type CommitmentGroup,
+} from "@/components/buyer-commitments/bucket-by-lifecycle";
+import { PortfolioStrip } from "@/components/buyer-commitments/portfolio-strip";
+import { NeedsAttentionCard } from "@/components/buyer-commitments/needs-attention-card";
+import { RaisingLotCard } from "@/components/buyer-commitments/raising-lot-card";
+import { InMotionLotCard } from "@/components/buyer-commitments/in-motion-lot-card";
+import { ClosedLotsTable } from "@/components/buyer-commitments/closed-lots-table";
 
 async function syncPendingSetupCommitments(
   supabase: Awaited<ReturnType<typeof createClient>>,
@@ -154,7 +101,7 @@ export default async function BuyerCommitmentsPage({
   const { data: commitments } = await supabase
     .from("commitments")
     .select(
-      "*, picked_up_at, lot:lots!commitments_lot_id_fkey(id, title, origin_country, settlement_status, commitment_deadline, currency, committed_quantity_kg, price_per_kg)"
+      "*, picked_up_at, lot:lots!commitments_lot_id_fkey(id, title, origin_country, region, farm, variety, process, score, images, crop_year, total_quantity_kg, settlement_status, settlement_processed_at, commitment_deadline, currency, committed_quantity_kg, price_per_kg)"
     )
     .eq("buyer_id", user.id)
     .not("stripe_payment_intent_id", "is", null)
@@ -163,25 +110,65 @@ export default async function BuyerCommitmentsPage({
   const items = (commitments || []) as Commitment[];
 
   const lotIds = Array.from(new Set(items.map((c) => c.lot_id).filter(Boolean)));
+  const campaignIds = Array.from(
+    new Set(items.map((c) => c.campaign_id).filter((id): id is string => !!id))
+  );
 
-  // Fetch shipment status for each lot to drive commitment badges
-  let shipmentByLotId: Record<string, { status: string; carrier: string | null; tracking_number: string | null }> = {};
+  // Fetch the campaigns referenced by these commitments — needed for per-campaign
+  // deadline (live countdown) and per-campaign status (failed/cancelled → closed).
+  let campaignById: Record<string, { id: string; status: string; deadline: string; settled_at: string | null }> = {};
+  if (campaignIds.length > 0) {
+    const { data: campaigns } = await supabase
+      .from("campaigns")
+      .select("id, status, deadline, settled_at")
+      .in("id", campaignIds);
+    for (const c of (campaigns || []) as any[]) {
+      campaignById[c.id] = {
+        id: c.id,
+        status: c.status,
+        deadline: c.deadline,
+        settled_at: c.settled_at,
+      };
+    }
+  }
+
+  // Fetch shipment status for each lot to drive lifecycle bucketing
+  let shipmentByLotId: Record<
+    string,
+    {
+      status: ShipmentStatus;
+      carrier: string | null;
+      tracking_number: string | null;
+      shipped_at: string | null;
+      delivered_at: string | null;
+      hub: { name: string } | null;
+    }
+  > = {};
   if (lotIds.length > 0) {
     const { data: shipments } = await supabase
       .from("shipments")
-      .select("lot_id, status, carrier, tracking_number")
+      .select(
+        "lot_id, status, carrier, tracking_number, shipped_at, delivered_at, hub:hubs!shipments_hub_id_fkey(name)"
+      )
       .in("lot_id", lotIds)
       .neq("status", "cancelled")
       .order("created_at", { ascending: false });
 
-    for (const s of shipments || []) {
+    for (const s of (shipments || []) as any[]) {
       if (!shipmentByLotId[s.lot_id]) {
-        shipmentByLotId[s.lot_id] = s;
+        shipmentByLotId[s.lot_id] = {
+          status: s.status as ShipmentStatus,
+          carrier: s.carrier,
+          tracking_number: s.tracking_number,
+          shipped_at: s.shipped_at,
+          delivered_at: s.delivered_at,
+          hub: s.hub ?? null,
+        };
       }
     }
   }
-  let tiersByLotId: Record<string, any[]> = {};
 
+  let tiersByLotId: Record<string, { min_quantity_kg: number; price_per_kg: number }[]> = {};
   if (lotIds.length > 0) {
     const { data: pricingTiers } = await supabase
       .from("pricing_tiers")
@@ -191,369 +178,188 @@ export default async function BuyerCommitmentsPage({
 
     for (const tier of pricingTiers || []) {
       if (!tiersByLotId[tier.lot_id]) tiersByLotId[tier.lot_id] = [];
-      tiersByLotId[tier.lot_id].push(tier);
-    }
-  }
-
-  const groupedByLot = new Map<
-    string,
-    {
-      lotId: string;
-      lot: any;
-      commitments: Commitment[];
-    }
-  >();
-
-  for (const c of items) {
-    const existing = groupedByLot.get(c.lot_id);
-    if (existing) {
-      existing.commitments.push(c);
-    } else {
-      groupedByLot.set(c.lot_id, {
-        lotId: c.lot_id,
-        lot: c.lot,
-        commitments: [c],
+      tiersByLotId[tier.lot_id].push({
+        min_quantity_kg: Number(tier.min_quantity_kg),
+        price_per_kg: Number(tier.price_per_kg),
       });
     }
   }
 
-  const groups = Array.from(groupedByLot.values())
-    .map((group) => {
-      const activeCommitments = group.commitments.filter((c) => c.status !== "cancelled");
-      const totalCommittedKg = activeCommitments.reduce(
-        (sum, c) => sum + Number(c.quantity_kg || 0),
-        0
-      );
+  // Group by campaign instance, not by lot — a lot can have multiple campaigns
+  // (e.g. one failed, one succeeded). Legacy commitments without a campaign_id
+  // fall back to a lot-scoped key so they still render.
+  const grouped = new Map<string, CommitmentGroup>();
+  for (const c of items) {
+    const groupKey = c.campaign_id ?? `lot:${c.lot_id}`;
+    const existing = grouped.get(groupKey);
+    if (existing) {
+      existing.commitments.push(c);
+    } else {
+      grouped.set(groupKey, {
+        groupKey,
+        lotId: c.lot_id,
+        campaignId: c.campaign_id,
+        lot: c.lot ?? null,
+        campaign: c.campaign_id ? (campaignById[c.campaign_id] as any) ?? null : null,
+        commitments: [c],
+        shipment: shipmentByLotId[c.lot_id] ?? null,
+      });
+    }
+  }
 
-      const paymentStatuses = group.commitments.map(
-        (c) => (c.payment_status || "pending_setup") as CommitmentPaymentStatus
-      );
-      const summaryPaymentStatus = summarizePaymentStatus(paymentStatuses);
+  const groups = Array.from(grouped.values());
+  const buckets = bucketByLifecycle(groups);
+  const stats = derivePortfolioStats(groups, addPlatformFee);
 
-      const displayCurrency =
-        group.commitments.find((c) => c.charge_currency)?.charge_currency ||
-        group.lot?.currency ||
-        "usd";
-
-      const tiers = tiersByLotId[group.lotId] || [];
-      const currentPricePerKg = getCurrentLotPrice(group.lot, tiers);
-      const totalAtCurrentPrice =
-        totalCommittedKg * addPlatformFee(currentPricePerKg);
-
-      const succeeded = group.commitments.filter((c) => c.payment_status === "charge_succeeded");
-      const paidAmount = succeeded.reduce((sum, c) => {
-        const commitmentTotal =
-          c.charge_amount_cents !== null ? c.charge_amount_cents / 100 : Number(c.total_price || 0);
-        return sum + commitmentTotal;
-      }, 0);
-      const paidAtCommitmentAmount = succeeded.reduce(
-        (sum, c) => sum + Number(c.total_price || 0),
-        0
-      );
-      const securedKg = succeeded.reduce((sum, c) => sum + Number(c.quantity_kg || 0), 0);
-      const finalBuyerPricePerKg =
-        securedKg > 0 ? paidAmount / securedKg : addPlatformFee(currentPricePerKg);
-      const refundedAmount = Math.max(0, paidAtCommitmentAmount - paidAmount);
-
-      const shipment = shipmentByLotId[group.lotId] ?? null;
-
-      return {
-        ...group,
-        activeCommitments,
-        totalCommittedKg,
-        displayCurrency,
-        summaryPaymentStatus,
-        currentPricePerKg,
-        totalAtCurrentPrice,
-        paidAmount,
-        paidAtCommitmentAmount,
-        securedKg,
-        finalBuyerPricePerKg,
-        refundedAmount,
-        shipment,
-      };
-    })
-    .sort((a, b) => {
-      const aDate = Math.max(...a.commitments.map((c) => new Date(c.created_at).getTime()));
-      const bDate = Math.max(...b.commitments.map((c) => new Date(c.created_at).getTime()));
-      return bDate - aDate;
-    });
+  if (groups.length === 0) {
+    return (
+      <div>
+        <PageHeader />
+        <div className="rounded-[14px] border-[3px] border-espresso bg-chalk px-5 py-12 text-center shadow-flat-md">
+          <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-xl border-2 border-espresso bg-cream text-espresso">
+            <ShoppingCart className="h-6 w-6" />
+          </div>
+          <p className="font-body text-sm text-espresso/70">
+            Nothing on the books yet.{" "}
+            <Link href="/dashboard/buyer" className="font-bold text-tomato underline underline-offset-4">
+              Browse open lots
+            </Link>{" "}
+            to get started.
+          </p>
+        </div>
+      </div>
+    );
+  }
 
   return (
-    <div>
-      <div className="mb-8">
-        <h1 className="text-2xl font-semibold tracking-tight text-foreground">My Commitments</h1>
-        <p className="mt-1 text-sm text-muted-foreground">
-          Consolidated by lot with a breakdown of each commitment.
-        </p>
-      </div>
+    <div className="pb-12">
+      <PageHeader />
+      <PortfolioStrip stats={stats} />
 
-      {groups.length === 0 ? (
-        <Card className="shadow-sm">
-          <CardContent className="flex flex-col items-center px-4 py-10">
-            <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-secondary text-muted-foreground">
-              <ShoppingCart className="h-6 w-6" />
-            </div>
-            <p className="text-center text-sm text-muted-foreground">
-              No commitments yet. <Link href="/dashboard/buyer" className="text-primary underline underline-offset-4">Browse lots</Link> to get started.
-            </p>
-          </CardContent>
-        </Card>
-      ) : (
-        <div className="space-y-3">
-          {groups.map((group) => {
-            return (
-              <Card key={group.lotId} className="shadow-sm">
-                <CardContent className="p-4">
-                  <div className="flex items-start justify-between gap-3">
-                    <div className="min-w-0 flex-1">
-                      <Link
-                        href={`/dashboard/buyer/lot/${group.lotId}`}
-                        className="text-sm font-semibold text-foreground transition-colors hover:text-primary"
-                      >
-                        {group.lot?.title || "Unknown Lot"}
-                      </Link>
-                      <p className="mt-0.5 text-xs text-muted-foreground">{group.lot?.origin_country}</p>
-                    </div>
-                    <div className="flex shrink-0 flex-col items-end gap-1">
-                      <Badge variant="outline" className={`text-xs ${paymentStatusStyles[group.summaryPaymentStatus] || ""}`}>
-                        {paymentStatusLabels[group.summaryPaymentStatus]}
-                      </Badge>
-                      <Badge variant="outline" className="text-xs">
-                        {group.activeCommitments.length} commitment{group.activeCommitments.length === 1 ? "" : "s"}
-                      </Badge>
-                      {group.shipment && (() => {
-                        const anyPickedUp = group.commitments.some((c: any) => c.picked_up_at);
-                        if (anyPickedUp) {
-                          return (
-                            <Badge variant="outline" className="text-xs bg-emerald-50 text-emerald-700 border-emerald-200">
-                              Picked Up
-                            </Badge>
-                          );
-                        }
-                        if (group.shipment.status === "at_hub") {
-                          return (
-                            <Badge variant="outline" className="text-xs bg-sun/20 text-yellow-800 border-yellow-300">
-                              Landed at Hub
-                            </Badge>
-                          );
-                        }
-                        if (group.shipment.status === "in_transit") {
-                          return (
-                            <Badge variant="outline" className="text-xs bg-blue-50 text-blue-700 border-blue-200">
-                              En Route To Hub
-                            </Badge>
-                          );
-                        }
-                        return null;
-                      })()}
-                    </div>
-                  </div>
+      {buckets.needsAttention.length > 0 && (
+        <section className="mb-9">
+          <SectionHead
+            eyebrow="Needs Attention"
+            title="Charge issues"
+            count={buckets.needsAttention.length}
+            accent="tomato"
+            note="payment retries"
+          />
+          <div className="mt-4 flex flex-col gap-3">
+            {buckets.needsAttention.map((g) => (
+              <NeedsAttentionCard key={g.groupKey} group={g} />
+            ))}
+          </div>
+        </section>
+      )}
 
-                  <div className="mt-3 grid grid-cols-1 gap-3 text-sm sm:grid-cols-3">
-                    <div>
-                      <p className="text-xs text-muted-foreground">Total Committed</p>
-                      <p className="font-semibold text-foreground">
-                        <UnitWeightText kg={group.totalCommittedKg} />
-                      </p>
-                    </div>
-                    <div>
-                      <p className="text-xs text-muted-foreground">Current Price</p>
-                      <p className="font-semibold text-foreground">
-                        <UnitPriceText
-                          pricePerKg={group.currentPricePerKg}
-                          currency={group.displayCurrency}
-                          includePlatformFee
-                        />
-                      </p>
-                    </div>
-                    <div>
-                      <p className="text-xs text-muted-foreground">Total at Current Price</p>
-                      <p className="font-semibold text-foreground">
-                        {formatMoney(group.totalAtCurrentPrice, group.displayCurrency)}
-                      </p>
-                    </div>
-                  </div>
+      {buckets.raising.length > 0 && (
+        <section className="mb-9">
+          <SectionHead
+            eyebrow="Open commits"
+            title="Still Raising"
+            count={buckets.raising.length}
+            accent="tomato"
+            note={`${stats.liveCount} lots live`}
+          />
+          <div className="mt-4 flex flex-col gap-4">
+            {buckets.raising.map((g) => (
+              <RaisingLotCard
+                key={g.groupKey}
+                group={g}
+                pricingTiers={tiersByLotId[g.lotId] || []}
+              />
+            ))}
+          </div>
+        </section>
+      )}
 
-                  {group.lot?.settlement_status !== "pending" && (
-                    <div className="mt-3 rounded-md border bg-muted/40 p-3">
-                      <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                        Campaign Result
-                      </p>
-                      {group.securedKg > 0 ? (
-                        <div className="mt-2 grid grid-cols-1 gap-3 text-sm sm:grid-cols-3">
-                          <div>
-                            <p className="text-xs text-muted-foreground">Paid at Commitment</p>
-                            <p className="font-semibold text-foreground">
-                              {formatMoney(group.paidAtCommitmentAmount, group.displayCurrency)}
-                            </p>
-                          </div>
-                          <div>
-                            <p className="text-xs text-muted-foreground">Final Paid Amount</p>
-                            <p className="font-semibold text-foreground">
-                              {formatMoney(group.paidAmount, group.displayCurrency)}
-                            </p>
-                          </div>
-                          <div>
-                            <p className="text-xs text-muted-foreground">Refunded Before Payout</p>
-                            <p className="font-semibold text-foreground">
-                              {formatMoney(group.refundedAmount, group.displayCurrency)}
-                            </p>
-                          </div>
-                          <div className="sm:col-span-3 grid grid-cols-1 gap-3 sm:grid-cols-2">
-                            <div>
-                              <p className="text-xs text-muted-foreground">Coffee Secured</p>
-                              <p className="font-semibold text-foreground">
-                                <UnitWeightText kg={group.securedKg} />
-                              </p>
-                            </div>
-                            <div>
-                            <p className="text-xs text-muted-foreground">Final Price</p>
-                            <p className="font-semibold text-foreground">
-                              <UnitPriceText
-                                pricePerKg={group.finalBuyerPricePerKg}
-                                currency={group.displayCurrency}
-                              />
-                            </p>
-                            </div>
-                          </div>
-                        </div>
-                      ) : group.lot?.settlement_status === "minimum_not_met" ? (
-                        <p className="mt-2 text-sm text-muted-foreground">
-                          This campaign did not reach its minimum commitment. Your payment was refunded.
-                        </p>
-                      ) : group.commitments.some((c) => c.payment_status === "charge_failed") ? (
-                        <p className="mt-2 text-sm text-red-700">
-                          One or more charges failed for this lot. We will continue retrying.
-                        </p>
-                      ) : group.lot?.settlement_status === "failed" ? (
-                        <p className="mt-2 text-sm text-red-700">
-                          Settlement failed for this campaign. We will retry automatically.
-                        </p>
-                      ) : (
-                        <p className="mt-2 text-sm text-muted-foreground">
-                          Settlement is processing for this campaign.
-                        </p>
-                      )}
-                    </div>
-                  )}
+      {buckets.inMotion.length > 0 && (
+        <section className="mb-9">
+          <SectionHead
+            eyebrow="Underway"
+            title="In Motion"
+            count={buckets.inMotion.length}
+            accent="sky"
+            note={`${stats.landingKg.toLocaleString()} lb landing soon`}
+          />
+          <div className="mt-4 flex flex-col gap-3.5">
+            {buckets.inMotion.map((g) => (
+              <InMotionLotCard key={g.groupKey} group={g} />
+            ))}
+          </div>
+        </section>
+      )}
 
-                  <Accordion type="single" collapsible className="mt-3 w-full">
-                    <AccordionItem value={`lot-${group.lotId}`} className="border-b-0">
-                      <AccordionTrigger className="py-2 text-sm font-medium text-foreground hover:no-underline">
-                        View commitment breakdown
-                      </AccordionTrigger>
-                      <AccordionContent>
-                        <div className="space-y-2">
-                          {group.commitments.map((c) => {
-                            const paymentStatus = (c.payment_status || "pending_setup") as CommitmentPaymentStatus;
-                            return (
-                              <div key={c.id} className="rounded-md border bg-background p-3">
-                                <div className="flex flex-wrap items-center justify-between gap-2">
-                                  <p className="text-xs text-muted-foreground">
-                                    {new Date(c.created_at).toLocaleDateString(undefined, {
-                                      month: "short",
-                                      day: "numeric",
-                                      year: "numeric",
-                                    })}
-                                  </p>
-                                  <div className="flex items-center gap-1">
-                                    <Badge
-                                      variant="outline"
-                                      className={`text-xs ${statusStyles[c.status as CommitmentStatus] || ""}`}
-                                    >
-                                      {c.status.charAt(0).toUpperCase() + c.status.slice(1)}
-                                    </Badge>
-                                    <Badge
-                                      variant="outline"
-                                      className={`text-xs ${paymentStatusStyles[paymentStatus] || ""}`}
-                                    >
-                                      {paymentStatusLabels[paymentStatus]}
-                                    </Badge>
-                                  </div>
-                                </div>
+      {buckets.closed.length > 0 && (
+        <section>
+          <SectionHead
+            eyebrow="In the books"
+            title="Closed Lots"
+            count={buckets.closed.length}
+            accent="fog"
+            note={`${new Intl.NumberFormat("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 0 }).format(stats.ytdSpend)} YTD`}
+          />
+          <div className="mt-4">
+            <ClosedLotsTable groups={buckets.closed} />
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}
 
-                                <div className="mt-2 grid grid-cols-3 gap-3 text-sm">
-                                  <div>
-                                    <p className="text-xs text-muted-foreground">Quantity</p>
-                                    <p className="font-medium text-foreground">
-                                      <UnitWeightText kg={Number(c.quantity_kg)} />
-                                    </p>
-                                  </div>
-                                  <div>
-                                    <p className="text-xs text-muted-foreground">Commit Price</p>
-                                    <p className="font-medium text-foreground">
-                                      <UnitPriceText
-                                        pricePerKg={Number(c.price_per_kg || 0)}
-                                        currency={c.charge_currency || group.displayCurrency}
-                                        includePlatformFee
-                                      />
-                                    </p>
-                                  </div>
-                                  <div>
-                                    <p className="text-xs text-muted-foreground">Paid at Commit</p>
-                                    <p className="font-semibold text-foreground">
-                                      {formatMoney(Number(c.total_price || 0), c.charge_currency || group.displayCurrency)}
-                                    </p>
-                                  </div>
-                                </div>
-
-                                {group.lot?.settlement_status !== "pending" && c.payment_status === "charge_succeeded" && (
-                                  <div className="mt-2 grid grid-cols-3 gap-3 text-sm">
-                                    <div>
-                                      <p className="text-xs text-muted-foreground">Final Price</p>
-                                      <p className="font-medium text-foreground">
-                                        <UnitPriceText
-                                          pricePerKg={group.currentPricePerKg}
-                                          currency={c.charge_currency || group.displayCurrency}
-                                          includePlatformFee
-                                        />
-                                      </p>
-                                    </div>
-                                    <div>
-                                      <p className="text-xs text-muted-foreground">Final Paid</p>
-                                      <p className="font-medium text-foreground">
-                                        {formatMoney(
-                                          c.charge_amount_cents !== null
-                                            ? c.charge_amount_cents / 100
-                                            : Number(c.total_price || 0),
-                                          c.charge_currency || group.displayCurrency
-                                        )}
-                                      </p>
-                                    </div>
-                                    <div>
-                                      <p className="text-xs text-muted-foreground">Refund</p>
-                                      <p className="font-medium text-foreground">
-                                        {formatMoney(
-                                          Math.max(
-                                            0,
-                                            Number(c.total_price || 0) -
-                                              (c.charge_amount_cents !== null
-                                                ? c.charge_amount_cents / 100
-                                                : Number(c.total_price || 0))
-                                          ),
-                                          c.charge_currency || group.displayCurrency
-                                        )}
-                                      </p>
-                                    </div>
-                                  </div>
-                                )}
-
-                                {c.payment_status === "charge_failed" && c.payment_error && (
-                                  <p className="mt-2 text-xs text-red-700">Charge issue: {c.payment_error}</p>
-                                )}
-                              </div>
-                            );
-                          })}
-                        </div>
-                      </AccordionContent>
-                    </AccordionItem>
-                  </Accordion>
-                </CardContent>
-              </Card>
-            );
-          })}
+function PageHeader() {
+  return (
+    <div className="mb-5 flex items-end justify-between gap-4">
+      <div>
+        <div className="font-headline text-[11px] font-extrabold uppercase tracking-[0.22em] text-espresso/55">
+          Your portfolio
         </div>
+        {/* "Commitments" is intentionally the only Adore Cats moment on this page. */}
+        <h1 className="mt-1.5 font-display text-[44px] leading-[0.95] tracking-tight text-espresso">
+          Commitments
+        </h1>
+      </div>
+      <Button asChild variant="default" size="sm">
+        <Link href="/dashboard/buyer">Browse open lots →</Link>
+      </Button>
+    </div>
+  );
+}
+
+const sectionAccent: Record<"tomato" | "sky" | "fog", string> = {
+  tomato: "bg-tomato text-cream",
+  sky:    "bg-sky text-espresso",
+  fog:    "bg-fog text-espresso",
+};
+
+function SectionHead({
+  eyebrow,
+  title,
+  count,
+  accent,
+  note,
+}: {
+  eyebrow: string;
+  title: string;
+  count: number;
+  accent: "tomato" | "sky" | "fog";
+  note?: string;
+}) {
+  return (
+    <div className="flex items-end justify-between gap-4 border-b-2 border-espresso/80 pb-2.5">
+      <div className="flex items-baseline gap-3">
+        <span
+          className={`rounded-md border-2 border-espresso px-2.5 py-[3px] font-headline text-[10px] font-extrabold uppercase tracking-[0.18em] ${sectionAccent[accent]}`}
+        >
+          {eyebrow.toUpperCase()}
+        </span>
+        <h2 className="m-0 font-headline text-[22px] font-bold leading-none text-espresso">{title}</h2>
+        <span className="font-headline text-[16px] font-bold leading-none text-espresso/50">{count}</span>
+      </div>
+      {note && (
+        <span className="font-headline text-[11px] font-bold lowercase text-espresso/55">{note}</span>
       )}
     </div>
   );

--- a/app/dashboard/buyer/page.tsx
+++ b/app/dashboard/buyer/page.tsx
@@ -6,7 +6,6 @@ import { Button } from "@merninos/ui";
 import { UnitPriceText, UnitWeightText } from "@/components/unit-value";
 import { LeaveHubButton } from "@/components/leave-hub-button";
 import { FeaturedRoastHero } from "@/components/featured-roast-hero";
-import { CrTicker } from "@/components/cr-ticker";
 
 function getHubName(memberships: any[], hubId: string) {
   const membership = memberships.find((m: any) => m.hub_id === hubId);
@@ -253,11 +252,6 @@ export default async function BuyerOverview({
 
   return (
     <div>
-      {/* Dual-track live ticker */}
-      <div className="-mx-4 md:-mx-6 lg:-mx-8 mb-0">
-        <CrTicker />
-      </div>
-
       {/* Featured Roast hero — renders above everything when an active lot is available */}
       {activeTab === "active" && (
         <div className="-mx-4 md:-mx-6 lg:-mx-8 mb-8">

--- a/components/buyer-commitments/__tests__/bucket-by-lifecycle.test.ts
+++ b/components/buyer-commitments/__tests__/bucket-by-lifecycle.test.ts
@@ -1,0 +1,434 @@
+/**
+ * Tests for bucket-by-lifecycle — the spec § C5 math contract and § C7/C8
+ * bucketing/sort rules. Pure-function tests; no React, no jsdom.
+ *
+ * Failure cases caught:
+ * - charge_failed leaking into Live Exposure or YTD Spend
+ * - YTD Spend not netting refunds (returns gross instead of net)
+ * - Two campaigns for the same lot collapsing into one group
+ * - Raising sort defaulting to insertion order instead of deadline asc
+ * - Closed bucket missing minimum_not_met
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  bucketByLifecycle,
+  derivePortfolioStats,
+  stageOfGroup,
+  type CommitmentGroup,
+} from "../bucket-by-lifecycle";
+import type { Commitment, Lot } from "@/lib/types";
+
+const NOOP_FEE = (p: number) => p;
+
+const dayOffset = (d: number) =>
+  new Date(Date.now() + d * 24 * 60 * 60 * 1000).toISOString();
+
+let cId = 0;
+const mkCommit = (over: Partial<Commitment> = {}): Commitment => {
+  cId += 1;
+  const base: Commitment = {
+    id: `c-${cId}`,
+    lot_id: "lot-x",
+    buyer_id: "buyer-1",
+    hub_id: null,
+    campaign_id: "camp-1",
+    quantity_kg: 100,
+    price_per_kg: 10,
+    total_price: 1000,
+    status: "confirmed",
+    payment_status: "charge_succeeded",
+    charge_amount_cents: 100000,
+    charge_currency: "usd",
+    stripe_checkout_session_id: null,
+    stripe_setup_intent_id: null,
+    stripe_payment_method_id: null,
+    stripe_customer_id: null,
+    stripe_payment_intent_id: "pi-x",
+    stripe_charge_id: null,
+    payment_error: null,
+    charged_at: new Date().toISOString(),
+    notes: null,
+    picked_up_at: null,
+    picked_up_by: null,
+    created_at: dayOffset(-30),
+    updated_at: new Date().toISOString(),
+  };
+  return { ...base, ...over };
+};
+
+const mkLot = (over: Partial<Lot> = {}): Lot => ({
+  id: "lot-x",
+  seller_id: "seller-1",
+  hub_id: null,
+  title: "Test Lot",
+  origin_country: "Ethiopia",
+  region: null,
+  farm: null,
+  variety: null,
+  process: null,
+  altitude_min: null,
+  altitude_max: null,
+  crop_year: null,
+  score: null,
+  description: null,
+  total_quantity_kg: 1500,
+  committed_quantity_kg: 1000,
+  min_commitment_kg: 800,
+  price_per_kg: 10,
+  currency: "usd",
+  status: "active" as Lot["status"],
+  commitment_deadline: dayOffset(2),
+  expiry_date: null,
+  settlement_status: "pending",
+  settlement_processed_at: null,
+  images: [],
+  flavor_notes: [],
+  certifications: [],
+  created_at: dayOffset(-60),
+  updated_at: new Date().toISOString(),
+  ...over,
+});
+
+const mkGroup = (over: Partial<CommitmentGroup> = {}): CommitmentGroup => ({
+  groupKey: "camp-1",
+  lotId: "lot-x",
+  campaignId: "camp-1",
+  lot: mkLot(),
+  campaign: null,
+  commitments: [mkCommit()],
+  shipment: null,
+  ...over,
+});
+
+describe("stageOfGroup", () => {
+  it("classifies raising when settlement is pending and deadline is in the future", () => {
+    const g = mkGroup({ lot: mkLot({ settlement_status: "pending", commitment_deadline: dayOffset(3) }) });
+    expect(stageOfGroup(g)).toBe("raising");
+  });
+
+  it("classifies funds_held when settled and no shipment", () => {
+    const g = mkGroup({ lot: mkLot({ settlement_status: "settled" }), shipment: null });
+    expect(stageOfGroup(g)).toBe("funds_held");
+  });
+
+  it("classifies in_transit from shipment status", () => {
+    const g = mkGroup({
+      lot: mkLot({ settlement_status: "settled" }),
+      shipment: { status: "in_transit", carrier: null, tracking_number: null, shipped_at: null, delivered_at: null, hub: null },
+    });
+    expect(stageOfGroup(g)).toBe("in_transit");
+  });
+
+  it.each(["at_hub", "out_for_delivery", "delivered"] as const)(
+    "classifies at_hub for shipment status %s",
+    (status) => {
+      const g = mkGroup({
+        lot: mkLot({ settlement_status: "settled" }),
+        shipment: { status, carrier: null, tracking_number: null, shipped_at: null, delivered_at: null, hub: null },
+      });
+      expect(stageOfGroup(g)).toBe("at_hub");
+    }
+  );
+
+  it("classifies picked_up when any commitment has picked_up_at", () => {
+    const g = mkGroup({
+      lot: mkLot({ settlement_status: "settled" }),
+      shipment: { status: "delivered", carrier: null, tracking_number: null, shipped_at: null, delivered_at: null, hub: null },
+      commitments: [mkCommit({ picked_up_at: dayOffset(-1) })],
+    });
+    expect(stageOfGroup(g)).toBe("picked_up");
+  });
+
+  it("classifies minimum_not_met regardless of other signals", () => {
+    const g = mkGroup({ lot: mkLot({ settlement_status: "minimum_not_met" }) });
+    expect(stageOfGroup(g)).toBe("minimum_not_met");
+  });
+
+  it("classifies a failed campaign as terminated even if the lot has been re-launched and settled", () => {
+    // Realistic case: the lot has a NEW campaign that succeeded — the new
+    // campaign sits in 'funds_held'. The OLD failed campaign for the same
+    // lot must NOT inherit the lot's current settled state.
+    const g = mkGroup({
+      campaignId: "camp-old",
+      campaign: { id: "camp-old", status: "failed", deadline: dayOffset(-30), settled_at: null },
+      lot: mkLot({ settlement_status: "settled" }),
+    });
+    expect(stageOfGroup(g)).toBe("minimum_not_met");
+  });
+
+  it("classifies a cancelled campaign as terminated", () => {
+    const g = mkGroup({
+      campaign: { id: "camp-1", status: "cancelled", deadline: dayOffset(-3), settled_at: null },
+    });
+    expect(stageOfGroup(g)).toBe("minimum_not_met");
+  });
+
+  it("classifies an active campaign whose deadline has passed as funds_held (awaiting settle cron)", () => {
+    // Reproduces user-reported bug: a successful campaign whose deadline has
+    // passed but the settle-deadlines cron hasn't run yet must NOT show
+    // 'min not met'. It belongs in In Motion / funds_held.
+    const g = mkGroup({
+      campaign: { id: "camp-1", status: "active", deadline: dayOffset(-1), settled_at: null },
+      lot: mkLot({ settlement_status: "pending", commitment_deadline: dayOffset(-1) }),
+    });
+    expect(stageOfGroup(g)).toBe("funds_held");
+  });
+
+  it("does not poison a successful new campaign with a stale lot.settlement_status from a prior failed campaign", () => {
+    // A lot can be re-launched in a new campaign after the previous campaign
+    // failed. The lot's settlement_status reflects the most-recent campaign's
+    // outcome (here: 'minimum_not_met' from the prior campaign). The CURRENT
+    // campaign for this group is settled, so the group must not inherit the
+    // lot's stale terminal state.
+    const g = mkGroup({
+      campaignId: "camp-new",
+      campaign: { id: "camp-new", status: "settled", deadline: dayOffset(-3), settled_at: dayOffset(-2) },
+      lot: mkLot({ settlement_status: "minimum_not_met" }),
+    });
+    expect(stageOfGroup(g)).toBe("funds_held");
+  });
+
+  it("uses campaign deadline (not lot deadline) to classify raising", () => {
+    // Lot's commitment_deadline is in the past, but the campaign's deadline
+    // is in the future — raising should win.
+    const g = mkGroup({
+      campaign: { id: "camp-1", status: "active", deadline: dayOffset(5), settled_at: null },
+      lot: mkLot({ settlement_status: "pending", commitment_deadline: dayOffset(-2) }),
+    });
+    expect(stageOfGroup(g)).toBe("raising");
+  });
+});
+
+describe("bucketByLifecycle", () => {
+  it("places raising / in_motion / closed groups in the right buckets", () => {
+    const raising = mkGroup({
+      groupKey: "g-r", lotId: "lot-r", campaignId: "g-r",
+      lot: mkLot({ id: "lot-r", settlement_status: "pending", commitment_deadline: dayOffset(2) }),
+    });
+    const inFlight = mkGroup({
+      groupKey: "g-t", lotId: "lot-t", campaignId: "g-t",
+      lot: mkLot({ id: "lot-t", settlement_status: "settled" }),
+      shipment: { status: "in_transit", carrier: null, tracking_number: null, shipped_at: null, delivered_at: null, hub: null },
+    });
+    const done = mkGroup({
+      groupKey: "g-d", lotId: "lot-d", campaignId: "g-d",
+      lot: mkLot({ id: "lot-d", settlement_status: "settled" }),
+      commitments: [mkCommit({ picked_up_at: dayOffset(-90) })],
+    });
+    const refunded = mkGroup({
+      groupKey: "g-m", lotId: "lot-m", campaignId: "g-m",
+      lot: mkLot({ id: "lot-m", settlement_status: "minimum_not_met" }),
+    });
+
+    const out = bucketByLifecycle([done, raising, refunded, inFlight]);
+    expect(out.raising.map((g) => g.lotId)).toEqual(["lot-r"]);
+    expect(out.inMotion.map((g) => g.lotId)).toEqual(["lot-t"]);
+    expect(out.closed.map((g) => g.lotId).sort()).toEqual(["lot-d", "lot-m"]);
+  });
+
+  it("surfaces charge_failed groups in needsAttention without removing them from cycle buckets", () => {
+    const failedRaising = mkGroup({
+      groupKey: "g-rf", lotId: "lot-rf", campaignId: "g-rf",
+      lot: mkLot({ id: "lot-rf", settlement_status: "pending", commitment_deadline: dayOffset(1) }),
+      commitments: [mkCommit({ payment_status: "charge_failed", charge_amount_cents: null, payment_error: "card declined" })],
+    });
+    const out = bucketByLifecycle([failedRaising]);
+    expect(out.needsAttention.map((g) => g.lotId)).toEqual(["lot-rf"]);
+    expect(out.raising.map((g) => g.lotId)).toEqual(["lot-rf"]);
+  });
+
+  it("sorts raising by deadline ascending, ties broken by lotId", () => {
+    const a = mkGroup({ groupKey: "ga", lotId: "lot-a", lot: mkLot({ id: "lot-a", commitment_deadline: dayOffset(5) }) });
+    const b = mkGroup({ groupKey: "gb", lotId: "lot-b", lot: mkLot({ id: "lot-b", commitment_deadline: dayOffset(1) }) });
+    const c = mkGroup({ groupKey: "gc", lotId: "lot-c", lot: mkLot({ id: "lot-c", commitment_deadline: dayOffset(1) }) });
+    const out = bucketByLifecycle([a, b, c]);
+    expect(out.raising.map((g) => g.lotId)).toEqual(["lot-b", "lot-c", "lot-a"]);
+  });
+
+  it("sorts inMotion by lifecycle step, then by lotId", () => {
+    const fundsHeld = mkGroup({
+      groupKey: "gf", lotId: "lot-f",
+      lot: mkLot({ id: "lot-f", settlement_status: "settled" }),
+    });
+    const inTransit = mkGroup({
+      groupKey: "gt", lotId: "lot-t",
+      lot: mkLot({ id: "lot-t", settlement_status: "settled" }),
+      shipment: { status: "in_transit", carrier: null, tracking_number: null, shipped_at: null, delivered_at: null, hub: null },
+    });
+    const atHub = mkGroup({
+      groupKey: "gh", lotId: "lot-h",
+      lot: mkLot({ id: "lot-h", settlement_status: "settled" }),
+      shipment: { status: "at_hub", carrier: null, tracking_number: null, shipped_at: null, delivered_at: null, hub: null },
+    });
+    const out = bucketByLifecycle([atHub, fundsHeld, inTransit]);
+    expect(out.inMotion.map((g) => g.lotId)).toEqual(["lot-f", "lot-t", "lot-h"]);
+  });
+
+  it("sorts closed by most-recent activity descending", () => {
+    const oldDone = mkGroup({
+      groupKey: "g1", lotId: "lot-old",
+      lot: mkLot({ id: "lot-old", settlement_status: "settled" }),
+      commitments: [mkCommit({ picked_up_at: dayOffset(-180) })],
+    });
+    const newDone = mkGroup({
+      groupKey: "g2", lotId: "lot-new",
+      lot: mkLot({ id: "lot-new", settlement_status: "settled" }),
+      commitments: [mkCommit({ picked_up_at: dayOffset(-2) })],
+    });
+    const out = bucketByLifecycle([oldDone, newDone]);
+    expect(out.closed.map((g) => g.lotId)).toEqual(["lot-new", "lot-old"]);
+  });
+
+  it("treats empty input as four empty buckets", () => {
+    const out = bucketByLifecycle([]);
+    expect(out).toEqual({ needsAttention: [], raising: [], inMotion: [], closed: [] });
+  });
+});
+
+describe("derivePortfolioStats", () => {
+  it("returns all zeros for an empty portfolio", () => {
+    const s = derivePortfolioStats([], NOOP_FEE);
+    expect(s).toEqual({
+      liveExposure: 0,
+      landingKg: 0,
+      savedVsBase: 0,
+      ytdSpend: 0,
+      liveCount: 0,
+      inMotionCount: 0,
+    });
+  });
+
+  it("sums Live Exposure across raising commitments and excludes charge_failed", () => {
+    const raising = mkGroup({
+      groupKey: "gr", lotId: "lot-r",
+      lot: mkLot({ id: "lot-r", settlement_status: "pending", commitment_deadline: dayOffset(2) }),
+      commitments: [
+        mkCommit({ quantity_kg: 80, price_per_kg: 14.2, payment_status: "setup_complete" }),
+        mkCommit({ quantity_kg: 100, price_per_kg: 14.2, payment_status: "charge_failed" }),
+      ],
+    });
+    const s = derivePortfolioStats([raising], NOOP_FEE);
+    // 80 × 14.20 = 1136. The charge_failed 100 lb must NOT contribute.
+    expect(s.liveExposure).toBeCloseTo(1136, 2);
+    expect(s.liveCount).toBe(1);
+  });
+
+  it("nets refund out of YTD Spend (fully refunded minimum_not_met → $0)", () => {
+    const refunded = mkGroup({
+      groupKey: "gm", lotId: "lot-m",
+      lot: mkLot({ id: "lot-m", settlement_status: "minimum_not_met" }),
+      // total_price 7820, charge_amount_cents 0 → fully refunded → net 0
+      commitments: [mkCommit({ total_price: 7820, charge_amount_cents: 0, payment_status: "charge_succeeded" })],
+    });
+    const succeeded = mkGroup({
+      groupKey: "gp", lotId: "lot-p",
+      lot: mkLot({ id: "lot-p", settlement_status: "settled" }),
+      commitments: [
+        mkCommit({
+          total_price: 3312,
+          charge_amount_cents: 331200,
+          payment_status: "charge_succeeded",
+          picked_up_at: dayOffset(-90),
+        }),
+      ],
+    });
+    const s = derivePortfolioStats([refunded, succeeded], NOOP_FEE);
+    expect(s.ytdSpend).toBeCloseTo(3312, 2);
+  });
+
+  it("excludes charge_failed from YTD Spend entirely", () => {
+    const failed = mkGroup({
+      commitments: [mkCommit({ payment_status: "charge_failed", charge_amount_cents: null, total_price: 1000 })],
+    });
+    const s = derivePortfolioStats([failed], NOOP_FEE);
+    expect(s.ytdSpend).toBe(0);
+  });
+
+  it("counts secured_kg in Landing Soon for funds_held/in_transit/at_hub only", () => {
+    const inTransit = mkGroup({
+      groupKey: "gt", lotId: "lot-t",
+      lot: mkLot({ id: "lot-t", settlement_status: "settled" }),
+      shipment: { status: "in_transit", carrier: null, tracking_number: null, shipped_at: null, delivered_at: null, hub: null },
+      commitments: [mkCommit({ quantity_kg: 600, payment_status: "charge_succeeded" })],
+    });
+    const raising = mkGroup({
+      groupKey: "gr", lotId: "lot-r",
+      lot: mkLot({ id: "lot-r", settlement_status: "pending", commitment_deadline: dayOffset(2) }),
+      commitments: [mkCommit({ quantity_kg: 999 })],
+    });
+    const s = derivePortfolioStats([inTransit, raising], NOOP_FEE);
+    expect(s.landingKg).toBe(600);
+    expect(s.inMotionCount).toBe(1);
+  });
+
+  it("computes Saved via Tiers as (lot base price × qty) minus actual paid", () => {
+    // Lot base price = $17.50/lb. Buyer's commitment was charged $1,420
+    // (qty 100 lb), reflecting a tier-unlock discount net of refunds.
+    // Savings = 17.50 × 100 − 1,420 = $330.
+    const saved = mkGroup({
+      groupKey: "gs", lotId: "lot-s",
+      lot: mkLot({ id: "lot-s", settlement_status: "settled", price_per_kg: 17.5 }),
+      commitments: [
+        mkCommit({
+          quantity_kg: 100,
+          price_per_kg: 14.2,
+          total_price: 1750,
+          charge_amount_cents: 142000, // $1,420 net (after tier-unlock refund)
+          payment_status: "charge_succeeded",
+          picked_up_at: dayOffset(-90),
+        }),
+      ],
+    });
+    const s = derivePortfolioStats([saved], NOOP_FEE);
+    expect(s.savedVsBase).toBeCloseTo(330, 2);
+  });
+
+  it("returns 0 saved when buyer paid the lot's base price (no tier unlock)", () => {
+    const noSavings = mkGroup({
+      lot: mkLot({ settlement_status: "settled", price_per_kg: 17.5 }),
+      commitments: [
+        mkCommit({
+          quantity_kg: 100,
+          price_per_kg: 17.5,
+          total_price: 1750,
+          charge_amount_cents: 175000, // paid full base
+          payment_status: "charge_succeeded",
+        }),
+      ],
+    });
+    const s = derivePortfolioStats([noSavings], NOOP_FEE);
+    expect(s.savedVsBase).toBe(0);
+  });
+
+  it("excludes charge_failed and cancelled commitments from Saved via Tiers", () => {
+    const mixed = mkGroup({
+      lot: mkLot({ settlement_status: "settled", price_per_kg: 17.5 }),
+      commitments: [
+        mkCommit({ quantity_kg: 50, payment_status: "charge_failed", charge_amount_cents: null, total_price: 875 }),
+        mkCommit({ quantity_kg: 50, status: "cancelled", payment_status: "cancelled", charge_amount_cents: null, total_price: 875 }),
+      ],
+    });
+    const s = derivePortfolioStats([mixed], NOOP_FEE);
+    expect(s.savedVsBase).toBe(0);
+  });
+
+  it("applies the platform fee to the base-price side of the comparison", () => {
+    // With a 10% platform fee: base = $17.50 → effective base = $19.25.
+    // Buyer paid $1,420 net for 100 lb → savings = 19.25 × 100 − 1420 = $505.
+    const tenPctFee = (p: number) => p * 1.1;
+    const g = mkGroup({
+      lot: mkLot({ settlement_status: "settled", price_per_kg: 17.5 }),
+      commitments: [
+        mkCommit({
+          quantity_kg: 100,
+          payment_status: "charge_succeeded",
+          charge_amount_cents: 142000,
+          total_price: 1925,
+        }),
+      ],
+    });
+    const s = derivePortfolioStats([g], tenPctFee);
+    expect(s.savedVsBase).toBeCloseTo(505, 2);
+  });
+});

--- a/components/buyer-commitments/bucket-by-lifecycle.ts
+++ b/components/buyer-commitments/bucket-by-lifecycle.ts
@@ -1,0 +1,252 @@
+import type { Campaign, Commitment, Lot, Shipment } from "@/lib/types";
+
+export type LifecycleStage =
+  | "raising"
+  | "funds_held"
+  | "in_transit"
+  | "at_hub"
+  | "picked_up"
+  | "done"
+  | "minimum_not_met";
+
+export type StageColor = "tomato" | "honey" | "sky" | "sun" | "matcha" | "fog" | "espresso";
+
+export interface StageMeta {
+  label: string;
+  step: number;
+  color: StageColor;
+  desc: string;
+}
+
+export const STAGE_META: Record<LifecycleStage, StageMeta> = {
+  raising:         { label: "Raising",         step: 1, color: "tomato",   desc: "Commits open" },
+  funds_held:      { label: "Funds Held",      step: 2, color: "honey",    desc: "Settled, awaiting ship" },
+  in_transit:      { label: "In Transit",      step: 3, color: "sky",      desc: "Sailing to your hub" },
+  at_hub:          { label: "At Hub",          step: 4, color: "sun",      desc: "Ready for pickup" },
+  picked_up:       { label: "Picked Up",       step: 5, color: "matcha",   desc: "In your possession" },
+  done:            { label: "Done",            step: 6, color: "fog",      desc: "Closed in the books" },
+  minimum_not_met: { label: "Min Not Met",     step: 0, color: "espresso", desc: "Refunded — didn't hit minimum" },
+};
+
+export const LIFECYCLE_STEPS: { key: LifecycleStage; label: string }[] = [
+  { key: "raising",    label: "Raising" },
+  { key: "funds_held", label: "Funds Held" },
+  { key: "in_transit", label: "In Transit" },
+  { key: "at_hub",     label: "At Hub" },
+  { key: "picked_up",  label: "Picked Up" },
+  { key: "done",       label: "Done" },
+];
+
+export interface CommitmentGroup {
+  groupKey: string;
+  lotId: string;
+  campaignId: string | null;
+  lot: Lot | null;
+  campaign: Pick<Campaign, "id" | "status" | "deadline" | "settled_at"> | null;
+  commitments: Commitment[];
+  shipment: Pick<Shipment, "status" | "carrier" | "tracking_number" | "shipped_at" | "delivered_at"> & { hub?: { name: string } | null } | null;
+}
+
+export interface BucketedGroups {
+  needsAttention: CommitmentGroup[];
+  raising: CommitmentGroup[];
+  inMotion: CommitmentGroup[];
+  closed: CommitmentGroup[];
+}
+
+const NOW = () => Date.now();
+
+function deadlineInFuture(group: CommitmentGroup): boolean {
+  // Prefer the campaign deadline (each campaign instance has its own clock);
+  // fall back to the lot's legacy commitment_deadline for pre-campaign data.
+  const deadline = group.campaign?.deadline ?? group.lot?.commitment_deadline;
+  if (!deadline) return false;
+  return new Date(deadline).getTime() > NOW();
+}
+
+function anyPickedUp(group: CommitmentGroup): boolean {
+  return group.commitments.some((c) => c.picked_up_at != null);
+}
+
+function hasChargeFailed(group: CommitmentGroup): boolean {
+  return group.commitments.some((c) => c.payment_status === "charge_failed");
+}
+
+/**
+ * Map a (lot × campaign) group to its lifecycle stage.
+ *
+ * Whenever a `campaign` is present, the campaign's own status is the
+ * authoritative source for THIS group. The lot-level `settlement_status`
+ * reflects only the *most recent* campaign's outcome (the lot is a shared
+ * surface across multiple campaigns) — using it would poison every group
+ * for that lot with the latest campaign's state. We only fall back to
+ * lot-level state for legacy commitments that pre-date the campaigns table.
+ */
+export function stageOfGroup(group: CommitmentGroup): LifecycleStage {
+  const campaignStatus = group.campaign?.status;
+
+  if (campaignStatus) {
+    if (campaignStatus === "failed" || campaignStatus === "cancelled") {
+      return "minimum_not_met";
+    }
+    if (campaignStatus === "active") {
+      // Open for commits if the campaign deadline is still in the future;
+      // otherwise the deadline has passed and we're awaiting the settle cron.
+      return deadlineInFuture(group) ? "raising" : "funds_held";
+    }
+    // campaignStatus === "settled" — progress along the shipment timeline.
+    if (anyPickedUp(group)) return "picked_up";
+    const shipStatus = group.shipment?.status;
+    if (shipStatus === "in_transit") return "in_transit";
+    if (shipStatus === "at_hub" || shipStatus === "out_for_delivery" || shipStatus === "delivered") return "at_hub";
+    return "funds_held";
+  }
+
+  // Legacy fallback (no campaign on the group) — read lot-level state.
+  const settlement = group.lot?.settlement_status;
+  if (settlement === "minimum_not_met") return "minimum_not_met";
+  if (settlement === "pending" && deadlineInFuture(group)) return "raising";
+  if (anyPickedUp(group)) return "picked_up";
+  const shipStatus = group.shipment?.status;
+  if (shipStatus === "in_transit") return "in_transit";
+  if (shipStatus === "at_hub" || shipStatus === "out_for_delivery" || shipStatus === "delivered") return "at_hub";
+  return "funds_held";
+}
+
+export function bucketByLifecycle(groups: CommitmentGroup[]): BucketedGroups {
+  const needsAttention = groups.filter(hasChargeFailed);
+
+  const cycleGroups = groups; // charge_failed groups still bucket normally per spec C6
+  const raising: CommitmentGroup[] = [];
+  const inMotion: CommitmentGroup[] = [];
+  const closed: CommitmentGroup[] = [];
+
+  for (const g of cycleGroups) {
+    const stage = stageOfGroup(g);
+    if (stage === "raising") raising.push(g);
+    else if (stage === "funds_held" || stage === "in_transit" || stage === "at_hub") inMotion.push(g);
+    else closed.push(g); // picked_up, done, minimum_not_met
+  }
+
+  // Within-section sort (spec C8)
+  raising.sort((a, b) => {
+    const ad = a.lot?.commitment_deadline ? new Date(a.lot.commitment_deadline).getTime() : Infinity;
+    const bd = b.lot?.commitment_deadline ? new Date(b.lot.commitment_deadline).getTime() : Infinity;
+    return ad - bd || a.lotId.localeCompare(b.lotId);
+  });
+  inMotion.sort((a, b) => {
+    const sa = STAGE_META[stageOfGroup(a)].step;
+    const sb = STAGE_META[stageOfGroup(b)].step;
+    return sa - sb || a.lotId.localeCompare(b.lotId);
+  });
+  closed.sort((a, b) => {
+    const ad = closedDateOf(a);
+    const bd = closedDateOf(b);
+    return bd - ad || a.lotId.localeCompare(b.lotId);
+  });
+
+  return { needsAttention, raising, inMotion, closed };
+}
+
+function closedDateOf(g: CommitmentGroup): number {
+  const pickedUp = g.commitments
+    .map((c) => c.picked_up_at)
+    .filter((d): d is string => !!d)
+    .map((d) => new Date(d).getTime());
+  if (pickedUp.length) return Math.max(...pickedUp);
+  if (g.lot?.settlement_processed_at) return new Date(g.lot.settlement_processed_at).getTime();
+  const created = g.commitments.map((c) => new Date(c.created_at).getTime());
+  return created.length ? Math.max(...created) : 0;
+}
+
+export interface PortfolioStats {
+  liveExposure: number;
+  landingKg: number;
+  savedVsBase: number;
+  ytdSpend: number;
+  liveCount: number;
+  inMotionCount: number;
+}
+
+/**
+ * Derive the portfolio strip values from grouped commitments.
+ *
+ * Math contract (spec § C5):
+ * - Live Exposure = Σ qty × commit_price × (1 + platform fee) over RAISING groups, excluding charge_failed commitments
+ * - Landing Soon = Σ secured_kg over funds_held + in_transit + at_hub
+ * - Saved via Tiers = Σ max(0, (committed_avg − final_price) × secured_kg) over settled groups
+ * - YTD Spend = Σ (paid − refunded) per commitment charged this calendar year, excluding charge_failed
+ */
+export function derivePortfolioStats(
+  groups: CommitmentGroup[],
+  addPlatformFee: (pricePerKg: number) => number
+): PortfolioStats {
+  const buckets = bucketByLifecycle(groups);
+  const ytStart = new Date(new Date().getFullYear(), 0, 1).getTime();
+
+  const liveExposure = buckets.raising.reduce((sum, g) => {
+    return (
+      sum +
+      g.commitments
+        .filter((c) => c.payment_status !== "charge_failed" && c.status !== "cancelled")
+        .reduce((acc, c) => acc + Number(c.quantity_kg) * addPlatformFee(Number(c.price_per_kg)), 0)
+    );
+  }, 0);
+
+  const landingKg = buckets.inMotion.reduce((sum, g) => {
+    return (
+      sum +
+      g.commitments
+        .filter((c) => c.payment_status === "charge_succeeded")
+        .reduce((acc, c) => acc + Number(c.quantity_kg), 0)
+    );
+  }, 0);
+
+  // Saved via Tiers — for each successfully-charged commitment, compare what
+  // the buyer would have paid at the lot's BASE price (lot.price_per_kg, with
+  // platform fee) against what they actually paid (charge_amount_cents, which
+  // is already net of any tier-unlock refunds Stripe processed).
+  // Excludes: raising (no charge yet), cancelled, charge_failed, refunded.
+  const savedVsBase = groups.reduce((sum, g) => {
+    const basePrice = g.lot ? Number(g.lot.price_per_kg) : 0;
+    if (basePrice <= 0) return sum;
+    const baseWithFee = addPlatformFee(basePrice);
+    return (
+      sum +
+      g.commitments.reduce((acc, c) => {
+        if (c.payment_status !== "charge_succeeded") return acc;
+        if (c.status === "cancelled") return acc;
+        const qty = Number(c.quantity_kg || 0);
+        const actualPaid =
+          c.charge_amount_cents != null ? c.charge_amount_cents / 100 : Number(c.total_price || 0);
+        const wouldHavePaid = baseWithFee * qty;
+        return acc + Math.max(0, wouldHavePaid - actualPaid);
+      }, 0)
+    );
+  }, 0);
+
+  const ytdSpend = groups.reduce((sum, g) => {
+    return (
+      sum +
+      g.commitments.reduce((acc, c) => {
+        if (c.payment_status !== "charge_succeeded") return acc;
+        if (!c.charged_at) return acc;
+        if (new Date(c.charged_at).getTime() < ytStart) return acc;
+        // `charge_amount_cents` is already net of refunds (Stripe updates it
+        // on partial/full refund), so summing it gives net YTD spend without
+        // additional refund subtraction.
+        const paid = c.charge_amount_cents != null ? c.charge_amount_cents / 100 : Number(c.total_price || 0);
+        return acc + paid;
+      }, 0)
+    );
+  }, 0);
+
+  return {
+    liveExposure,
+    landingKg,
+    savedVsBase,
+    ytdSpend,
+    liveCount: buckets.raising.length,
+    inMotionCount: buckets.inMotion.length,
+  };
+}

--- a/components/buyer-commitments/closed-lots-table.tsx
+++ b/components/buyer-commitments/closed-lots-table.tsx
@@ -37,62 +37,121 @@ function rowDate(g: CommitmentGroup): string | null {
   return g.commitments[0]?.created_at ?? null;
 }
 
+function buildRow(g: CommitmentGroup) {
+  const stage = stageOfGroup(g);
+  const succeeded = g.commitments.filter((c) => c.payment_status === "charge_succeeded");
+  const securedKg = succeeded.reduce((s, c) => s + Number(c.quantity_kg || 0), 0);
+  const paid = succeeded.reduce(
+    (s, c) => s + (c.charge_amount_cents != null ? c.charge_amount_cents / 100 : Number(c.total_price || 0)),
+    0
+  );
+  const billed = succeeded.reduce((s, c) => s + Number(c.total_price || 0), 0);
+  const refunded = Math.max(0, billed - paid);
+  const avg = securedKg > 0 ? paid / securedKg : Number(g.lot?.price_per_kg || 0);
+  const totalCell = stage === "minimum_not_met" ? `−${fmtMoney(refunded)}` : fmtMoney(paid);
+  const date = rowDate(g);
+  return { stage, securedKg, avg, totalCell, date };
+}
+
 export function ClosedLotsTable({ groups }: ClosedLotsTableProps) {
   return (
-    <div className="overflow-hidden rounded-[14px] border-[3px] border-espresso bg-chalk shadow-flat-md">
-      <div className="grid grid-cols-[1.6fr_1fr_0.8fr_0.9fr_0.9fr_0.9fr] gap-4 bg-espresso px-5 py-3 font-headline text-[10px] font-extrabold uppercase tracking-[0.18em] text-cream">
-        <div>Lot</div>
-        <div>Status</div>
-        <div>Qty</div>
-        <div>Avg price</div>
-        <div>Total</div>
-        <div>Date</div>
-      </div>
-      {groups.map((g, i) => {
-        const stage = stageOfGroup(g);
-        const succeeded = g.commitments.filter((c) => c.payment_status === "charge_succeeded");
-        const securedKg = succeeded.reduce((s, c) => s + Number(c.quantity_kg || 0), 0);
-        const paid = succeeded.reduce(
-          (s, c) => s + (c.charge_amount_cents != null ? c.charge_amount_cents / 100 : Number(c.total_price || 0)),
-          0
-        );
-        const billed = succeeded.reduce((s, c) => s + Number(c.total_price || 0), 0);
-        const refunded = Math.max(0, billed - paid);
-        const avg = securedKg > 0 ? paid / securedKg : Number(g.lot?.price_per_kg || 0);
-        const totalCell = stage === "minimum_not_met" ? `−${fmtMoney(refunded)}` : fmtMoney(paid);
-        const date = rowDate(g);
-        return (
-          <div
-            key={g.groupKey}
-            className={`grid grid-cols-[1.6fr_1fr_0.8fr_0.9fr_0.9fr_0.9fr] items-center gap-4 px-5 py-3.5 font-headline text-[13px] ${
-              i < groups.length - 1 ? "border-b border-fog" : ""
-            }`}
-          >
-            <div>
-              <Link
-                href={`/dashboard/buyer/lot/${g.lotId}`}
-                className="font-headline text-[15px] font-bold leading-tight text-espresso transition-colors hover:text-tomato"
-              >
-                {g.lot?.title || "Unknown lot"}
-              </Link>
-              <div className="mt-0.5 text-[11px] text-espresso/60">
-                {[g.lot?.region, g.lot?.origin_country].filter(Boolean).join(" · ")}
+    <>
+      {/* Phone: stacked card list (the 6-col table won't fit) */}
+      <div className="flex flex-col gap-3 md:hidden">
+        {groups.map((g) => {
+          const r = buildRow(g);
+          return (
+            <div
+              key={g.groupKey}
+              className="rounded-[14px] border-[3px] border-espresso bg-chalk p-4 shadow-flat-sm"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0 flex-1">
+                  <Link
+                    href={`/dashboard/buyer/lot/${g.lotId}`}
+                    className="font-headline text-[16px] font-bold leading-tight text-espresso hover:text-tomato"
+                  >
+                    {g.lot?.title || "Unknown lot"}
+                  </Link>
+                  <div className="mt-0.5 font-headline text-[11px] text-espresso/60">
+                    {[g.lot?.region, g.lot?.origin_country].filter(Boolean).join(" · ")}
+                  </div>
+                </div>
+                <StageBadge stage={r.stage} />
               </div>
+              <div className="mt-3 grid grid-cols-3 gap-3 font-headline text-[12px]">
+                <div>
+                  <div className="text-[9px] font-extrabold uppercase tracking-[0.16em] text-espresso/55">Qty</div>
+                  <div className="mt-0.5 font-bold text-espresso">
+                    <UnitWeightText kg={r.securedKg} maximumFractionDigits={0} />
+                  </div>
+                </div>
+                <div>
+                  <div className="text-[9px] font-extrabold uppercase tracking-[0.16em] text-espresso/55">Avg price</div>
+                  <div className="mt-0.5 font-bold text-espresso">
+                    <UnitPriceText pricePerKg={r.avg} currency="usd" />
+                  </div>
+                </div>
+                <div>
+                  <div className="text-[9px] font-extrabold uppercase tracking-[0.16em] text-espresso/55">Total</div>
+                  <div className="mt-0.5 font-extrabold text-espresso">{r.totalCell}</div>
+                </div>
+              </div>
+              {r.date && (
+                <div className="mt-2 font-headline text-[11px] text-espresso/55">
+                  {new Date(r.date).toLocaleDateString()}
+                </div>
+              )}
             </div>
-            <div>
-              <StageBadge stage={stage} />
+          );
+        })}
+      </div>
+
+      {/* Tablet+: the 6-column table */}
+      <div className="hidden overflow-hidden rounded-[14px] border-[3px] border-espresso bg-chalk shadow-flat-md md:block">
+        <div className="grid grid-cols-[1.6fr_1fr_0.8fr_0.9fr_0.9fr_0.9fr] gap-4 bg-espresso px-5 py-3 font-headline text-[10px] font-extrabold uppercase tracking-[0.18em] text-cream">
+          <div>Lot</div>
+          <div>Status</div>
+          <div>Qty</div>
+          <div>Avg price</div>
+          <div>Total</div>
+          <div>Date</div>
+        </div>
+        {groups.map((g, i) => {
+          const r = buildRow(g);
+          return (
+            <div
+              key={g.groupKey}
+              className={`grid grid-cols-[1.6fr_1fr_0.8fr_0.9fr_0.9fr_0.9fr] items-center gap-4 px-5 py-3.5 font-headline text-[13px] ${
+                i < groups.length - 1 ? "border-b border-fog" : ""
+              }`}
+            >
+              <div>
+                <Link
+                  href={`/dashboard/buyer/lot/${g.lotId}`}
+                  className="font-headline text-[15px] font-bold leading-tight text-espresso transition-colors hover:text-tomato"
+                >
+                  {g.lot?.title || "Unknown lot"}
+                </Link>
+                <div className="mt-0.5 text-[11px] text-espresso/60">
+                  {[g.lot?.region, g.lot?.origin_country].filter(Boolean).join(" · ")}
+                </div>
+              </div>
+              <div>
+                <StageBadge stage={r.stage} />
+              </div>
+              <div className="font-bold text-espresso">
+                <UnitWeightText kg={r.securedKg} maximumFractionDigits={0} />
+              </div>
+              <div className="font-bold text-espresso">
+                <UnitPriceText pricePerKg={r.avg} currency="usd" />
+              </div>
+              <div className="font-extrabold text-espresso">{r.totalCell}</div>
+              <div className="text-[11px] text-espresso/60">{r.date ? new Date(r.date).toLocaleDateString() : "—"}</div>
             </div>
-            <div className="font-bold text-espresso">
-              <UnitWeightText kg={securedKg} maximumFractionDigits={0} />
-            </div>
-            <div className="font-bold text-espresso">
-              <UnitPriceText pricePerKg={avg} currency="usd" />
-            </div>
-            <div className="font-extrabold text-espresso">{totalCell}</div>
-            <div className="text-[11px] text-espresso/60">{date ? new Date(date).toLocaleDateString() : "—"}</div>
-          </div>
-        );
-      })}
-    </div>
+          );
+        })}
+      </div>
+    </>
   );
 }

--- a/components/buyer-commitments/closed-lots-table.tsx
+++ b/components/buyer-commitments/closed-lots-table.tsx
@@ -1,0 +1,98 @@
+import Link from "next/link";
+import { UnitPriceText, UnitWeightText } from "@/components/unit-value";
+import { stageOfGroup, STAGE_META, type CommitmentGroup, type StageColor } from "./bucket-by-lifecycle";
+
+export interface ClosedLotsTableProps {
+  groups: CommitmentGroup[];
+}
+
+const fmtMoney = (n: number) =>
+  new Intl.NumberFormat("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 0 }).format(n || 0);
+
+const stageBadgeStyles: Record<StageColor, string> = {
+  tomato:   "bg-tomato text-cream",
+  honey:    "bg-honey text-espresso",
+  sky:      "bg-sky text-espresso",
+  sun:      "bg-sun text-espresso",
+  matcha:   "bg-matcha text-cream",
+  fog:      "bg-fog text-espresso",
+  espresso: "bg-espresso text-cream",
+};
+
+function StageBadge({ stage }: { stage: ReturnType<typeof stageOfGroup> }) {
+  const meta = STAGE_META[stage];
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-full border-[2.5px] border-espresso px-2.5 py-[3px] font-headline text-[10px] font-extrabold uppercase tracking-[0.1em] ${stageBadgeStyles[meta.color]}`}
+    >
+      {meta.label}
+    </span>
+  );
+}
+
+function rowDate(g: CommitmentGroup): string | null {
+  const pickedUp = g.commitments.map((c) => c.picked_up_at).filter((d): d is string => !!d);
+  if (pickedUp.length) return pickedUp.sort().reverse()[0];
+  if (g.lot?.settlement_processed_at) return g.lot.settlement_processed_at;
+  return g.commitments[0]?.created_at ?? null;
+}
+
+export function ClosedLotsTable({ groups }: ClosedLotsTableProps) {
+  return (
+    <div className="overflow-hidden rounded-[14px] border-[3px] border-espresso bg-chalk shadow-flat-md">
+      <div className="grid grid-cols-[1.6fr_1fr_0.8fr_0.9fr_0.9fr_0.9fr] gap-4 bg-espresso px-5 py-3 font-headline text-[10px] font-extrabold uppercase tracking-[0.18em] text-cream">
+        <div>Lot</div>
+        <div>Status</div>
+        <div>Qty</div>
+        <div>Avg price</div>
+        <div>Total</div>
+        <div>Date</div>
+      </div>
+      {groups.map((g, i) => {
+        const stage = stageOfGroup(g);
+        const succeeded = g.commitments.filter((c) => c.payment_status === "charge_succeeded");
+        const securedKg = succeeded.reduce((s, c) => s + Number(c.quantity_kg || 0), 0);
+        const paid = succeeded.reduce(
+          (s, c) => s + (c.charge_amount_cents != null ? c.charge_amount_cents / 100 : Number(c.total_price || 0)),
+          0
+        );
+        const billed = succeeded.reduce((s, c) => s + Number(c.total_price || 0), 0);
+        const refunded = Math.max(0, billed - paid);
+        const avg = securedKg > 0 ? paid / securedKg : Number(g.lot?.price_per_kg || 0);
+        const totalCell = stage === "minimum_not_met" ? `−${fmtMoney(refunded)}` : fmtMoney(paid);
+        const date = rowDate(g);
+        return (
+          <div
+            key={g.groupKey}
+            className={`grid grid-cols-[1.6fr_1fr_0.8fr_0.9fr_0.9fr_0.9fr] items-center gap-4 px-5 py-3.5 font-headline text-[13px] ${
+              i < groups.length - 1 ? "border-b border-fog" : ""
+            }`}
+          >
+            <div>
+              <Link
+                href={`/dashboard/buyer/lot/${g.lotId}`}
+                className="font-headline text-[15px] font-bold leading-tight text-espresso transition-colors hover:text-tomato"
+              >
+                {g.lot?.title || "Unknown lot"}
+              </Link>
+              <div className="mt-0.5 text-[11px] text-espresso/60">
+                {[g.lot?.region, g.lot?.origin_country].filter(Boolean).join(" · ")}
+              </div>
+            </div>
+            <div>
+              <StageBadge stage={stage} />
+            </div>
+            <div className="font-bold text-espresso">
+              <UnitWeightText kg={securedKg} maximumFractionDigits={0} />
+            </div>
+            <div className="font-bold text-espresso">
+              <UnitPriceText pricePerKg={avg} currency="usd" />
+            </div>
+            <div className="font-extrabold text-espresso">{totalCell}</div>
+            <div className="text-[11px] text-espresso/60">{date ? new Date(date).toLocaleDateString() : "—"}</div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/components/buyer-commitments/in-motion-lot-card.tsx
+++ b/components/buyer-commitments/in-motion-lot-card.tsx
@@ -1,0 +1,112 @@
+import { CommitmentPickupButton } from "@/components/commitment-pickup-button";
+import { UnitWeightText } from "@/components/unit-value";
+import { LifecycleTrack } from "./lifecycle-track";
+import { stageOfGroup, type CommitmentGroup } from "./bucket-by-lifecycle";
+
+export interface InMotionLotCardProps {
+  group: CommitmentGroup;
+}
+
+const fmtMoney = (n: number) =>
+  new Intl.NumberFormat("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 0 }).format(n || 0);
+
+function fmtRelDays(iso: string | null | undefined): string | null {
+  if (!iso) return null;
+  const ms = new Date(iso).getTime() - Date.now();
+  const d = Math.round(ms / 86_400_000);
+  if (d === 0) return "today";
+  if (d > 0) return `in ${d}d`;
+  return `${-d}d ago`;
+}
+
+export function InMotionLotCard({ group }: InMotionLotCardProps) {
+  const lot = group.lot;
+  const stage = stageOfGroup(group);
+  const succeeded = group.commitments.filter((c) => c.payment_status === "charge_succeeded");
+  const myKg = succeeded.reduce((s, c) => s + Number(c.quantity_kg || 0), 0);
+  const paid = succeeded.reduce(
+    (s, c) => s + (c.charge_amount_cents != null ? c.charge_amount_cents / 100 : Number(c.total_price || 0)),
+    0
+  );
+  const billed = succeeded.reduce((s, c) => s + Number(c.total_price || 0), 0);
+  const refunded = Math.max(0, billed - paid);
+  const settlementFailed = lot?.settlement_status === "failed";
+
+  // Use the most-recent at-hub-stage commitment for the pickup button (any one will do — the API marks per-commitment)
+  const pickupCommitmentId = succeeded[0]?.id ?? group.commitments[0]?.id;
+
+  let nextEvent: string | null = null;
+  if (stage === "in_transit") {
+    nextEvent = group.shipment?.delivered_at ? `Landed ${fmtRelDays(group.shipment.delivered_at)}` : "Sailing to your hub";
+  } else if (stage === "at_hub") {
+    nextEvent = group.shipment?.delivered_at ? `Landed ${fmtRelDays(group.shipment.delivered_at)}` : "Ready for pickup";
+  } else if (stage === "funds_held") {
+    nextEvent = group.shipment?.shipped_at ? `Shipped ${fmtRelDays(group.shipment.shipped_at)}` : "Awaiting shipment";
+  }
+
+  return (
+    <div className="rounded-[14px] border-[3px] border-espresso bg-chalk p-5 shadow-flat-md">
+      <div className="mb-3.5 flex items-start justify-between gap-4">
+        <div className="min-w-0 flex-1">
+          <div className="font-headline text-[10px] font-extrabold uppercase tracking-[0.18em] text-espresso/60">
+            {(lot?.region || lot?.origin_country || "").toString().toUpperCase()}
+            {lot?.region && lot?.origin_country ? ` · ${lot.origin_country.toUpperCase()}` : ""}
+          </div>
+          <div className="mt-1 font-headline text-[20px] font-bold leading-tight text-espresso">
+            {lot?.title || "Unknown lot"}
+          </div>
+          <div className="mt-1 font-headline text-xs text-espresso/60">
+            <UnitWeightText kg={myKg} maximumFractionDigits={0} /> · {fmtMoney(paid)} settled
+            {refunded > 0 && (
+              <span className="font-bold text-matcha"> · refunded {fmtMoney(refunded)}</span>
+            )}
+          </div>
+        </div>
+        <div className="text-right">
+          {nextEvent && (
+            <>
+              <div className="font-headline text-[9px] font-extrabold uppercase tracking-[0.18em] text-espresso/55">
+                Next event
+              </div>
+              <div className="mt-0.5 font-headline text-sm font-extrabold text-espresso">{nextEvent}</div>
+            </>
+          )}
+          {(group.shipment?.carrier || group.shipment?.tracking_number) && (
+            <div className="mt-1 font-headline text-[11px] text-espresso/60">
+              {group.shipment.carrier}
+              {group.shipment.carrier && group.shipment.tracking_number ? " · " : ""}
+              {group.shipment.tracking_number}
+            </div>
+          )}
+          {group.shipment?.hub?.name && (
+            <div className="mt-1 font-headline text-[11px] text-espresso/60">{group.shipment.hub.name}</div>
+          )}
+        </div>
+      </div>
+
+      <LifecycleTrack stage={stage} dense />
+
+      {settlementFailed && (
+        <div className="mt-3 rounded border-2 border-tomato bg-tomato/10 px-3 py-2 font-headline text-xs font-bold text-tomato">
+          Settlement retrying — we'll keep you posted.
+        </div>
+      )}
+
+      {stage === "at_hub" && pickupCommitmentId && (
+        <div className="mt-3.5 flex items-center justify-between gap-3 border-t-2 border-dashed border-espresso/20 pt-3.5">
+          <div className="font-headline text-xs text-espresso">
+            <span className="font-extrabold">Ready for pickup</span>
+            {group.shipment?.hub?.name && <span className="text-espresso/60"> · {group.shipment.hub.name}</span>}
+          </div>
+          <CommitmentPickupButton
+            commitmentId={pickupCommitmentId}
+            alreadyPickedUp={false}
+            variant="matcha"
+            size="sm"
+            label="✓ Mark as picked up"
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/buyer-commitments/in-motion-lot-card.tsx
+++ b/components/buyer-commitments/in-motion-lot-card.tsx
@@ -46,7 +46,7 @@ export function InMotionLotCard({ group }: InMotionLotCardProps) {
 
   return (
     <div className="rounded-[14px] border-[3px] border-espresso bg-chalk p-5 shadow-flat-md">
-      <div className="mb-3.5 flex items-start justify-between gap-4">
+      <div className="mb-3.5 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
         <div className="min-w-0 flex-1">
           <div className="font-headline text-[10px] font-extrabold uppercase tracking-[0.18em] text-espresso/60">
             {(lot?.region || lot?.origin_country || "").toString().toUpperCase()}
@@ -62,7 +62,7 @@ export function InMotionLotCard({ group }: InMotionLotCardProps) {
             )}
           </div>
         </div>
-        <div className="text-right">
+        <div className="text-left sm:text-right">
           {nextEvent && (
             <>
               <div className="font-headline text-[9px] font-extrabold uppercase tracking-[0.18em] text-espresso/55">
@@ -93,7 +93,7 @@ export function InMotionLotCard({ group }: InMotionLotCardProps) {
       )}
 
       {stage === "at_hub" && pickupCommitmentId && (
-        <div className="mt-3.5 flex items-center justify-between gap-3 border-t-2 border-dashed border-espresso/20 pt-3.5">
+        <div className="mt-3.5 flex flex-col gap-3 border-t-2 border-dashed border-espresso/20 pt-3.5 sm:flex-row sm:items-center sm:justify-between">
           <div className="font-headline text-xs text-espresso">
             <span className="font-extrabold">Ready for pickup</span>
             {group.shipment?.hub?.name && <span className="text-espresso/60"> · {group.shipment.hub.name}</span>}

--- a/components/buyer-commitments/lifecycle-track.tsx
+++ b/components/buyer-commitments/lifecycle-track.tsx
@@ -1,0 +1,36 @@
+import { Stepper } from "@merninos/ui";
+import { LIFECYCLE_STEPS, type LifecycleStage } from "./bucket-by-lifecycle";
+
+export interface LifecycleTrackProps {
+  stage: LifecycleStage;
+  dense?: boolean;
+  className?: string;
+}
+
+/**
+ * Crowdroast-specific stepper that pre-binds the 6 commitment lifecycle
+ * stages to the generic <Stepper> in @merninos/ui. Renders a fallback chip
+ * for the off-track `minimum_not_met` stage.
+ */
+export function LifecycleTrack({ stage, dense = false, className }: LifecycleTrackProps) {
+  if (stage === "minimum_not_met") {
+    return (
+      <div
+        className={
+          "inline-flex items-center gap-2 rounded-full border-[2.5px] border-espresso bg-espresso px-3.5 py-1.5 font-body text-[11px] font-extrabold uppercase tracking-[0.1em] text-cream shadow-[3px_3px_0_var(--mernin-tomato,#E8442A)]"
+        }
+      >
+        ✕ Min not met · refunded
+      </div>
+    );
+  }
+
+  return (
+    <Stepper
+      steps={LIFECYCLE_STEPS}
+      currentKey={stage}
+      dense={dense}
+      className={className}
+    />
+  );
+}

--- a/components/buyer-commitments/needs-attention-card.tsx
+++ b/components/buyer-commitments/needs-attention-card.tsx
@@ -1,0 +1,43 @@
+import Link from "next/link";
+import { Button } from "@merninos/ui";
+import { UnitWeightText } from "@/components/unit-value";
+import type { CommitmentGroup } from "./bucket-by-lifecycle";
+
+export interface NeedsAttentionCardProps {
+  group: CommitmentGroup;
+}
+
+/**
+ * Surfaces a commitment whose payment has failed (`payment_status = 'charge_failed'`).
+ * Excluded from cycle math; the user's only action is to fix payment.
+ */
+export function NeedsAttentionCard({ group }: NeedsAttentionCardProps) {
+  const failed = group.commitments.filter((c) => c.payment_status === "charge_failed");
+  const failedKg = failed.reduce((s, c) => s + Number(c.quantity_kg || 0), 0);
+  const reason = failed.find((c) => c.payment_error)?.payment_error || "Charge failed — retrying";
+
+  return (
+    <div
+      className="flex items-center gap-4 rounded-[14px] border-[3px] border-tomato bg-cream px-5 py-4 shadow-flat-sm"
+      role="alert"
+    >
+      <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border-[2.5px] border-espresso bg-tomato font-headline text-lg font-extrabold text-cream">
+        !
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="font-headline text-[10px] font-extrabold uppercase tracking-[0.18em] text-tomato">
+          Charge issue
+        </div>
+        <div className="mt-0.5 font-headline text-[18px] font-bold leading-tight text-espresso">
+          {group.lot?.title || "Unknown lot"}
+        </div>
+        <div className="mt-1 font-headline text-[12px] text-espresso/70">
+          <UnitWeightText kg={failedKg} maximumFractionDigits={0} /> · {reason}
+        </div>
+      </div>
+      <Button asChild size="sm" variant="default">
+        <Link href={`/dashboard/buyer/lot/${group.lotId}`}>Update payment →</Link>
+      </Button>
+    </div>
+  );
+}

--- a/components/buyer-commitments/needs-attention-card.tsx
+++ b/components/buyer-commitments/needs-attention-card.tsx
@@ -18,24 +18,26 @@ export function NeedsAttentionCard({ group }: NeedsAttentionCardProps) {
 
   return (
     <div
-      className="flex items-center gap-4 rounded-[14px] border-[3px] border-tomato bg-cream px-5 py-4 shadow-flat-sm"
+      className="flex flex-col gap-3 rounded-[14px] border-[3px] border-tomato bg-cream px-5 py-4 shadow-flat-sm sm:flex-row sm:items-center sm:gap-4"
       role="alert"
     >
-      <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border-[2.5px] border-espresso bg-tomato font-headline text-lg font-extrabold text-cream">
-        !
+      <div className="flex items-start gap-3 sm:contents">
+        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border-[2.5px] border-espresso bg-tomato font-headline text-lg font-extrabold text-cream">
+          !
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="font-headline text-[10px] font-extrabold uppercase tracking-[0.18em] text-tomato">
+            Charge issue
+          </div>
+          <div className="mt-0.5 font-headline text-[18px] font-bold leading-tight text-espresso">
+            {group.lot?.title || "Unknown lot"}
+          </div>
+          <div className="mt-1 font-headline text-[12px] text-espresso/70">
+            <UnitWeightText kg={failedKg} maximumFractionDigits={0} /> · {reason}
+          </div>
+        </div>
       </div>
-      <div className="min-w-0 flex-1">
-        <div className="font-headline text-[10px] font-extrabold uppercase tracking-[0.18em] text-tomato">
-          Charge issue
-        </div>
-        <div className="mt-0.5 font-headline text-[18px] font-bold leading-tight text-espresso">
-          {group.lot?.title || "Unknown lot"}
-        </div>
-        <div className="mt-1 font-headline text-[12px] text-espresso/70">
-          <UnitWeightText kg={failedKg} maximumFractionDigits={0} /> · {reason}
-        </div>
-      </div>
-      <Button asChild size="sm" variant="default">
+      <Button asChild size="sm" variant="default" className="self-stretch sm:self-auto">
         <Link href={`/dashboard/buyer/lot/${group.lotId}`}>Update payment →</Link>
       </Button>
     </div>

--- a/components/buyer-commitments/portfolio-strip.tsx
+++ b/components/buyer-commitments/portfolio-strip.tsx
@@ -1,0 +1,63 @@
+import { StatCard } from "@merninos/ui";
+import type { PortfolioStats } from "./bucket-by-lifecycle";
+
+export interface PortfolioStripProps {
+  stats: PortfolioStats;
+}
+
+const fmtMoney = (n: number) =>
+  new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  }).format(n || 0);
+
+const fmtKg = (kg: number) =>
+  kg >= 1000
+    ? `${(kg / 1000).toFixed(2).replace(/\.?0+$/, "")} t`
+    : `${(kg || 0).toLocaleString()} lb`;
+
+/**
+ * 4-card portfolio strip for the buyer commitments page.
+ *
+ * Math definitions live in `bucket-by-lifecycle.ts:derivePortfolioStats`.
+ * This component is presentation only.
+ *
+ * StatCard's value slot defaults to font-display (Adore Cats) — we override
+ * with font-headline (Cal Sans in crowdroast) to keep the page calmer per
+ * the buyer's tighter typographic brief on this surface.
+ */
+const Val = ({ children }: { children: React.ReactNode }) => (
+  <span className="font-headline">{children}</span>
+);
+
+export function PortfolioStrip({ stats }: PortfolioStripProps) {
+  return (
+    <div className="mb-6 grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-4">
+      <StatCard
+        variant="tomato"
+        label="Live Exposure"
+        value={<Val>{fmtMoney(stats.liveExposure)}</Val>}
+        sub={`${stats.liveCount} lots raising`}
+      />
+      <StatCard
+        variant="sky"
+        label="Landing Soon"
+        value={<Val>{fmtKg(stats.landingKg)}</Val>}
+        sub={`${stats.inMotionCount} in motion`}
+      />
+      <StatCard
+        variant="matcha"
+        label="Saved via Tiers"
+        value={<Val>{fmtMoney(stats.savedVsBase)}</Val>}
+        sub="vs base price"
+      />
+      <StatCard
+        variant="espresso"
+        label="YTD Spend"
+        value={<Val>{fmtMoney(stats.ytdSpend)}</Val>}
+        sub="all settled lots"
+      />
+    </div>
+  );
+}

--- a/components/buyer-commitments/portfolio-strip.tsx
+++ b/components/buyer-commitments/portfolio-strip.tsx
@@ -23,36 +23,44 @@ const fmtKg = (kg: number) =>
  * Math definitions live in `bucket-by-lifecycle.ts:derivePortfolioStats`.
  * This component is presentation only.
  *
- * StatCard's value slot defaults to font-display (Adore Cats) — we override
- * with font-headline (Cal Sans in crowdroast) to keep the page calmer per
- * the buyer's tighter typographic brief on this surface.
+ * StatCard's value slot defaults to font-display (Adore Cats) at 38px and
+ * the card frame uses p-4 / border-4 / shadow-flat-md. On this page we want
+ * the strip to read as a compact KPI row, not a hero block, so we override:
+ *   - Val span: font-headline (Cal Sans) at a smaller size, overrides inherited
+ *   - StatCard root: lighter padding, border, and shadow via className
  */
 const Val = ({ children }: { children: React.ReactNode }) => (
-  <span className="font-headline">{children}</span>
+  <span className="font-headline text-[22px] leading-none">{children}</span>
 );
+
+const cardClass = "p-3 border-[3px] shadow-flat-sm rounded-[14px]";
 
 export function PortfolioStrip({ stats }: PortfolioStripProps) {
   return (
-    <div className="mb-6 grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-4">
+    <div className="mb-6 grid grid-cols-2 gap-2.5 lg:grid-cols-4">
       <StatCard
+        className={cardClass}
         variant="tomato"
         label="Live Exposure"
         value={<Val>{fmtMoney(stats.liveExposure)}</Val>}
         sub={`${stats.liveCount} lots raising`}
       />
       <StatCard
+        className={cardClass}
         variant="sky"
         label="Landing Soon"
         value={<Val>{fmtKg(stats.landingKg)}</Val>}
         sub={`${stats.inMotionCount} in motion`}
       />
       <StatCard
+        className={cardClass}
         variant="matcha"
         label="Saved via Tiers"
         value={<Val>{fmtMoney(stats.savedVsBase)}</Val>}
         sub="vs base price"
       />
       <StatCard
+        className={cardClass}
         variant="espresso"
         label="YTD Spend"
         value={<Val>{fmtMoney(stats.ytdSpend)}</Val>}

--- a/components/buyer-commitments/raising-lot-card.tsx
+++ b/components/buyer-commitments/raising-lot-card.tsx
@@ -69,8 +69,8 @@ export function RaisingLotCard({ group, pricingTiers }: RaisingLotCardProps) {
         goingFast ? "border-tomato" : "border-espresso"
       }`}
     >
-      {/* Photo column */}
-      <div className="relative min-h-[180px] bg-roast">
+      {/* Photo column — full width banner on mobile, side panel on desktop */}
+      <div className="relative h-[140px] bg-roast md:h-auto md:min-h-[180px]">
         {photoUrl ? (
           <Image
             src={photoUrl}
@@ -136,8 +136,8 @@ export function RaisingLotCard({ group, pricingTiers }: RaisingLotCardProps) {
         </div>
       </div>
 
-      {/* Position + CTA column */}
-      <div className="flex flex-col justify-between border-l-2 border-dashed border-espresso/20 bg-cream p-5">
+      {/* Position + CTA column — bottom strip on mobile, side panel on desktop */}
+      <div className="flex flex-col justify-between gap-3 border-t-2 border-dashed border-espresso/20 bg-cream p-5 md:border-l-2 md:border-t-0">
         <div>
           <div className="font-headline text-[9px] font-extrabold uppercase tracking-[0.18em] text-espresso/55">
             Closes in

--- a/components/buyer-commitments/raising-lot-card.tsx
+++ b/components/buyer-commitments/raising-lot-card.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import Link from "next/link";
+import Image from "next/image";
+import { useEffect, useState } from "react";
+import { Button, TierBar, type TierBarTick } from "@merninos/ui";
+import { addPlatformFee } from "@/lib/pricing";
+import { UnitPriceText, UnitWeightText } from "@/components/unit-value";
+import type { CommitmentGroup } from "./bucket-by-lifecycle";
+
+export interface RaisingLotCardProps {
+  group: CommitmentGroup;
+  /** Sorted ascending by min_quantity_kg from the page query. */
+  pricingTiers: { min_quantity_kg: number; price_per_kg: number }[];
+}
+
+const fmtMoney = (n: number) =>
+  new Intl.NumberFormat("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 0 }).format(n || 0);
+
+function fmtCountdown(deadline: string | null | undefined, nowMs: number): { label: string; goingFast: boolean } {
+  if (!deadline) return { label: "—", goingFast: false };
+  const ms = Math.max(0, new Date(deadline).getTime() - nowMs);
+  if (ms === 0) return { label: "Ended", goingFast: false };
+  const d = Math.floor(ms / 86_400_000);
+  const h = Math.floor((ms % 86_400_000) / 3_600_000);
+  const m = Math.floor((ms % 3_600_000) / 60_000);
+  const s = Math.floor((ms % 60_000) / 1000);
+  const goingFast = ms < 24 * 3_600_000;
+  if (d > 0) return { label: `${d}d ${String(h).padStart(2, "0")}h`, goingFast };
+  if (h > 0) return { label: `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`, goingFast };
+  if (m > 0) return { label: `${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`, goingFast };
+  return { label: `${s}s`, goingFast };
+}
+
+export function RaisingLotCard({ group, pricingTiers }: RaisingLotCardProps) {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const t = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(t);
+  }, []);
+
+  const lot = group.lot;
+  const myCommits = group.commitments.filter((c) => c.status !== "cancelled" && c.payment_status !== "charge_failed");
+  const myKg = myCommits.reduce((s, c) => s + Number(c.quantity_kg || 0), 0);
+  const myValue = myCommits.reduce((s, c) => s + Number(c.quantity_kg || 0) * addPlatformFee(Number(c.price_per_kg || 0)), 0);
+
+  // Use the lot's running global commitment total. Fall back to the user's
+  // own commitments only if the lot column is null/0 — covers buyer-only DBs.
+  const lotCommittedKg = Number(lot?.committed_quantity_kg || 0);
+  const committedKg = lotCommittedKg > 0 ? lotCommittedKg : myKg;
+  const targetKg = Number(lot?.total_quantity_kg || 0);
+  const tierMaxes = pricingTiers.map((t) => Number(t.min_quantity_kg));
+  const maxBarUnits = Math.max(targetKg, ...tierMaxes, committedKg, 1);
+  const ticks: TierBarTick[] = pricingTiers
+    .filter((t) => Number(t.min_quantity_kg) > 0)
+    .map((t) => ({
+      position: Number(t.min_quantity_kg),
+      sub: `${new Intl.NumberFormat("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 2 }).format(addPlatformFee(Number(t.price_per_kg)))}/lb`,
+    }));
+
+  const nextTier = pricingTiers.find((t) => Number(t.min_quantity_kg) > committedKg);
+  const deadline = group.campaign?.deadline ?? lot?.commitment_deadline ?? null;
+  const { label: countdownLabel, goingFast } = fmtCountdown(deadline, now);
+  const photoUrl = lot?.images?.[0] || null;
+
+  return (
+    <div
+      className={`relative grid grid-cols-1 overflow-hidden rounded-[14px] border-[3px] bg-chalk shadow-flat-md md:grid-cols-[180px_1fr_220px] ${
+        goingFast ? "border-tomato" : "border-espresso"
+      }`}
+    >
+      {/* Photo column */}
+      <div className="relative min-h-[180px] bg-roast">
+        {photoUrl ? (
+          <Image
+            src={photoUrl}
+            alt={lot?.title || "lot photo"}
+            fill
+            sizes="180px"
+            className="object-cover"
+          />
+        ) : (
+          <div className="absolute inset-0 bg-gradient-to-br from-roast to-honey/40" aria-hidden />
+        )}
+        {lot?.score != null && (
+          <div className="absolute left-2.5 top-2.5 rounded-full border-2 border-espresso bg-sun px-2.5 py-1 font-headline text-[10px] font-extrabold tracking-[0.1em] text-espresso">
+            {Number(lot.score).toFixed(1)} PTS
+          </div>
+        )}
+        {goingFast && (
+          <div className="absolute inset-x-2.5 bottom-2.5 rounded border-2 border-espresso bg-tomato px-2.5 py-1 text-center font-headline text-[9.5px] font-extrabold uppercase tracking-[0.14em] text-cream">
+            ⚡ Going fast
+          </div>
+        )}
+      </div>
+
+      {/* Detail column */}
+      <div className="flex flex-col p-5">
+        <div className="font-headline text-[9.5px] font-extrabold uppercase tracking-[0.18em] text-espresso/60">
+          {(lot?.region || lot?.origin_country || "").toString().toUpperCase()}
+          {lot?.region && lot?.origin_country ? ` · ${lot.origin_country.toUpperCase()}` : ""}
+        </div>
+        <Link
+          href={`/dashboard/buyer/lot/${group.lotId}`}
+          className="mt-1 font-headline text-[20px] font-bold leading-tight text-espresso transition-colors hover:text-tomato"
+        >
+          {lot?.title || "Unknown lot"}
+        </Link>
+        {(lot?.farm || lot?.process) && (
+          <div className="mb-3.5 mt-1 font-headline text-xs italic text-espresso/60">
+            {[lot?.farm, lot?.process].filter(Boolean).join(" · ")}
+          </div>
+        )}
+
+        <TierBar value={committedKg} max={maxBarUnits} ticks={ticks} variant="tomato" />
+
+        <div className="mt-3 flex items-center gap-1.5 font-headline text-[11px] text-espresso">
+          {nextTier ? (
+            <>
+              <span className="h-1.5 w-1.5 rounded-full bg-tomato" aria-hidden />
+              <span className="font-extrabold tracking-[0.06em]">NEXT TIER</span>
+              <span className="opacity-70">·</span>
+              <span>
+                <UnitWeightText kg={Number(nextTier.min_quantity_kg) - committedKg} maximumFractionDigits={0} /> to{" "}
+                <b>
+                  <UnitPriceText pricePerKg={Number(nextTier.price_per_kg)} currency="usd" includePlatformFee />
+                </b>
+              </span>
+            </>
+          ) : (
+            <>
+              <span className="h-1.5 w-1.5 rounded-full bg-matcha" aria-hidden />
+              <span className="font-extrabold uppercase tracking-[0.06em] text-matcha">Full tier unlocked</span>
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* Position + CTA column */}
+      <div className="flex flex-col justify-between border-l-2 border-dashed border-espresso/20 bg-cream p-5">
+        <div>
+          <div className="font-headline text-[9px] font-extrabold uppercase tracking-[0.18em] text-espresso/55">
+            Closes in
+          </div>
+          <div className="mt-1 font-headline text-[24px] font-bold leading-none text-tomato tabular-nums">{countdownLabel}</div>
+          <div className="mt-3 font-headline text-[9px] font-extrabold uppercase tracking-[0.18em] text-espresso/55">
+            Your position
+          </div>
+          <div className="mt-0.5 font-headline text-[15px] font-extrabold text-espresso">
+            <UnitWeightText kg={myKg} maximumFractionDigits={0} />
+          </div>
+          <div className="mt-px font-headline text-[11px] text-espresso/60">
+            {fmtMoney(myValue)} @ <UnitPriceText pricePerKg={Number(lot?.price_per_kg || 0)} currency="usd" includePlatformFee />
+          </div>
+        </div>
+        <Button asChild variant="sun" size="sm" className="mt-3">
+          <Link href={`/dashboard/buyer/lot/${group.lotId}`}>Commit more →</Link>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/components/commitment-pickup-button.tsx
+++ b/components/commitment-pickup-button.tsx
@@ -3,15 +3,23 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import { Button } from "@merninos/ui";
+import { Button, type ButtonProps } from "@merninos/ui";
+
+interface CommitmentPickupButtonProps {
+  commitmentId: string;
+  alreadyPickedUp: boolean;
+  variant?: ButtonProps["variant"];
+  size?: ButtonProps["size"];
+  label?: string;
+}
 
 export function CommitmentPickupButton({
   commitmentId,
   alreadyPickedUp,
-}: {
-  commitmentId: string;
-  alreadyPickedUp: boolean;
-}) {
+  variant = "outline",
+  size = "sm",
+  label = "Mark Picked Up",
+}: CommitmentPickupButtonProps) {
   const router = useRouter();
   const [loading, setLoading] = useState(false);
 
@@ -36,8 +44,8 @@ export function CommitmentPickupButton({
   };
 
   return (
-    <Button size="sm" variant="outline" onClick={handlePickup} disabled={loading}>
-      {loading ? "Saving..." : "Mark Picked Up"}
+    <Button size={size} variant={variant} onClick={handlePickup} disabled={loading}>
+      {loading ? "Saving..." : label}
     </Button>
   );
 }

--- a/components/dashboard-shell.tsx
+++ b/components/dashboard-shell.tsx
@@ -23,6 +23,7 @@ import {
 import type { User } from "@supabase/supabase-js";
 import type { Profile, UserRole } from "@/lib/types";
 import { UnitToggle } from "@/components/unit-toggle";
+import { CrTicker } from "@/components/cr-ticker";
 import { NavTab as UiNavTab } from "@merninos/ui";
 
 type DashboardRole = UserRole | "admin";
@@ -331,6 +332,7 @@ export function DashboardShell({
 
       {/* ─── MAIN ────────────────────────────────────────────────────────── */}
       <main className="flex-1 overflow-auto">
+        <CrTicker />
         <div className="mx-auto max-w-7xl p-4 md:p-6 lg:p-8">{children}</div>
       </main>
     </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@hookform/resolvers": "^3.9.1",
-        "@merninos/ui": "^0.1.6",
+        "@merninos/ui": "^0.2.1",
         "@radix-ui/react-accordion": "1.2.2",
         "@radix-ui/react-alert-dialog": "1.1.4",
         "@radix-ui/react-aspect-ratio": "1.1.1",
@@ -1003,9 +1003,9 @@
       }
     },
     "node_modules/@merninos/ui": {
-      "version": "0.1.6",
-      "resolved": "https://npm.pkg.github.com/download/@merninos/ui/0.1.6/39577d0e98807347fddc9373112a1e6c71c41260",
-      "integrity": "sha512-qMC6vGYrnh2eXFeJsSc3LNpbcc8X2uwY/SW8BQnP7puTp7CiIi+e+XsQr4ZtRt8wpTNtU3UfAediDQynQZ+Dxg==",
+      "version": "0.2.1",
+      "resolved": "https://npm.pkg.github.com/download/@merninos/ui/0.2.1/6bf8eca342b5ed6eb579b011b8cc8d0eedd1506a",
+      "integrity": "sha512-A4LHoQ4ZIqaiZouSSuyyUYAG9Ll8kX+dEz5TqBCbUbMwKJiZ8cE6n9UGB2YWVNjjNvS8UXk1SRMAvxwiLEH1JQ==",
       "dependencies": {
         "@radix-ui/react-slot": "^1",
         "class-variance-authority": "^0.7",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",
-    "@merninos/ui": "^0.1.6",
+    "@merninos/ui": "^0.2.1",
     "@radix-ui/react-accordion": "1.2.2",
     "@radix-ui/react-alert-dialog": "1.1.4",
     "@radix-ui/react-aspect-ratio": "1.1.1",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -6,6 +6,7 @@ const config: Config = {
     './pages/**/*.{js,ts,jsx,tsx,mdx}',
     './components/**/*.{js,ts,jsx,tsx,mdx}',
     './app/**/*.{js,ts,jsx,tsx,mdx}',
+    './node_modules/@merninos/ui/dist/**/*.{js,mjs}',
     '*.{js,ts,jsx,tsx,mdx}',
   ],
   theme: {
@@ -15,7 +16,7 @@ const config: Config = {
         mono:     ['var(--font-mono)', 'monospace'],
         display:  ["'Adore Cats'", 'var(--font-display)'],
         headline: ["'Cal Sans'", 'var(--font-headline)'],
-        body:     ['system-ui', 'sans-serif'],
+        body:     ["'Cal Sans'", 'system-ui', 'sans-serif'],
       },
       colors: {
         background: 'hsl(var(--background))',


### PR DESCRIPTION
## Summary

Replaces the flat reverse-chrono lot list at `/dashboard/buyer/commitments` with a lifecycle-organized layout. Buyers can now answer at a glance: what's still raising (where I can commit more / watch tiers unlock), what's moving toward my hub, and what's reconciled in the books.

- **Needs Attention** mini-section surfaces `charge_failed` commitments with a payment-update CTA. Excluded from all cycle math.
- **Still Raising** rows show a live HH:MM:SS countdown to the **campaign deadline** (not the lot's), tier-progress bar with per-tier ticks, and a "Commit more →" CTA.
- **In Motion** rows show the 6-pill lifecycle chain (Raising → Funds Held → In Transit → At Hub → Picked Up → Done) and an at-hub "Mark as picked up" CTA wired to a buyer-side pickup flow.
- **Closed Lots** is a compact reconciliation table on tablet+ and a stacked card list on phone widths.
- **Portfolio strip** at top: Live Exposure / Landing Soon / Saved via Tiers (base × qty − actual paid) / YTD Spend (net of refunds via `charge_amount_cents`).

## Correctness work worth flagging in review

- **Group key migrated** from `lot_id` to `(campaign_id ?? "lot:" + lot_id)`. A lot with multiple campaigns over time now renders as separate rows. Matches the seller side (already groups by `campaign_id`).
- **Bucketing trusts `campaign.status`** when present and ignores `lot.settlement_status` (lot-level state reflects only the *most recent* campaign's outcome, which would otherwise poison every prior campaign's group with the wrong status — e.g., labeling a successful new campaign "Min Not Met" because the previous campaign on that lot failed).
- **Buyer-side pickup auth**: the `PATCH /api/commitments/[id]` handler now allows either the commitment's buyer or the lot's hub owner. Was hub-owner-only.
- **Saved via Tiers math**: `Σ (addPlatformFee(lot.price_per_kg) × qty) − (charge_amount_cents / 100)` for charge_succeeded commitments. The previous formula compared commit-time price to current price and returned $0 in nearly all cases.
- **CrTicker lifted** from the buyer overview into `DashboardShell` so all dashboard pages get the FOB·LIVE / THE WIRE chrome consistently.
- **Tailwind config**: now scans `node_modules/@merninos/ui/dist/**` so JIT generates the arbitrary-value classes used inside the published primitives. Without this, `h-[22px]` and `rounded-[16px]` weren't rendered. Also aligned `font-body` with mernin-ui's setting (Cal Sans first).
- **`@merninos/ui` bumped to ^0.2.1**: adds Stepper, TierBar, SectionHeader, StatCard primitives + a matcha Button variant + roomier Stepper pill spacing.

## Test plan

Per `casaflow.config.md` (`test-strategy: manual`); the bucketing helper is the one piece with automated coverage:

- [x] **Unit:** `npm test -- components/buyer-commitments` — 28 tests covering bucketing rules, sort order, charge_failed exclusion, refund netting, lot-state-poisoning prevention, and Saved via Tiers math
- [ ] **Manual:** Sectioned layout — three sections (Needs Attention conditional) in correct order, count badges match row counts
- [ ] **Manual:** Lifecycle pills render with correct stage active/done/future states per shipment status
- [ ] **Manual:** Tier progress bar fills proportionally; "next tier in X lb to $Y/lb" matches DB tier rows
- [ ] **Manual:** "Mark as picked up" appears only on `at_hub` rows; click sets `picked_up_at` and the row moves to Closed on refresh
- [ ] **Manual:** Portfolio strip values reconcile against SQL: Live Exposure / Landing Soon / Saved via Tiers / YTD Spend
- [ ] **Manual:** `charge_failed` commitment surfaces in Needs Attention; doesn't appear in any other section's count or math
- [ ] **Manual:** Empty sections hidden; sort within each section correct
- [ ] **Manual:** Mobile (iPhone 14 viewport) — stacks cleanly; no horizontal overflow on Closed table
- [ ] **Manual:** Buyer with cross-campaign commitments to the same lot sees them as separate rows

## Spec

Spec: `~/Documents/crowdroast/buyer-commitments-redesign/spec.md`
Plan: `~/Documents/crowdroast/buyer-commitments-redesign/plan.md`

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)