### PR TITLE
fix(settle-deadlines): cancel orphan commitments before settling

### DIFF
--- a/app/api/payments/settle-deadlines/__tests__/orphan-cancellation.test.ts
+++ b/app/api/payments/settle-deadlines/__tests__/orphan-cancellation.test.ts
@@ -1,0 +1,293 @@
+/**
+ * Regression test for the "Min Not Met" bug.
+ *
+ * Symptom: a buyer commits, hits minimum, cron runs successfully, but the
+ * lot still shows up as "Min Not Met" on the buyer commitments page and the
+ * campaign DB row says `status='failed'`.
+ *
+ * Root cause: at deadline, any commitment with `stripe_payment_intent_id IS
+ * NULL` (abandoned cart, last-minute commit, missed webhook) was added to
+ * `failedCount`, flipping the campaign to `failed` even though every actual
+ * charge succeeded.
+ *
+ * Fix: cancel orphans first (the lot trigger drops their qty), then evaluate.
+ *
+ * This test verifies the orphan path end-to-end without exercising the
+ * Stripe transfer pipeline.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+type Update = { table: string; payload: Record<string, unknown>; eqId?: unknown };
+const updateCalls: Update[] = [];
+const fromQueue: Array<() => Record<string, unknown>> = [];
+let pendingTable: string | null = null;
+
+function makeChain(response: { data: unknown; error: unknown }) {
+  let pendingPayload: Record<string, unknown> | null = null;
+  let pendingEqId: unknown = undefined;
+  const table = pendingTable!;
+  const chain: Record<string, unknown> = {
+    update: vi.fn((p: Record<string, unknown>) => {
+      pendingPayload = p;
+      return chain;
+    }),
+    insert: vi.fn().mockReturnThis(),
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn((col: string, val: unknown) => {
+      if (col === "id") pendingEqId = val;
+      return chain;
+    }),
+    neq: vi.fn().mockReturnThis(),
+    in: vi.fn().mockReturnThis(),
+    is: vi.fn().mockReturnThis(),
+    lte: vi.fn().mockReturnThis(),
+    not: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    maybeSingle: vi.fn(() => {
+      if (pendingPayload) updateCalls.push({ table, payload: pendingPayload, eqId: pendingEqId });
+      return Promise.resolve(response);
+    }),
+    single: vi.fn(() => {
+      if (pendingPayload) updateCalls.push({ table, payload: pendingPayload, eqId: pendingEqId });
+      return Promise.resolve(response);
+    }),
+    then: (resolve: (v: unknown) => void) => {
+      if (pendingPayload) updateCalls.push({ table, payload: pendingPayload, eqId: pendingEqId });
+      return Promise.resolve(response).then(resolve);
+    },
+  };
+  return chain;
+}
+
+function enqueue(table: string, response: { data: unknown; error: unknown }) {
+  fromQueue.push(() => {
+    pendingTable = table;
+    return makeChain(response);
+  });
+}
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({
+    from: vi.fn((table: string) => {
+      const next = fromQueue.shift();
+      if (!next) throw new Error(`Unexpected from(${table}) — queue empty`);
+      return next();
+    }),
+  })),
+}));
+
+vi.mock("@/lib/auth/admin", () => ({
+  getConfiguredAdminEmails: () => ["admin@test.local"],
+}));
+
+vi.mock("@/lib/email", () => ({
+  sendLotClosedEmailsBatch: vi.fn().mockResolvedValue({ success: true }),
+  sendLotFailedEmail: vi.fn().mockResolvedValue({ success: true }),
+}));
+
+vi.mock("@/lib/shipments", () => ({
+  createShipmentForLot: vi.fn().mockResolvedValue({ ok: true }),
+}));
+
+vi.mock("@/lib/stripe", () => ({
+  getConnectedAccount: vi.fn().mockResolvedValue({
+    capabilities: { transfers: "active" },
+  }),
+  getPaymentIntent: vi.fn().mockResolvedValue({ latest_charge: null }),
+  listRefundsForPaymentIntent: vi.fn().mockResolvedValue({ data: [] }),
+  listTransfersForSourceCharge: vi.fn().mockResolvedValue({ data: [] }),
+  createTransfer: vi.fn().mockResolvedValue({ id: "tr_x" }),
+  createRefund: vi.fn().mockResolvedValue({ id: "re_x" }),
+}));
+
+vi.mock("@/lib/payments/settlement-logic", () => ({
+  getFinalPricePerKg: vi.fn(() => 10),
+  computeChargeAdjustment: vi.fn(() => ({ finalAmountCents: 100000, refundAmountCents: 0 })),
+  computeSellerNetAmountCents: vi.fn(() => 90000),
+  computeSplit: vi.fn(() => ({ sellerAmount: 90000, hubAmount: 2000, platformAmount: 8000 })),
+}));
+
+import { POST } from "@/app/api/payments/settle-deadlines/route";
+
+const CRON_SECRET = "test-secret";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  updateCalls.length = 0;
+  fromQueue.length = 0;
+  process.env.CRON_SECRET = CRON_SECRET;
+  process.env.SUPABASE_SERVICE_ROLE_KEY = "test";
+  process.env.NEXT_PUBLIC_SUPABASE_URL = "http://localhost:54321";
+});
+
+function makeReq(): Request {
+  return new Request("http://localhost/api/payments/settle-deadlines", {
+    method: "POST",
+    headers: { authorization: `Bearer ${CRON_SECRET}` },
+  });
+}
+
+describe("settle-deadlines — orphan commitment handling", () => {
+  it("cancels orphan commitments before evaluating minimum, settles when paid quantity meets minimum", async () => {
+    // Pre-cron queries (platform setup)
+    enqueue("platform_settings", {
+      data: { platform_connect_account_id: "acct_platform" },
+      error: null,
+    });
+    enqueue("profiles", { data: [], error: null }); // payout profiles list
+    enqueue("campaigns", {
+      data: [
+        {
+          id: "camp-1",
+          lot_id: "lot-1",
+          hub_id: "hub-1",
+          deadline: new Date(Date.now() - 60_000).toISOString(),
+          status: "active",
+        },
+      ],
+      error: null,
+    });
+
+    // Per-campaign sequence:
+    // 1) orphan query (one orphan with no payment intent)
+    enqueue("commitments", { data: [{ id: "orphan-1" }], error: null });
+    // 2) cancel orphan update
+    enqueue("commitments", { data: null, error: null });
+    // 3) lot fetch — committed_quantity_kg already reflects orphan removed by trigger
+    enqueue("lots", {
+      data: {
+        id: "lot-1",
+        seller_id: "seller-1",
+        status: "active",
+        currency: "usd",
+        price_per_kg: 10,
+        committed_quantity_kg: 100, // post-trigger: orphan dropped
+        min_commitment_kg: 50,
+        commitment_deadline: new Date(Date.now() - 60_000).toISOString(),
+        settlement_status: "pending",
+        expiry_date: new Date(Date.now() - 60_000).toISOString(),
+      },
+      error: null,
+    });
+    // 4) seller profile fetch
+    enqueue("profiles", {
+      data: { stripe_connect_account_id: "acct_seller" },
+      error: null,
+    });
+    // 5) pricing_tiers
+    enqueue("pricing_tiers", { data: [], error: null });
+    // 6) chargeable commitments query — empty (everything was already confirmed before this run)
+    enqueue("commitments", { data: [], error: null });
+    // 7) campaign update — should be settled, NOT failed
+    enqueue("campaigns", { data: null, error: null });
+    // 8) lot update — should be settled, NOT failed
+    enqueue("lots", { data: null, error: null });
+    // 9) success notifications: lot fetch
+    enqueue("lots", {
+      data: { id: "lot-1", title: "Test Lot", seller_id: "seller-1", committed_quantity_kg: 100 },
+      error: null,
+    });
+    // 10) seller profile for emails
+    enqueue("profiles", { data: { email: "seller@test", contact_name: "Seller" }, error: null });
+    // 11) confirmed commitments for emails
+    enqueue("commitments", { data: [], error: null });
+    // 12) hub fetch for emails
+    enqueue("hubs", {
+      data: { id: "hub-1", name: "Hub", address: null, city: null, state: null, country: null, owner_id: "owner-1" },
+      error: null,
+    });
+    // 13) hub owner profile
+    enqueue("profiles", { data: { email: "owner@test", contact_name: "Owner" }, error: null });
+
+    const res = await POST(makeReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.processed_campaigns).toBe(1);
+    expect(body.results[0]).toMatchObject({
+      campaign_id: "camp-1",
+      lot_id: "lot-1",
+      outcome: "settled",
+      orphans_cancelled: 1,
+    });
+
+    // Orphan was cancelled with status='cancelled' so the lot trigger drops its qty.
+    const orphanCancel = updateCalls.find(
+      (c) => c.table === "commitments" && c.eqId === "orphan-1"
+    );
+    expect(orphanCancel?.payload).toMatchObject({
+      status: "cancelled",
+      payment_status: "cancelled",
+    });
+
+    // Campaign was marked settled — the regression we're guarding against
+    // (it used to be marked 'failed' because the orphan inflated failedCount).
+    const campaignUpdate = updateCalls.find((c) => c.table === "campaigns");
+    expect(campaignUpdate?.payload).toMatchObject({ status: "settled" });
+
+    // Lot was marked settled, not failed.
+    const lotUpdate = updateCalls.find((c) => c.table === "lots");
+    expect(lotUpdate?.payload).toMatchObject({
+      status: "closed",
+      settlement_status: "settled",
+    });
+  });
+
+  it("with NO orphans, behavior is unchanged (campaign settles cleanly)", async () => {
+    enqueue("platform_settings", {
+      data: { platform_connect_account_id: "acct_platform" },
+      error: null,
+    });
+    enqueue("profiles", { data: [], error: null });
+    enqueue("campaigns", {
+      data: [
+        {
+          id: "camp-2",
+          lot_id: "lot-2",
+          hub_id: "hub-2",
+          deadline: new Date(Date.now() - 60_000).toISOString(),
+          status: "active",
+        },
+      ],
+      error: null,
+    });
+    enqueue("commitments", { data: [], error: null }); // no orphans
+    enqueue("lots", {
+      data: {
+        id: "lot-2",
+        seller_id: "seller-2",
+        status: "active",
+        currency: "usd",
+        price_per_kg: 10,
+        committed_quantity_kg: 75,
+        min_commitment_kg: 50,
+        commitment_deadline: new Date(Date.now() - 60_000).toISOString(),
+        settlement_status: "pending",
+        expiry_date: new Date(Date.now() - 60_000).toISOString(),
+      },
+      error: null,
+    });
+    enqueue("profiles", { data: { stripe_connect_account_id: "acct_seller" }, error: null });
+    enqueue("pricing_tiers", { data: [], error: null });
+    enqueue("commitments", { data: [], error: null });
+    enqueue("campaigns", { data: null, error: null });
+    enqueue("lots", { data: null, error: null });
+    enqueue("lots", {
+      data: { id: "lot-2", title: "T", seller_id: "seller-2", committed_quantity_kg: 75 },
+      error: null,
+    });
+    enqueue("profiles", { data: { email: "s@t", contact_name: "S" }, error: null });
+    enqueue("commitments", { data: [], error: null });
+    enqueue("hubs", {
+      data: { id: "hub-2", name: "H", address: null, city: null, state: null, country: null, owner_id: "o" },
+      error: null,
+    });
+    enqueue("profiles", { data: { email: "o@t", contact_name: "O" }, error: null });
+
+    const res = await POST(makeReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.results[0]).toMatchObject({ outcome: "settled", orphans_cancelled: 0 });
+  });
+});

--- a/app/api/payments/settle-deadlines/route.ts
+++ b/app/api/payments/settle-deadlines/route.ts
@@ -335,6 +335,34 @@ async function settleDeadlines(request: Request) {
   const backgroundTasks: Promise<unknown>[] = [];
 
   for (const campaign of dueCampaigns || []) {
+    // Cancel orphans first — commitments where the buyer started checkout but never
+    // got `stripe_payment_intent_id` stamped. Webhooks should already have done this
+    // on `checkout.session.expired`/`payment_intent.payment_failed`; this is the
+    // safety net for races (last-minute commits, missed webhooks). Cancelling fires
+    // the lot trigger so committed_quantity_kg drops to truth before we read it.
+    let orphansCancelled = 0;
+    if (!debug) {
+      const { data: orphans } = await admin
+        .from("commitments")
+        .select("id")
+        .eq("campaign_id", campaign.id)
+        .is("stripe_payment_intent_id", null)
+        .neq("status", "cancelled")
+        .neq("status", "confirmed");
+
+      for (const orphan of orphans || []) {
+        await admin
+          .from("commitments")
+          .update({
+            status: "cancelled",
+            payment_status: "cancelled",
+            payment_error: "Cancelled at deadline: payment never completed",
+          })
+          .eq("id", orphan.id);
+        orphansCancelled += 1;
+      }
+    }
+
     const { data: lot, error: lotFetchError } = await admin
       .from("lots")
       .select(
@@ -573,13 +601,6 @@ async function settleDeadlines(request: Request) {
       continue;
     }
 
-    const { data: unpaidCommitments } = await admin
-      .from("commitments")
-      .select("id")
-      .eq("campaign_id", campaign.id)
-      .is("stripe_payment_intent_id", null)
-      .neq("status", "cancelled");
-
     const { data: tiers } = await admin
       .from("pricing_tiers")
       .select("min_quantity_kg, price_per_kg")
@@ -607,9 +628,8 @@ async function settleDeadlines(request: Request) {
       continue;
     }
 
-    const unpaidCount = unpaidCommitments?.length || 0;
     let transferFailedCount = 0;
-    let failedCount = unpaidCount;
+    let failedCount = 0;
     let succeededCount = 0;
     const debugCommitments: Array<Record<string, unknown>> = [];
     const hubConnectAccountByHubId = new Map<string, string | null>();
@@ -961,11 +981,12 @@ async function settleDeadlines(request: Request) {
       outcome: failedCount > 0 ? "failed" : "settled",
       commitments_succeeded: succeededCount,
       commitments_failed: failedCount,
+      orphans_cancelled: orphansCancelled,
       ...(debug ? { debug_commitments: debugCommitments } : {}),
     });
 
     // AC-6: notify all parties on successful settlement
-    console.log("[settle-deadlines] campaign", campaign.id, "lot", lot.id, "— debug:", debug, "transferFailedCount:", transferFailedCount, "failedCount:", failedCount, "succeededCount:", succeededCount, "unpaidCount:", unpaidCount);
+    console.log("[settle-deadlines] campaign", campaign.id, "lot", lot.id, "— debug:", debug, "transferFailedCount:", transferFailedCount, "failedCount:", failedCount, "succeededCount:", succeededCount, "orphansCancelled:", orphansCancelled);
     if (!debug && transferFailedCount === 0) {
       backgroundTasks.push(sendLotSuccessNotifications(admin, lot.id, campaign.hub_id));
       backgroundTasks.push(createShipmentForLot(lot.id, campaign.hub_id));

--- a/app/api/stripe/webhook/__tests__/webhook-failure-events.test.ts
+++ b/app/api/stripe/webhook/__tests__/webhook-failure-events.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Tests for the Stripe webhook's failure-path handlers.
+ *
+ * The bug these guard against: a buyer abandons checkout → no `completed`
+ * webhook fires → commitment row sits in `pending_setup` with status='pending'
+ * → DB trigger keeps inflating `lots.committed_quantity_kg` → settle-deadlines
+ * cron flips the whole campaign to `failed`.
+ *
+ * Fix: cancel the commitment the moment Stripe tells us payment will not
+ * complete, so the lot trigger drops the quantity immediately.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const updateCalls: Array<{
+  table: string;
+  payload: Record<string, unknown>;
+  filters: Array<{ op: string; col: string; val: unknown }>;
+}> = [];
+
+function makeChain(table: string) {
+  let pendingPayload: Record<string, unknown> | null = null;
+  const filters: Array<{ op: string; col: string; val: unknown }> = [];
+  const chain: Record<string, unknown> = {
+    update: vi.fn((payload: Record<string, unknown>) => {
+      pendingPayload = payload;
+      return chain;
+    }),
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn((col: string, val: unknown) => {
+      filters.push({ op: "eq", col, val });
+      return chain;
+    }),
+    neq: vi.fn((col: string, val: unknown) => {
+      filters.push({ op: "neq", col, val });
+      return chain;
+    }),
+    is: vi.fn((col: string, val: unknown) => {
+      filters.push({ op: "is", col, val });
+      return chain;
+    }),
+    then: (resolve: (v: unknown) => void) => {
+      if (pendingPayload) {
+        updateCalls.push({ table, payload: pendingPayload, filters: [...filters] });
+      }
+      return Promise.resolve({ data: null, error: null }).then(resolve);
+    },
+  };
+  return chain;
+}
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({
+    from: (table: string) => makeChain(table),
+  })),
+}));
+
+vi.mock("@/lib/stripe", () => ({
+  verifyStripeWebhookSignature: vi.fn(() => true),
+  getPaymentIntent: vi.fn().mockResolvedValue({ latest_charge: null }),
+}));
+
+import { POST } from "@/app/api/stripe/webhook/route";
+
+function makeRequest(event: unknown): Request {
+  return new Request("http://localhost/api/stripe/webhook", {
+    method: "POST",
+    headers: { "stripe-signature": "t=123,v1=fake" },
+    body: JSON.stringify(event),
+  });
+}
+
+beforeEach(() => {
+  updateCalls.length = 0;
+  process.env.STRIPE_WEBHOOK_SECRET = "whsec_test";
+});
+
+describe("Stripe webhook — failure events cancel commitments", () => {
+  it("checkout.session.expired cancels by session id and skips already-confirmed rows", async () => {
+    const res = await POST(
+      makeRequest({
+        id: "evt_1",
+        type: "checkout.session.expired",
+        data: { object: { id: "cs_abandoned" } },
+      })
+    );
+
+    expect(res.status).toBe(200);
+    expect(updateCalls).toHaveLength(1);
+    const call = updateCalls[0];
+    expect(call.table).toBe("commitments");
+    expect(call.payload).toMatchObject({
+      status: "cancelled",
+      payment_status: "cancelled",
+    });
+    expect(call.filters).toContainEqual({
+      op: "eq",
+      col: "stripe_checkout_session_id",
+      val: "cs_abandoned",
+    });
+    // Critical: must not flip an already-confirmed commitment back to cancelled
+    // if a stale `expired` event arrives after settlement.
+    expect(call.filters).toContainEqual({
+      op: "neq",
+      col: "status",
+      val: "confirmed",
+    });
+  });
+
+  it("payment_intent.payment_failed cancels by metadata.commitment_id with error message", async () => {
+    const res = await POST(
+      makeRequest({
+        id: "evt_2",
+        type: "payment_intent.payment_failed",
+        data: {
+          object: {
+            id: "pi_failed",
+            last_payment_error: { message: "Your card was declined." },
+            metadata: { commitment_id: "commit-xyz" },
+          },
+        },
+      })
+    );
+
+    expect(res.status).toBe(200);
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0].payload).toMatchObject({
+      status: "cancelled",
+      payment_status: "charge_failed",
+      payment_error: "Your card was declined.",
+    });
+    expect(updateCalls[0].filters).toContainEqual({
+      op: "eq",
+      col: "id",
+      val: "commit-xyz",
+    });
+  });
+
+  it("payment_intent.payment_failed falls back to PI id when metadata is missing", async () => {
+    const res = await POST(
+      makeRequest({
+        id: "evt_3",
+        type: "payment_intent.payment_failed",
+        data: { object: { id: "pi_orphan", last_payment_error: null } },
+      })
+    );
+
+    expect(res.status).toBe(200);
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0].payload).toMatchObject({
+      status: "cancelled",
+      payment_status: "charge_failed",
+      payment_error: "Payment failed",
+    });
+    expect(updateCalls[0].filters).toContainEqual({
+      op: "eq",
+      col: "stripe_payment_intent_id",
+      val: "pi_orphan",
+    });
+  });
+
+  it("charge.failed cancels by metadata.commitment_id", async () => {
+    const res = await POST(
+      makeRequest({
+        id: "evt_4",
+        type: "charge.failed",
+        data: {
+          object: {
+            id: "ch_failed",
+            payment_intent: "pi_x",
+            failure_message: "Insufficient funds.",
+            metadata: { commitment_id: "commit-abc" },
+          },
+        },
+      })
+    );
+
+    expect(res.status).toBe(200);
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0].payload).toMatchObject({
+      status: "cancelled",
+      payment_status: "charge_failed",
+      payment_error: "Insufficient funds.",
+    });
+    expect(updateCalls[0].filters).toContainEqual({
+      op: "eq",
+      col: "id",
+      val: "commit-abc",
+    });
+  });
+
+  it("setup_intent.setup_failed cancels via metadata.commitment_id", async () => {
+    const res = await POST(
+      makeRequest({
+        id: "evt_5",
+        type: "setup_intent.setup_failed",
+        data: {
+          object: {
+            id: "si_failed",
+            last_setup_error: { message: "Authentication failed." },
+            metadata: { commitment_id: "commit-setup" },
+          },
+        },
+      })
+    );
+
+    expect(res.status).toBe(200);
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0].payload).toMatchObject({
+      status: "cancelled",
+      payment_status: "cancelled",
+      payment_error: "Authentication failed.",
+    });
+  });
+
+  it("checkout.session.completed in payment mode without paid status now cancels (regression: previously left status=pending)", async () => {
+    const res = await POST(
+      makeRequest({
+        id: "evt_6",
+        type: "checkout.session.completed",
+        data: {
+          object: {
+            id: "cs_unpaid",
+            mode: "payment",
+            payment_intent: "pi_unpaid",
+            payment_status: "unpaid",
+            customer: "cus_x",
+          },
+        },
+      })
+    );
+
+    expect(res.status).toBe(200);
+    // The fix: this branch now sets status: 'cancelled' so the lot trigger
+    // subtracts the quantity. Previously it only flipped payment_status,
+    // leaving the row counted toward committed_quantity_kg.
+    expect(updateCalls[0].payload).toMatchObject({
+      status: "cancelled",
+      payment_status: "charge_failed",
+    });
+  });
+
+  it("checkout.session.completed in payment mode with paid status charges and does NOT cancel", async () => {
+    const res = await POST(
+      makeRequest({
+        id: "evt_7",
+        type: "checkout.session.completed",
+        data: {
+          object: {
+            id: "cs_paid",
+            mode: "payment",
+            payment_intent: "pi_paid",
+            payment_status: "paid",
+            customer: "cus_x",
+          },
+        },
+      })
+    );
+
+    expect(res.status).toBe(200);
+    expect(updateCalls[0].payload).toMatchObject({
+      payment_status: "charge_succeeded",
+    });
+    // Critically, status must NOT be set to 'cancelled' on the happy path.
+    expect(updateCalls[0].payload.status).toBeUndefined();
+  });
+});

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -60,6 +60,9 @@ export async function POST(request: Request) {
           updatePayload.charged_at = new Date().toISOString();
           updatePayload.payment_error = null;
         } else {
+          // Cancel the commitment so the lot quantity trigger drops it.
+          // Without `status: 'cancelled'` the row keeps inflating committed_quantity_kg.
+          updatePayload.status = "cancelled";
           updatePayload.payment_status = "charge_failed";
           updatePayload.payment_error = "Checkout completed without paid status";
         }
@@ -131,6 +134,114 @@ export async function POST(request: Request) {
             stripe_customer_id: setupIntent.customer || null,
           })
           .eq("id", setupIntent.metadata.commitment_id);
+      }
+    }
+
+    // Cancel commitments the moment Stripe tells us the buyer's payment will not happen.
+    // The lot trigger then subtracts their quantity from committed_quantity_kg, so abandoned
+    // carts can't drag a successful campaign into "failed" at settlement time.
+    if (event.type === "checkout.session.expired") {
+      const session = event.data.object as { id: string };
+      const admin = createAdminClient();
+      await admin
+        .from("commitments")
+        .update({
+          status: "cancelled",
+          payment_status: "cancelled",
+          payment_error: "Checkout session expired before completion",
+        })
+        .eq("stripe_checkout_session_id", session.id)
+        .neq("status", "confirmed");
+    }
+
+    if (event.type === "payment_intent.payment_failed") {
+      const paymentIntent = event.data.object as {
+        id: string;
+        last_payment_error?: { message?: string } | null;
+        metadata?: { commitment_id?: string };
+      };
+      const errorMessage =
+        paymentIntent.last_payment_error?.message || "Payment failed";
+
+      if (paymentIntent.metadata?.commitment_id) {
+        const admin = createAdminClient();
+        await admin
+          .from("commitments")
+          .update({
+            status: "cancelled",
+            payment_status: "charge_failed",
+            payment_error: errorMessage,
+          })
+          .eq("id", paymentIntent.metadata.commitment_id)
+          .neq("status", "confirmed");
+      } else {
+        // Fall back to PI ID lookup if metadata wasn't attached.
+        const admin = createAdminClient();
+        await admin
+          .from("commitments")
+          .update({
+            status: "cancelled",
+            payment_status: "charge_failed",
+            payment_error: errorMessage,
+          })
+          .eq("stripe_payment_intent_id", paymentIntent.id)
+          .neq("status", "confirmed");
+      }
+    }
+
+    if (event.type === "charge.failed") {
+      const charge = event.data.object as {
+        id: string;
+        payment_intent?: string | null;
+        failure_message?: string | null;
+        metadata?: { commitment_id?: string };
+      };
+      const errorMessage = charge.failure_message || "Charge failed";
+      const admin = createAdminClient();
+
+      if (charge.metadata?.commitment_id) {
+        await admin
+          .from("commitments")
+          .update({
+            status: "cancelled",
+            payment_status: "charge_failed",
+            payment_error: errorMessage,
+          })
+          .eq("id", charge.metadata.commitment_id)
+          .neq("status", "confirmed");
+      } else if (charge.payment_intent) {
+        await admin
+          .from("commitments")
+          .update({
+            status: "cancelled",
+            payment_status: "charge_failed",
+            payment_error: errorMessage,
+          })
+          .eq("stripe_payment_intent_id", charge.payment_intent)
+          .neq("status", "confirmed");
+      }
+    }
+
+    if (event.type === "setup_intent.setup_failed") {
+      const setupIntent = event.data.object as {
+        id: string;
+        last_setup_error?: { message?: string } | null;
+        metadata?: { commitment_id?: string };
+      };
+      const errorMessage =
+        setupIntent.last_setup_error?.message || "Payment setup failed";
+
+      if (setupIntent.metadata?.commitment_id) {
+        const admin = createAdminClient();
+        await admin
+          .from("commitments")
+          .update({
+            status: "cancelled",
+            payment_status: "cancelled",
+            payment_error: errorMessage,
+          })
+          .eq("id", setupIntent.metadata.commitment_id)
+          .neq("status", "confirmed");
       }
     }
 

--- a/scripts/data-repair-campaign-79444189.sql
+++ b/scripts/data-repair-campaign-79444189.sql
@@ -1,0 +1,57 @@
+-- Data repair: campaign 79444189-06a4-496e-b7ca-8214c07f1abf was incorrectly
+-- marked 'failed' by the settle-deadlines cron. The campaign actually settled
+-- successfully — emails and a shipment were created — but one orphan commitment
+-- (no stripe_payment_intent_id) inflated `failedCount` and flipped the status.
+--
+-- See: app/api/payments/settle-deadlines/route.ts (the failedCount = unpaidCount fix).
+-- See: app/api/stripe/webhook/route.ts (new failure-event handlers).
+--
+-- Apply ONLY after deploying the code fix. Run in a single transaction.
+
+BEGIN;
+
+-- 1) Cancel the orphan commitment. The on_commitment_change trigger will
+--    decrement lots.committed_quantity_kg from 45.812... to 45.359... (exactly
+--    100 lb). After this step, lot.committed_quantity_kg ≥ min_commitment_kg.
+UPDATE commitments
+SET status = 'cancelled',
+    payment_status = 'cancelled',
+    payment_error = 'Cancelled retroactively: never completed Stripe Checkout. See data-repair-campaign-79444189.sql.',
+    updated_at = NOW()
+WHERE id = '3e891a6d-6507-434a-b685-814a95634c59'
+  AND status != 'confirmed';
+
+-- 2) Verify the orphan removal actually dropped the lot's committed_quantity_kg
+--    (sanity check — fail loudly if the trigger didn't run).
+DO $$
+DECLARE
+  qty numeric;
+BEGIN
+  SELECT committed_quantity_kg INTO qty
+  FROM lots
+  WHERE id = 'a33c0b03-28b5-4dfb-b3dc-3e38983d8ef3';
+  IF qty < 35 THEN
+    RAISE EXCEPTION 'Sanity check failed: lot.committed_quantity_kg=% is below min_commitment_kg after orphan cancel', qty;
+  END IF;
+END $$;
+
+-- 3) Restore the campaign to its true outcome: settled at the original
+--    settlement_processed_at timestamp.
+UPDATE campaigns
+SET status = 'settled',
+    settled_at = '2026-04-26T03:17:27.36+00:00'
+WHERE id = '79444189-06a4-496e-b7ca-8214c07f1abf'
+  AND status = 'failed';
+
+-- 4) Restore the lot's settlement status (status='closed' is correct as-is).
+UPDATE lots
+SET settlement_status = 'settled'
+WHERE id = 'a33c0b03-28b5-4dfb-b3dc-3e38983d8ef3'
+  AND settlement_status = 'failed';
+
+COMMIT;
+
+-- Verification (run AFTER COMMIT to confirm):
+-- SELECT id, status, settled_at FROM campaigns WHERE id = '79444189-06a4-496e-b7ca-8214c07f1abf';
+-- SELECT id, status, settlement_status, committed_quantity_kg FROM lots WHERE id = 'a33c0b03-28b5-4dfb-b3dc-3e38983d8ef3';
+-- SELECT id, status, payment_status FROM commitments WHERE id = '3e891a6d-6507-434a-b685-814a95634c59';


### PR DESCRIPTION
## Summary

- **Bug:** A buyer who started Stripe Checkout but never finished it left a commitment in `pending_setup` with no `stripe_payment_intent_id`. At the campaign deadline, the cron counted these toward `failedCount`, flipping the entire campaign to `failed` — even when every real charge succeeded. Hub owner saw success emails + a shipment; buyer page showed "Min Not Met". The lot trigger also kept the orphan's `quantity_kg` in `committed_quantity_kg`, inflating the apparent campaign volume.
- **Webhook fix:** added handlers for `checkout.session.expired`, `payment_intent.payment_failed`, `charge.failed`, `setup_intent.setup_failed`, and updated the existing "completed without paid status" branch to set `status='cancelled'` so the lot trigger drops the qty in real time.
- **Cron fix:** `settle-deadlines` now sweeps orphan commitments before the minimum-met check, re-fetches the lot for accurate `committed_quantity_kg`, and removes the `failedCount = unpaidCount` initialization that drove the regression.
- **One-time data repair:** `scripts/data-repair-campaign-79444189.sql` un-fails the production campaign affected by the bug. Gated by a sanity check that aborts if the lot trigger doesn't drop the orphan's qty.

## Test plan

- [x] All 118 Vitest tests pass (`npm test`) — includes 9 new tests covering webhook failure paths and the cron orphan-cancellation regression
- [x] Add the four new event types to the Stripe webhook endpoint in the Stripe Dashboard:
  - `checkout.session.expired`
  - `payment_intent.payment_failed`
  - `charge.failed`
  - `setup_intent.setup_failed`
- [x] Manual webhook smoke test: trigger a `checkout.session.expired` event in Stripe and confirm the matching commitment row flips to `status='cancelled'` and `lots.committed_quantity_kg` decreases
- [ ] Confirm an already-`confirmed` commitment is **not** cancelled by a stale `expired` event (the `.neq('status', 'confirmed')` guard)
- [ ] After deploy, apply `scripts/data-repair-campaign-79444189.sql` in Supabase SQL editor
- [ ] Visit `/dashboard/buyer/commitments` for the affected buyer and confirm lot `a33c0b03-…` moves out of "Closed > Min Not Met" into the appropriate "In Motion" stage based on shipment status
- [ ] Run the next daily cron and confirm new campaigns with last-minute abandoned commits settle correctly (campaign `status='settled'`, lot `settlement_status='settled'`, results JSON shows `orphans_cancelled` count)

🤖 Generated with [Claude Code](https://claude.com/claude-code)