### PR TITLE
fix(cron): allow 'expired' status on lots and surface update errors

### DIFF
--- a/app/api/cron/lot-expiry/route.ts
+++ b/app/api/cron/lot-expiry/route.ts
@@ -56,7 +56,7 @@ export async function GET(request: Request) {
     }
 
     // Mark lot as expired
-    await admin
+    const { error: updateErr } = await admin
       .from("lots")
       .update({
         status: "expired",
@@ -64,6 +64,10 @@ export async function GET(request: Request) {
         settlement_processed_at: now,
       })
       .eq("id", lot.id);
+    if (updateErr) {
+      console.error(`lot-expiry: failed to update lot ${lot.id}`, updateErr);
+      continue;
+    }
 
     // Fetch seller profile and send notification
     const { data: seller } = await admin

--- a/supabase/migrations/20240101000022_lots_status_add_expired.sql
+++ b/supabase/migrations/20240101000022_lots_status_add_expired.sql
@@ -1,0 +1,6 @@
+alter table public.lots
+drop constraint if exists lots_status_check;
+
+alter table public.lots
+add constraint lots_status_check
+check (status in ('draft', 'active', 'fully_committed', 'shipped', 'delivered', 'closed', 'expired'));


### PR DESCRIPTION
The lot-expiry route writes status='expired', but lots_status_check never included that value. The route discarded the UPDATE error and still incremented expired_lots, masking the schema drift end-to-end.

- migration 22: add 'expired' to lots_status_check
- route: capture and log the UPDATE error, continue on failure