### PR TITLE
fix(buyer-commitments): pass hub through lot links from commitments page

### DIFF
--- a/app/api/commitments/__tests__/commitments-campaign.test.ts
+++ b/app/api/commitments/__tests__/commitments-campaign.test.ts
@@ -123,11 +123,8 @@ describe("POST /api/commitments — campaign requirement", () => {
         return makeChain({ data: activeLot, error: null });
       }
       if (table === "campaigns") {
-        // No active campaign found — single() returns error
-        return makeChain({
-          data: null,
-          error: { code: "PGRST116", message: "no rows returned" },
-        });
+        // No active campaign found — maybeSingle() returns null with no error
+        return makeChain({ data: null, error: null });
       }
       return makeChain({ data: null, error: null });
     });

--- a/app/api/commitments/route.ts
+++ b/app/api/commitments/route.ts
@@ -51,9 +51,16 @@ export async function POST(request: Request) {
     .eq("lot_id", lot_id)
     .eq("hub_id", hub_id)
     .eq("status", "active")
-    .single();
+    .maybeSingle();
 
-  if (campaignError || !campaign) {
+  if (campaignError) {
+    return NextResponse.json(
+      { error: `Campaign lookup failed: ${campaignError.message}` },
+      { status: 500 }
+    );
+  }
+
+  if (!campaign) {
     return NextResponse.json(
       { error: "No active campaign for this lot in your hub" },
       { status: 400 }

--- a/app/dashboard/buyer/commitments/page.tsx
+++ b/app/dashboard/buyer/commitments/page.tsx
@@ -199,6 +199,7 @@ export default async function BuyerCommitmentsPage({
         groupKey,
         lotId: c.lot_id,
         campaignId: c.campaign_id,
+        hubId: c.hub_id ?? null,
         lot: c.lot ?? null,
         campaign: c.campaign_id ? (campaignById[c.campaign_id] as any) ?? null : null,
         commitments: [c],

--- a/components/buyer-commitments/bucket-by-lifecycle.ts
+++ b/components/buyer-commitments/bucket-by-lifecycle.ts
@@ -41,6 +41,7 @@ export interface CommitmentGroup {
   groupKey: string;
   lotId: string;
   campaignId: string | null;
+  hubId: string | null;
   lot: Lot | null;
   campaign: Pick<Campaign, "id" | "status" | "deadline" | "settled_at"> | null;
   commitments: Commitment[];

--- a/components/buyer-commitments/closed-lots-table.tsx
+++ b/components/buyer-commitments/closed-lots-table.tsx
@@ -68,7 +68,7 @@ export function ClosedLotsTable({ groups }: ClosedLotsTableProps) {
               <div className="flex items-start justify-between gap-3">
                 <div className="min-w-0 flex-1">
                   <Link
-                    href={`/dashboard/buyer/lot/${g.lotId}`}
+                    href={`/dashboard/buyer/lot/${g.lotId}${g.hubId ? `?hub=${g.hubId}` : ""}`}
                     className="font-headline text-[16px] font-bold leading-tight text-espresso hover:text-tomato"
                   >
                     {g.lot?.title || "Unknown lot"}
@@ -128,7 +128,7 @@ export function ClosedLotsTable({ groups }: ClosedLotsTableProps) {
             >
               <div>
                 <Link
-                  href={`/dashboard/buyer/lot/${g.lotId}`}
+                  href={`/dashboard/buyer/lot/${g.lotId}${g.hubId ? `?hub=${g.hubId}` : ""}`}
                   className="font-headline text-[15px] font-bold leading-tight text-espresso transition-colors hover:text-tomato"
                 >
                   {g.lot?.title || "Unknown lot"}

--- a/components/buyer-commitments/needs-attention-card.tsx
+++ b/components/buyer-commitments/needs-attention-card.tsx
@@ -38,7 +38,11 @@ export function NeedsAttentionCard({ group }: NeedsAttentionCardProps) {
         </div>
       </div>
       <Button asChild size="sm" variant="default" className="self-stretch sm:self-auto">
-        <Link href={`/dashboard/buyer/lot/${group.lotId}`}>Update payment →</Link>
+        <Link
+          href={`/dashboard/buyer/lot/${group.lotId}${group.hubId ? `?hub=${group.hubId}` : ""}`}
+        >
+          Update payment →
+        </Link>
       </Button>
     </div>
   );

--- a/components/buyer-commitments/raising-lot-card.tsx
+++ b/components/buyer-commitments/raising-lot-card.tsx
@@ -101,7 +101,7 @@ export function RaisingLotCard({ group, pricingTiers }: RaisingLotCardProps) {
           {lot?.region && lot?.origin_country ? ` · ${lot.origin_country.toUpperCase()}` : ""}
         </div>
         <Link
-          href={`/dashboard/buyer/lot/${group.lotId}`}
+          href={`/dashboard/buyer/lot/${group.lotId}${group.hubId ? `?hub=${group.hubId}` : ""}`}
           className="mt-1 font-headline text-[20px] font-bold leading-tight text-espresso transition-colors hover:text-tomato"
         >
           {lot?.title || "Unknown lot"}
@@ -154,7 +154,7 @@ export function RaisingLotCard({ group, pricingTiers }: RaisingLotCardProps) {
           </div>
         </div>
         <Button asChild variant="sun" size="sm" className="mt-3">
-          <Link href={`/dashboard/buyer/lot/${group.lotId}`}>Commit more →</Link>
+          <Link href={`/dashboard/buyer/lot/${group.lotId}${group.hubId ? `?hub=${group.hubId}` : ""}`}>Commit more →</Link>
         </Button>
       </div>
     </div>


### PR DESCRIPTION
Lot links on the redesigned /dashboard/buyer/commitments page (Commit more, Update payment, lot titles) routed to /dashboard/buyer/lot/<id> without the ?hub=<uuid> query param. The detail page reads hub from searchParams and threads it into CommitmentForm, so any commit attempted from one of those entry points POSTed without hub_id. The API then queried Supabase with the literal string "undefined" (Postgres 22P02) and surfaced the misleading "No active campaign for this lot in your hub" instead of the real error.

- Add hubId to CommitmentGroup and populate it from commitments.hub_id when grouping rows on the commitments page.
- Update raising-lot-card, needs-attention-card, and closed-lots-table to append ?hub=<id> when present.
- API: switch the campaign lookup to maybeSingle() and surface real Postgres errors instead of swallowing them as "no campaign". Drop the noisy debug log.
- Test: update fixture for the new maybeSingle() semantics.