### PR TITLE
Campaign close — lot recycling

### DIFF
--- a/app/api/campaigns/[id]/__tests__/cancel.test.ts
+++ b/app/api/campaigns/[id]/__tests__/cancel.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Tests for campaign cancellation PATCH route.
+ *
+ * PATCH /api/campaigns/[id] with { status: "cancelled" } — hub owner cancels
+ * their active campaign. After cancel, the lot recycles back to the seller.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// User-scoped supabase client (used for ownership/auth checks + commitment cancel)
+const mockSupabaseFrom = vi.fn();
+const mockSupabaseAuth = {
+  getUser: vi.fn(),
+};
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn().mockResolvedValue({
+    auth: { getUser: () => mockSupabaseAuth.getUser() },
+    from: (...args: unknown[]) => mockSupabaseFrom(...args),
+  }),
+}));
+
+// Admin client (only used for the recycle_lot RPC)
+type RpcCall = { fn: string; args: unknown };
+const adminRpcCalls: RpcCall[] = [];
+const adminFrom = vi.fn();
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({
+    from: (...args: unknown[]) => adminFrom(...args),
+    rpc: vi.fn((fn: string, args: unknown) => {
+      adminRpcCalls.push({ fn, args });
+      return Promise.resolve({ data: null, error: null });
+    }),
+  })),
+}));
+
+import { PATCH } from "@/app/api/campaigns/[id]/route";
+
+function makeChain(response: { data: unknown; error: unknown }) {
+  const chain: Record<string, unknown> = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    neq: vi.fn().mockReturnThis(),
+    in: vi.fn().mockReturnThis(),
+    update: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue(response),
+    maybeSingle: vi.fn().mockResolvedValue(response),
+    then: (
+      resolve: (v: { data: unknown; error: unknown }) => void,
+      reject?: (e: unknown) => void,
+    ) => Promise.resolve(response).then(resolve, reject),
+  };
+  (["select", "eq", "neq", "in", "update"] as const).forEach((m) => {
+    (chain[m] as ReturnType<typeof vi.fn>).mockReturnValue(chain);
+  });
+  return chain;
+}
+
+function makeRequest(body: Record<string, unknown>): Request {
+  return new Request("http://localhost/api/campaigns/camp-1", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const params = Promise.resolve({ id: "camp-1" });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  adminRpcCalls.length = 0;
+  process.env.NEXT_PUBLIC_SUPABASE_URL = "http://localhost:54321";
+  process.env.SUPABASE_SERVICE_ROLE_KEY = "test-service-role-key";
+});
+
+describe("PATCH /api/campaigns/[id]", () => {
+  it("recycles the lot after a hub owner cancels the campaign", async () => {
+    mockSupabaseAuth.getUser.mockResolvedValue({
+      data: { user: { id: "owner-1" } },
+    });
+
+    // Sequence:
+    //  1. fetch campaign — found, active, lot-1, hub-1
+    //  2. fetch hub for ownership — owner matches
+    //  3. update campaign status='cancelled'
+    //  4. update commitments status='cancelled' (the bulk cancel)
+    mockSupabaseFrom
+      .mockReturnValueOnce(
+        makeChain({
+          data: { id: "camp-1", hub_id: "hub-1", lot_id: "lot-1", status: "active" },
+          error: null,
+        })
+      )
+      .mockReturnValueOnce(makeChain({ data: { id: "hub-1" }, error: null }))
+      .mockReturnValueOnce(makeChain({ data: null, error: null }))
+      .mockReturnValueOnce(makeChain({ data: null, error: null }));
+
+    const res = await PATCH(makeRequest({ status: "cancelled" }), { params });
+    expect(res.status).toBe(200);
+
+    // The lot got recycled via the admin RPC
+    expect(adminRpcCalls).toEqual([
+      { fn: "recycle_lot", args: { p_lot_id: "lot-1" } },
+    ]);
+  });
+
+  it("does not recycle when the caller is not the hub owner", async () => {
+    mockSupabaseAuth.getUser.mockResolvedValue({
+      data: { user: { id: "other-user" } },
+    });
+
+    // Sequence:
+    //  1. fetch campaign — found
+    //  2. fetch hub for ownership — null (caller is not the owner)
+    mockSupabaseFrom
+      .mockReturnValueOnce(
+        makeChain({
+          data: { id: "camp-1", hub_id: "hub-1", lot_id: "lot-1", status: "active" },
+          error: null,
+        })
+      )
+      .mockReturnValueOnce(makeChain({ data: null, error: null }));
+
+    const res = await PATCH(makeRequest({ status: "cancelled" }), { params });
+    expect(res.status).toBe(403);
+    expect(adminRpcCalls).toEqual([]);
+  });
+
+  it("does not recycle when the campaign is not active", async () => {
+    mockSupabaseAuth.getUser.mockResolvedValue({
+      data: { user: { id: "owner-1" } },
+    });
+
+    mockSupabaseFrom.mockReturnValueOnce(
+      makeChain({
+        data: { id: "camp-1", hub_id: "hub-1", lot_id: "lot-1", status: "settled" },
+        error: null,
+      })
+    );
+
+    const res = await PATCH(makeRequest({ status: "cancelled" }), { params });
+    expect(res.status).toBe(400);
+    expect(adminRpcCalls).toEqual([]);
+  });
+});

--- a/app/api/campaigns/[id]/__tests__/cancel.test.ts
+++ b/app/api/campaigns/[id]/__tests__/cancel.test.ts
@@ -74,16 +74,15 @@ beforeEach(() => {
 });
 
 describe("PATCH /api/campaigns/[id]", () => {
-  it("recycles the lot after a hub owner cancels the campaign", async () => {
+  it("calls finalize_campaign with outcome=cancelled after a hub owner cancels", async () => {
     mockSupabaseAuth.getUser.mockResolvedValue({
       data: { user: { id: "owner-1" } },
     });
 
-    // Sequence:
+    // Sequence (route now collapses the campaign update + commitments cancel
+    // + lot recycle into a single finalize_campaign RPC):
     //  1. fetch campaign — found, active, lot-1, hub-1
     //  2. fetch hub for ownership — owner matches
-    //  3. update campaign status='cancelled'
-    //  4. update commitments status='cancelled' (the bulk cancel)
     mockSupabaseFrom
       .mockReturnValueOnce(
         makeChain({
@@ -91,16 +90,16 @@ describe("PATCH /api/campaigns/[id]", () => {
           error: null,
         })
       )
-      .mockReturnValueOnce(makeChain({ data: { id: "hub-1" }, error: null }))
-      .mockReturnValueOnce(makeChain({ data: null, error: null }))
-      .mockReturnValueOnce(makeChain({ data: null, error: null }));
+      .mockReturnValueOnce(makeChain({ data: { id: "hub-1" }, error: null }));
 
     const res = await PATCH(makeRequest({ status: "cancelled" }), { params });
     expect(res.status).toBe(200);
 
-    // The lot got recycled via the admin RPC
     expect(adminRpcCalls).toEqual([
-      { fn: "recycle_lot", args: { p_lot_id: "lot-1" } },
+      {
+        fn: "finalize_campaign",
+        args: { p_campaign_id: "camp-1", p_outcome: "cancelled" },
+      },
     ]);
   });
 

--- a/app/api/campaigns/[id]/route.ts
+++ b/app/api/campaigns/[id]/route.ts
@@ -1,4 +1,6 @@
 import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { recycleLot } from "@/lib/lots/recycle-lot";
 import { NextResponse } from "next/server";
 
 export async function GET(
@@ -54,7 +56,7 @@ export async function PATCH(
   // Fetch campaign and verify it exists and is active
   const { data: campaign } = await supabase
     .from("campaigns")
-    .select("id, hub_id, status")
+    .select("id, hub_id, lot_id, status")
     .eq("id", id)
     .single();
 
@@ -109,6 +111,21 @@ export async function PATCH(
     })
     .eq("campaign_id", id)
     .neq("status", "cancelled");
+
+  // Recycle the lot back to the seller for review. Uses the admin client
+  // because recycle_lot is granted only to service_role.
+  const admin = createAdminClient();
+  const recycleResult = await recycleLot(admin, campaign.lot_id);
+  if (!recycleResult.ok) {
+    console.error(
+      `campaigns[id]: failed to recycle lot ${campaign.lot_id} after cancel`,
+      recycleResult.error
+    );
+    return NextResponse.json(
+      { error: "Campaign was cancelled but lot recycle failed; please contact support." },
+      { status: 500 }
+    );
+  }
 
   return NextResponse.json({ ok: true });
 }

--- a/app/api/campaigns/[id]/route.ts
+++ b/app/api/campaigns/[id]/route.ts
@@ -1,6 +1,6 @@
 import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
-import { recycleLot } from "@/lib/lots/recycle-lot";
+import { finalizeCampaign } from "@/lib/lots/finalize-campaign";
 import { NextResponse } from "next/server";
 
 export async function GET(
@@ -89,40 +89,19 @@ export async function PATCH(
     );
   }
 
-  // Update campaign status to cancelled
-  const { error: updateError } = await supabase
-    .from("campaigns")
-    .update({ status: "cancelled" })
-    .eq("id", id);
-
-  if (updateError) {
-    return NextResponse.json(
-      { error: updateError.message },
-      { status: 500 }
-    );
-  }
-
-  // Cancel all pending commitments for this campaign
-  await supabase
-    .from("commitments")
-    .update({
-      status: "cancelled",
-      payment_error: "Campaign was cancelled by hub owner",
-    })
-    .eq("campaign_id", id)
-    .neq("status", "cancelled");
-
-  // Recycle the lot back to the seller for review. Uses the admin client
-  // because recycle_lot is granted only to service_role.
+  // Atomically: cancel commitments, mark campaign cancelled, recycle the lot.
+  // The Postgres function does all three in one transaction; on failure
+  // nothing is committed and the next request can retry. Uses the admin
+  // client because finalize_campaign is granted only to service_role.
   const admin = createAdminClient();
-  const recycleResult = await recycleLot(admin, campaign.lot_id);
-  if (!recycleResult.ok) {
+  const finalizeResult = await finalizeCampaign(admin, id, "cancelled");
+  if (!finalizeResult.ok) {
     console.error(
-      `campaigns[id]: failed to recycle lot ${campaign.lot_id} after cancel`,
-      recycleResult.error
+      `campaigns[id]: finalize_campaign failed for cancel of ${id}`,
+      finalizeResult.error
     );
     return NextResponse.json(
-      { error: "Campaign was cancelled but lot recycle failed; please contact support." },
+      { error: "Failed to cancel the campaign; please try again." },
       { status: 500 }
     );
   }

--- a/app/api/cron/__tests__/lot-expiry.test.ts
+++ b/app/api/cron/__tests__/lot-expiry.test.ts
@@ -171,11 +171,14 @@ describe("GET /api/cron/lot-expiry", () => {
     });
 
     const res = await GET(makeRequest({ authorization: `Bearer ${CRON_SECRET}` }));
-    expect(res.status).toBe(200);
+    // 207 because at least one lot's recycle failed
+    expect(res.status).toBe(207);
 
     const body = await res.json();
     expect(body.expired_lots).toBe(0);
     expect(body.checked_lots).toBe(1);
+    expect(body.recycle_failures).toHaveLength(1);
+    expect(body.recycle_failures[0]).toMatchObject({ lot_id: "lot-fail" });
 
     expect(sendLotExpiredEmail).not.toHaveBeenCalled();
   });

--- a/app/api/cron/__tests__/lot-expiry.test.ts
+++ b/app/api/cron/__tests__/lot-expiry.test.ts
@@ -11,10 +11,12 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 // ---------------------------------------------------------------------------
 
 const mockFrom = vi.fn();
+const mockRpc = vi.fn();
 
 vi.mock("@/lib/supabase/admin", () => ({
   createAdminClient: vi.fn(() => ({
     from: (...args: unknown[]) => mockFrom(...args),
+    rpc: (...args: unknown[]) => mockRpc(...args),
   })),
 }));
 
@@ -104,7 +106,7 @@ describe("GET /api/cron/lot-expiry", () => {
     expect(res.status).toBe(200);
   });
 
-  it("expires lots past expiry_date with no active/settled campaigns", async () => {
+  it("recycles lots past expiry_date with no active/settled campaigns", async () => {
     const expiredLot = {
       id: "lot-1",
       title: "Ethiopian Yirgacheffe",
@@ -116,20 +118,16 @@ describe("GET /api/cron/lot-expiry", () => {
       contact_name: "Jane Seller",
     };
 
-    // First call: lots query
     const lotsChain = makeChain({ data: [expiredLot], error: null });
-    // Second call: campaigns query (no active/settled campaigns)
     const campaignsChain = makeChain({ data: [], error: null });
-    // Third call: lots update
-    const updateChain = makeChain({ data: null, error: null });
-    // Fourth call: profiles query
     const profilesChain = makeChain({ data: sellerProfile, error: null });
 
     mockFrom
       .mockReturnValueOnce(lotsChain)       // lots select
       .mockReturnValueOnce(campaignsChain)  // campaigns select
-      .mockReturnValueOnce(updateChain)     // lots update
       .mockReturnValueOnce(profilesChain);  // profiles select
+
+    mockRpc.mockResolvedValue({ data: null, error: null });
 
     const res = await GET(makeRequest({ authorization: `Bearer ${CRON_SECRET}` }));
     expect(res.status).toBe(200);
@@ -138,7 +136,10 @@ describe("GET /api/cron/lot-expiry", () => {
     expect(body.expired_lots).toBe(1);
     expect(body.checked_lots).toBe(1);
 
-    // Verify lot was updated
+    // Verify the recycle RPC was invoked with the right lot id
+    expect(mockRpc).toHaveBeenCalledWith("recycle_lot", { p_lot_id: "lot-1" });
+
+    // Verify lot lookups happened
     expect(mockFrom).toHaveBeenCalledWith("lots");
     expect(mockFrom).toHaveBeenCalledWith("campaigns");
     expect(mockFrom).toHaveBeenCalledWith("profiles");
@@ -148,6 +149,35 @@ describe("GET /api/cron/lot-expiry", () => {
       seller: { email: "seller@example.com", contact_name: "Jane Seller" },
       lot: { id: "lot-1", title: "Ethiopian Yirgacheffe" },
     });
+  });
+
+  it("skips email and logs when recycle RPC fails", async () => {
+    const expiredLot = {
+      id: "lot-fail",
+      title: "Failing Lot",
+      seller_id: "seller-1",
+    };
+
+    const lotsChain = makeChain({ data: [expiredLot], error: null });
+    const campaignsChain = makeChain({ data: [], error: null });
+
+    mockFrom
+      .mockReturnValueOnce(lotsChain)
+      .mockReturnValueOnce(campaignsChain);
+
+    mockRpc.mockResolvedValue({
+      data: null,
+      error: { message: "rpc unavailable" },
+    });
+
+    const res = await GET(makeRequest({ authorization: `Bearer ${CRON_SECRET}` }));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.expired_lots).toBe(0);
+    expect(body.checked_lots).toBe(1);
+
+    expect(sendLotExpiredEmail).not.toHaveBeenCalled();
   });
 
   it("skips lots that have an active campaign", async () => {

--- a/app/api/cron/lot-expiry/route.ts
+++ b/app/api/cron/lot-expiry/route.ts
@@ -14,7 +14,9 @@ function getBearerToken(header: string | null) {
  * Lot expiry cron — runs daily at 01:00 UTC (after settlement at 00:00 UTC).
  *
  * Finds lots whose expiry_date has passed and that have no active or settled
- * campaign. Marks them as expired and notifies the seller.
+ * campaign. Recycles them (clears hub_lots, sets status='awaiting_relist',
+ * resets committed_quantity_kg, nulls featured_lot_id) and notifies the
+ * seller so they can adjust the lot and decide whether to relist.
  */
 export async function GET(request: Request) {
   const cronSecret = process.env.CRON_SECRET;

--- a/app/api/cron/lot-expiry/route.ts
+++ b/app/api/cron/lot-expiry/route.ts
@@ -45,6 +45,7 @@ export async function GET(request: Request) {
   }
 
   let expiredCount = 0;
+  const recycleFailures: Array<{ lot_id: string; error: string }> = [];
 
   for (const lot of lots || []) {
     // Check if there's an active or settled campaign for this lot — if so, skip
@@ -63,6 +64,7 @@ export async function GET(request: Request) {
     const recycleResult = await recycleLot(admin, lot.id);
     if (!recycleResult.ok) {
       console.error(`lot-expiry: failed to recycle lot ${lot.id}`, recycleResult.error);
+      recycleFailures.push({ lot_id: lot.id, error: recycleResult.error });
       continue;
     }
 
@@ -84,7 +86,14 @@ export async function GET(request: Request) {
   }
 
   return NextResponse.json(
-    { expired_lots: expiredCount, checked_lots: (lots || []).length },
-    { status: 200 }
+    {
+      expired_lots: expiredCount,
+      checked_lots: (lots || []).length,
+      recycle_failures: recycleFailures,
+    },
+    // 207 (Multi-Status) when some lots failed to recycle. Cron retry logic
+    // can use the non-2xx status to surface the failure; the success metrics
+    // remain in the body so partial progress is still visible.
+    { status: recycleFailures.length > 0 ? 207 : 200 }
   );
 }

--- a/app/api/cron/lot-expiry/route.ts
+++ b/app/api/cron/lot-expiry/route.ts
@@ -1,5 +1,6 @@
 import { createAdminClient } from "@/lib/supabase/admin";
 import { sendLotExpiredEmail } from "@/lib/email";
+import { recycleLot } from "@/lib/lots/recycle-lot";
 import { NextResponse } from "next/server";
 
 function getBearerToken(header: string | null) {
@@ -55,17 +56,11 @@ export async function GET(request: Request) {
       continue;
     }
 
-    // Mark lot as expired
-    const { error: updateErr } = await admin
-      .from("lots")
-      .update({
-        status: "expired",
-        settlement_status: "minimum_not_met",
-        settlement_processed_at: now,
-      })
-      .eq("id", lot.id);
-    if (updateErr) {
-      console.error(`lot-expiry: failed to update lot ${lot.id}`, updateErr);
+    // Recycle the lot: clear hub_lots, set status='awaiting_relist',
+    // committed_quantity_kg=0, and null any featured-lot references.
+    const recycleResult = await recycleLot(admin, lot.id);
+    if (!recycleResult.ok) {
+      console.error(`lot-expiry: failed to recycle lot ${lot.id}`, recycleResult.error);
       continue;
     }
 

--- a/app/api/lots/[id]/__tests__/patch.test.ts
+++ b/app/api/lots/[id]/__tests__/patch.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Tests for the PATCH /api/lots/[id] guard relaxation.
+ *
+ * Old behavior: any commitment row on the lot (regardless of campaign state)
+ * blocked the PATCH with 409. After this change, only an *active* campaign
+ * blocks edits — historical commitments from closed campaigns are fine.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockSupabaseFrom = vi.fn();
+const mockSupabaseAuth = {
+  getUser: vi.fn(),
+};
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn().mockResolvedValue({
+    auth: { getUser: () => mockSupabaseAuth.getUser() },
+    from: (...args: unknown[]) => mockSupabaseFrom(...args),
+  }),
+}));
+
+import { PATCH } from "@/app/api/lots/[id]/route";
+
+function makeChain(response: { data: unknown; error: unknown }, opts?: { count?: number }) {
+  const chain: Record<string, unknown> = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    in: vi.fn().mockReturnThis(),
+    update: vi.fn().mockReturnThis(),
+    insert: vi.fn().mockReturnThis(),
+    delete: vi.fn().mockReturnThis(),
+    not: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue(response),
+    maybeSingle: vi.fn().mockResolvedValue(response),
+    then: (
+      resolve: (v: { data: unknown; error: unknown; count?: number }) => void,
+      reject?: (e: unknown) => void,
+    ) => Promise.resolve({ ...response, count: opts?.count }).then(resolve, reject),
+  };
+  (["select", "eq", "in", "update", "insert", "delete", "not", "order"] as const).forEach(
+    (m) => {
+      (chain[m] as ReturnType<typeof vi.fn>).mockReturnValue(chain);
+    },
+  );
+  return chain;
+}
+
+function makeRequest(body: Record<string, unknown>): Request {
+  return new Request("http://localhost/api/lots/lot-1", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const params = Promise.resolve({ id: "lot-1" });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockSupabaseAuth.getUser.mockResolvedValue({ data: { user: { id: "seller-1" } } });
+});
+
+describe("PATCH /api/lots/[id] — campaign-status guard", () => {
+  it("allows status PATCH when no active campaign exists, even with historical commitments", async () => {
+    // Sequence:
+    //  1. ownership check
+    //  2. active-campaign lookup → none
+    //  3. update lots (status-only branch)
+    mockSupabaseFrom
+      .mockReturnValueOnce(
+        makeChain({ data: { id: "lot-1", seller_id: "seller-1" }, error: null })
+      )
+      .mockReturnValueOnce(makeChain({ data: null, error: null })) // no active campaign
+      .mockReturnValueOnce(
+        makeChain({
+          data: { id: "lot-1", status: "active" },
+          error: null,
+        })
+      );
+
+    const res = await PATCH(makeRequest({ status: "active" }), { params });
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects status PATCH with 409 when an active campaign exists", async () => {
+    mockSupabaseFrom
+      .mockReturnValueOnce(
+        makeChain({ data: { id: "lot-1", seller_id: "seller-1" }, error: null })
+      )
+      .mockReturnValueOnce(
+        makeChain({
+          data: { id: "camp-1" },
+          error: null,
+        })
+      ); // active campaign found
+
+    const res = await PATCH(makeRequest({ status: "draft" }), { params });
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toMatch(/active campaign/i);
+  });
+
+  it("rejects an attempt to PATCH status='awaiting_relist' (system-set only)", async () => {
+    mockSupabaseFrom
+      .mockReturnValueOnce(
+        makeChain({ data: { id: "lot-1", seller_id: "seller-1" }, error: null })
+      )
+      .mockReturnValueOnce(makeChain({ data: null, error: null })); // no active campaign
+
+    const res = await PATCH(makeRequest({ status: "awaiting_relist" }), { params });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/active or draft/i);
+  });
+});

--- a/app/api/lots/[id]/__tests__/patch.test.ts
+++ b/app/api/lots/[id]/__tests__/patch.test.ts
@@ -62,15 +62,14 @@ beforeEach(() => {
   mockSupabaseAuth.getUser.mockResolvedValue({ data: { user: { id: "seller-1" } } });
 });
 
-describe("PATCH /api/lots/[id] — campaign-status guard", () => {
-  it("allows status PATCH when no active campaign exists, even with historical commitments", async () => {
-    // Sequence:
-    //  1. ownership check
-    //  2. active-campaign lookup → none
-    //  3. update lots (status-only branch)
+describe("PATCH /api/lots/[id] — guards", () => {
+  it("allows status PATCH from awaiting_relist with historical commitments", async () => {
     mockSupabaseFrom
       .mockReturnValueOnce(
-        makeChain({ data: { id: "lot-1", seller_id: "seller-1" }, error: null })
+        makeChain({
+          data: { id: "lot-1", seller_id: "seller-1", status: "awaiting_relist" },
+          error: null,
+        })
       )
       .mockReturnValueOnce(makeChain({ data: null, error: null })) // no active campaign
       .mockReturnValueOnce(
@@ -87,7 +86,10 @@ describe("PATCH /api/lots/[id] — campaign-status guard", () => {
   it("rejects status PATCH with 409 when an active campaign exists", async () => {
     mockSupabaseFrom
       .mockReturnValueOnce(
-        makeChain({ data: { id: "lot-1", seller_id: "seller-1" }, error: null })
+        makeChain({
+          data: { id: "lot-1", seller_id: "seller-1", status: "active" },
+          error: null,
+        })
       )
       .mockReturnValueOnce(
         makeChain({
@@ -105,7 +107,10 @@ describe("PATCH /api/lots/[id] — campaign-status guard", () => {
   it("rejects an attempt to PATCH status='awaiting_relist' (system-set only)", async () => {
     mockSupabaseFrom
       .mockReturnValueOnce(
-        makeChain({ data: { id: "lot-1", seller_id: "seller-1" }, error: null })
+        makeChain({
+          data: { id: "lot-1", seller_id: "seller-1", status: "awaiting_relist" },
+          error: null,
+        })
       )
       .mockReturnValueOnce(makeChain({ data: null, error: null })); // no active campaign
 
@@ -113,5 +118,25 @@ describe("PATCH /api/lots/[id] — campaign-status guard", () => {
     expect(res.status).toBe(400);
     const body = await res.json();
     expect(body.error).toMatch(/active or draft/i);
+  });
+
+  it.each([
+    ["fully_committed"],
+    ["shipped"],
+    ["delivered"],
+    ["closed"],
+    ["expired"],
+  ])("rejects edits when lot is in %s state, even without an active campaign", async (status) => {
+    mockSupabaseFrom.mockReturnValueOnce(
+      makeChain({
+        data: { id: "lot-1", seller_id: "seller-1", status },
+        error: null,
+      })
+    );
+
+    const res = await PATCH(makeRequest({ status: "draft" }), { params });
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toMatch(new RegExp(status));
   });
 });

--- a/app/api/lots/[id]/route.ts
+++ b/app/api/lots/[id]/route.ts
@@ -63,10 +63,10 @@ export async function PATCH(
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  // Verify ownership
+  // Verify ownership and read status — only certain statuses are editable.
   const { data: lot } = await supabase
     .from("lots")
-    .select("id, seller_id")
+    .select("id, seller_id, status")
     .eq("id", id)
     .eq("seller_id", user.id)
     .single();
@@ -75,7 +75,18 @@ export async function PATCH(
     return NextResponse.json({ error: "Lot not found or not yours" }, { status: 404 });
   }
 
-  // Block edits only while an active campaign exists. Historical commitments
+  // Status allowlist: a lot is only editable in pre-sale states. Once it
+  // ships, is delivered, or hits a closed/expired terminal state, sellers
+  // can't retroactively change the terms buyers committed against.
+  const editableStatuses = ["draft", "active", "awaiting_relist"];
+  if (!editableStatuses.includes(lot.status)) {
+    return NextResponse.json(
+      { error: `Cannot edit a lot in ${lot.status} state` },
+      { status: 409 }
+    );
+  }
+
+  // Block edits while an active campaign is running. Historical commitments
   // from closed campaigns no longer lock the lot — sellers need to adjust
   // their lot during the awaiting_relist review window.
   const { data: activeCampaign } = await supabase

--- a/app/api/lots/[id]/route.ts
+++ b/app/api/lots/[id]/route.ts
@@ -33,18 +33,19 @@ export async function GET(
     .eq("lot_id", id)
     .order("min_quantity_kg", { ascending: true });
 
-  // Check if any commitments exist
-  const { count } = await supabase
-    .from("commitments")
-    .select("id", { count: "exact", head: true })
+  // The edit-lock UI mirrors the PATCH guard: a lot is editable unless a
+  // campaign is currently active. Historical commitments don't lock it.
+  const { data: activeCampaign } = await supabase
+    .from("campaigns")
+    .select("id")
     .eq("lot_id", id)
-    .not("stripe_payment_intent_id", "is", null);
+    .eq("status", "active")
+    .maybeSingle();
 
   return NextResponse.json({
     lot,
     pricing_tiers: tiers || [],
-    has_commitments: (count || 0) > 0,
-    commitment_count: count || 0,
+    has_active_campaign: Boolean(activeCampaign),
   });
 }
 

--- a/app/api/lots/[id]/route.ts
+++ b/app/api/lots/[id]/route.ts
@@ -74,16 +74,19 @@ export async function PATCH(
     return NextResponse.json({ error: "Lot not found or not yours" }, { status: 404 });
   }
 
-  // Check for existing commitments
-  const { count } = await supabase
-    .from("commitments")
-    .select("id", { count: "exact", head: true })
+  // Block edits only while an active campaign exists. Historical commitments
+  // from closed campaigns no longer lock the lot — sellers need to adjust
+  // their lot during the awaiting_relist review window.
+  const { data: activeCampaign } = await supabase
+    .from("campaigns")
+    .select("id")
     .eq("lot_id", id)
-    .not("stripe_payment_intent_id", "is", null);
+    .eq("status", "active")
+    .maybeSingle();
 
-  if ((count || 0) > 0) {
+  if (activeCampaign) {
     return NextResponse.json(
-      { error: "Cannot edit a lot with existing commitments" },
+      { error: "Cannot edit a lot with an active campaign" },
       { status: 409 }
     );
   }

--- a/app/api/payments/settle-deadlines/__tests__/orphan-cancellation.test.ts
+++ b/app/api/payments/settle-deadlines/__tests__/orphan-cancellation.test.ts
@@ -187,10 +187,9 @@ describe("settle-deadlines — orphan commitment handling", () => {
     enqueue("pricing_tiers", { data: [], error: null });
     // 6) chargeable commitments query — empty (everything was already confirmed before this run)
     enqueue("commitments", { data: [], error: null });
-    // 7) campaign update — should be settled, NOT failed
-    enqueue("campaigns", { data: null, error: null });
-    // 8) lot is now recycled via the recycle_lot RPC (no from('lots').update call)
-    // 9) success notifications: lot fetch
+    // 7) campaign + lot transition is now atomic via finalize_campaign RPC
+    //    (no from('campaigns').update or from('lots').update from this route)
+    // 8) success notifications: lot fetch
     enqueue("lots", {
       data: { id: "lot-1", title: "Test Lot", seller_id: "seller-1", committed_quantity_kg: 100 },
       error: null,
@@ -228,15 +227,14 @@ describe("settle-deadlines — orphan commitment handling", () => {
       payment_status: "cancelled",
     });
 
-    // Campaign was marked settled — the regression we're guarding against
-    // (it used to be marked 'failed' because the orphan inflated failedCount).
-    const campaignUpdate = updateCalls.find((c) => c.table === "campaigns");
-    expect(campaignUpdate?.payload).toMatchObject({ status: "settled" });
-
-    // Lot was recycled via the recycle_lot RPC (replaces the bespoke
-    // closed/settled update that used to live here).
-    const recycleCall = rpcCalls.find((c) => c.fn === "recycle_lot");
-    expect(recycleCall?.args).toEqual({ p_lot_id: "lot-1" });
+    // Campaign + lot transition collapsed into the finalize_campaign RPC.
+    // The regression we're guarding against (campaign incorrectly marked
+    // 'failed' due to inflated failedCount) is now caught by the rpc args.
+    const finalizeCall = rpcCalls.find((c) => c.fn === "finalize_campaign");
+    expect(finalizeCall?.args).toEqual({
+      p_campaign_id: "camp-1",
+      p_outcome: "settled",
+    });
   });
 
   it("with NO orphans, behavior is unchanged (campaign settles cleanly)", async () => {
@@ -276,8 +274,7 @@ describe("settle-deadlines — orphan commitment handling", () => {
     enqueue("profiles", { data: { stripe_connect_account_id: "acct_seller" }, error: null });
     enqueue("pricing_tiers", { data: [], error: null });
     enqueue("commitments", { data: [], error: null });
-    enqueue("campaigns", { data: null, error: null });
-    // bespoke lot update replaced by recycle_lot RPC (see route.ts)
+    // campaign + lot transition is now atomic via finalize_campaign RPC
     enqueue("lots", {
       data: { id: "lot-2", title: "T", seller_id: "seller-2", committed_quantity_kg: 75 },
       error: null,
@@ -337,19 +334,18 @@ describe("settle-deadlines — orphan commitment handling", () => {
     });
     // 3) lotCommitments query for refund/cancel
     enqueue("commitments", { data: [], error: null });
-    // 4) campaign update to failed
-    enqueue("campaigns", { data: null, error: null });
-    // (lot is now recycled via RPC, no more from('lots').update calls)
+    // (campaign + lot transition is now atomic via finalize_campaign RPC)
 
     const res = await POST(makeReq());
     expect(res.status).toBe(200);
 
-    expect(rpcCalls.find((c) => c.fn === "recycle_lot")?.args).toEqual({
-      p_lot_id: "lot-3",
+    expect(rpcCalls.find((c) => c.fn === "finalize_campaign")?.args).toEqual({
+      p_campaign_id: "camp-3",
+      p_outcome: "failed",
     });
 
-    // No bespoke lot update should have been queued
-    const lotUpdate = updateCalls.find((c) => c.table === "lots");
-    expect(lotUpdate).toBeUndefined();
+    // No bespoke lot or campaign update should have been queued
+    expect(updateCalls.find((c) => c.table === "lots")).toBeUndefined();
+    expect(updateCalls.find((c) => c.table === "campaigns")).toBeUndefined();
   });
 });

--- a/app/api/payments/settle-deadlines/__tests__/orphan-cancellation.test.ts
+++ b/app/api/payments/settle-deadlines/__tests__/orphan-cancellation.test.ts
@@ -67,12 +67,19 @@ function enqueue(table: string, response: { data: unknown; error: unknown }) {
   });
 }
 
+type RpcCall = { fn: string; args: unknown };
+const rpcCalls: RpcCall[] = [];
+
 vi.mock("@/lib/supabase/admin", () => ({
   createAdminClient: vi.fn(() => ({
     from: vi.fn((table: string) => {
       const next = fromQueue.shift();
       if (!next) throw new Error(`Unexpected from(${table}) — queue empty`);
       return next();
+    }),
+    rpc: vi.fn((fn: string, args: unknown) => {
+      rpcCalls.push({ fn, args });
+      return Promise.resolve({ data: null, error: null });
     }),
   })),
 }));
@@ -116,6 +123,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   updateCalls.length = 0;
   fromQueue.length = 0;
+  rpcCalls.length = 0;
   process.env.CRON_SECRET = CRON_SECRET;
   process.env.SUPABASE_SERVICE_ROLE_KEY = "test";
   process.env.NEXT_PUBLIC_SUPABASE_URL = "http://localhost:54321";
@@ -181,8 +189,7 @@ describe("settle-deadlines — orphan commitment handling", () => {
     enqueue("commitments", { data: [], error: null });
     // 7) campaign update — should be settled, NOT failed
     enqueue("campaigns", { data: null, error: null });
-    // 8) lot update — should be settled, NOT failed
-    enqueue("lots", { data: null, error: null });
+    // 8) lot is now recycled via the recycle_lot RPC (no from('lots').update call)
     // 9) success notifications: lot fetch
     enqueue("lots", {
       data: { id: "lot-1", title: "Test Lot", seller_id: "seller-1", committed_quantity_kg: 100 },
@@ -226,12 +233,10 @@ describe("settle-deadlines — orphan commitment handling", () => {
     const campaignUpdate = updateCalls.find((c) => c.table === "campaigns");
     expect(campaignUpdate?.payload).toMatchObject({ status: "settled" });
 
-    // Lot was marked settled, not failed.
-    const lotUpdate = updateCalls.find((c) => c.table === "lots");
-    expect(lotUpdate?.payload).toMatchObject({
-      status: "closed",
-      settlement_status: "settled",
-    });
+    // Lot was recycled via the recycle_lot RPC (replaces the bespoke
+    // closed/settled update that used to live here).
+    const recycleCall = rpcCalls.find((c) => c.fn === "recycle_lot");
+    expect(recycleCall?.args).toEqual({ p_lot_id: "lot-1" });
   });
 
   it("with NO orphans, behavior is unchanged (campaign settles cleanly)", async () => {
@@ -272,7 +277,7 @@ describe("settle-deadlines — orphan commitment handling", () => {
     enqueue("pricing_tiers", { data: [], error: null });
     enqueue("commitments", { data: [], error: null });
     enqueue("campaigns", { data: null, error: null });
-    enqueue("lots", { data: null, error: null });
+    // bespoke lot update replaced by recycle_lot RPC (see route.ts)
     enqueue("lots", {
       data: { id: "lot-2", title: "T", seller_id: "seller-2", committed_quantity_kg: 75 },
       error: null,
@@ -289,5 +294,62 @@ describe("settle-deadlines — orphan commitment handling", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.results[0]).toMatchObject({ outcome: "settled", orphans_cancelled: 0 });
+  });
+
+  it("recycles the lot when minimum is not met, even if expiry hasn't passed", async () => {
+    // Minimum-not-met path with future expiry. Behavior change: previously
+    // the lot stayed 'active' so other hubs could re-claim. After recycling,
+    // it goes to awaiting_relist and the seller decides what to do next.
+    enqueue("platform_settings", {
+      data: { platform_connect_account_id: "acct_platform" },
+      error: null,
+    });
+    enqueue("profiles", { data: [], error: null });
+    enqueue("campaigns", {
+      data: [
+        {
+          id: "camp-3",
+          lot_id: "lot-3",
+          hub_id: "hub-3",
+          deadline: new Date(Date.now() - 60_000).toISOString(),
+          status: "active",
+        },
+      ],
+      error: null,
+    });
+    // 1) orphan query — none
+    enqueue("commitments", { data: [], error: null });
+    // 2) lot fetch — committed below minimum, expiry still in future
+    enqueue("lots", {
+      data: {
+        id: "lot-3",
+        seller_id: "seller-3",
+        status: "active",
+        currency: "usd",
+        price_per_kg: 10,
+        committed_quantity_kg: 10,
+        min_commitment_kg: 50,
+        commitment_deadline: new Date(Date.now() - 60_000).toISOString(),
+        settlement_status: "pending",
+        expiry_date: new Date(Date.now() + 86_400_000).toISOString(), // future
+      },
+      error: null,
+    });
+    // 3) lotCommitments query for refund/cancel
+    enqueue("commitments", { data: [], error: null });
+    // 4) campaign update to failed
+    enqueue("campaigns", { data: null, error: null });
+    // (lot is now recycled via RPC, no more from('lots').update calls)
+
+    const res = await POST(makeReq());
+    expect(res.status).toBe(200);
+
+    expect(rpcCalls.find((c) => c.fn === "recycle_lot")?.args).toEqual({
+      p_lot_id: "lot-3",
+    });
+
+    // No bespoke lot update should have been queued
+    const lotUpdate = updateCalls.find((c) => c.table === "lots");
+    expect(lotUpdate).toBeUndefined();
   });
 });

--- a/app/api/payments/settle-deadlines/route.ts
+++ b/app/api/payments/settle-deadlines/route.ts
@@ -146,8 +146,16 @@ async function sendLotSuccessNotifications(admin: AdminClient, lotId: string, hu
       hub: hub?.id ?? "none",
     });
 
+    // Sum confirmed commitments rather than reading lot.committed_quantity_kg
+    // — by the time this runs, finalize_campaign has already reset the lot
+    // row to committed_quantity_kg=0 as part of the recycle.
+    const totalQuantityKg = (commitments || []).reduce(
+      (sum, c) => sum + Number(c.quantity_kg || 0),
+      0
+    );
+
     const result = await sendLotClosedEmailsBatch({
-      lot: { id: lot.id, title: lot.title, total_quantity_kg: lot.committed_quantity_kg },
+      lot: { id: lot.id, title: lot.title, total_quantity_kg: totalQuantityKg },
       buyers: buyerPayloads,
       seller,
       hub,

--- a/app/api/payments/settle-deadlines/route.ts
+++ b/app/api/payments/settle-deadlines/route.ts
@@ -4,6 +4,7 @@ import {
   sendLotClosedEmailsBatch,
   sendLotFailedEmail,
 } from "@/lib/email";
+import { recycleLot } from "@/lib/lots/recycle-lot";
 import { createShipmentForLot } from "@/lib/shipments";
 import {
   createRefund,
@@ -489,29 +490,15 @@ async function settleDeadlines(request: Request) {
           .update({ status: "failed" })
           .eq("id", campaign.id);
 
-        // If the lot's expiry_date has also passed, expire the lot.
-        // Otherwise the lot stays active so it can be recycled for other hubs.
-        const lotExpired = lot.expiry_date && new Date(lot.expiry_date) <= new Date(nowIso);
-        if (lotExpired) {
-          await admin
-            .from("lots")
-            .update({
-              status: "closed",
-              committed_quantity_kg: 0,
-              settlement_status: refundFailedCount > 0 ? "failed" : "minimum_not_met",
-              settlement_processed_at: nowIso,
-            })
-            .eq("id", lot.id);
-        } else {
-          // Reset committed_quantity_kg so the lot recycles clean for the next campaign
-          await admin
-            .from("lots")
-            .update({
-              committed_quantity_kg: 0,
-              settlement_status: "pending",
-              settlement_processed_at: null,
-            })
-            .eq("id", lot.id);
+        // Recycle the lot back to the seller for review regardless of the
+        // lot's expiry_date — every failed campaign now ends in awaiting_relist
+        // so the seller decides whether to relist.
+        const recycleResult = await recycleLot(admin, lot.id);
+        if (!recycleResult.ok) {
+          console.error(
+            `settle-deadlines: failed to recycle lot ${lot.id} after failed campaign`,
+            recycleResult.error
+          );
         }
       }
 
@@ -965,14 +952,28 @@ async function settleDeadlines(request: Request) {
         })
         .eq("id", campaign.id);
 
-      await admin
-        .from("lots")
-        .update({
-          status: "closed",
-          settlement_status: failedCount > 0 ? "failed" : "settled",
-          settlement_processed_at: nowIso,
-        })
-        .eq("id", lot.id);
+      if (failedCount > 0) {
+        // Transfer failures leave the lot in a stuck-closed state for
+        // manual investigation; do NOT recycle while transfers are still
+        // incomplete — recycling would clear hub_lots mid-Stripe-flow.
+        await admin
+          .from("lots")
+          .update({
+            status: "closed",
+            settlement_status: "failed",
+            settlement_processed_at: nowIso,
+          })
+          .eq("id", lot.id);
+      } else {
+        // Clean settle: recycle the lot back to the seller for review.
+        const recycleResult = await recycleLot(admin, lot.id);
+        if (!recycleResult.ok) {
+          console.error(
+            `settle-deadlines: failed to recycle lot ${lot.id} after settled campaign`,
+            recycleResult.error
+          );
+        }
+      }
     }
 
     results.push({

--- a/app/api/payments/settle-deadlines/route.ts
+++ b/app/api/payments/settle-deadlines/route.ts
@@ -210,8 +210,14 @@ async function sendLotFailedNotifications(admin: AdminClient, lotId: string, hub
     }
 
     const emailPromises: Promise<unknown>[] = [];
+    // Dedupe by lower-cased email so a seller who is also a hub member or
+    // a buyer (admin testing accounts, shared inboxes) doesn't get the
+    // failure email twice. Seller send wins because it carries the
+    // awaiting_relist CTA the seller actually needs.
+    const sentTo = new Set<string>();
 
     if (seller?.email) {
+      sentTo.add(seller.email.toLowerCase());
       emailPromises.push(
         sendLotFailedEmail({
           recipient: { email: seller.email, contact_name: seller.contact_name },
@@ -223,6 +229,9 @@ async function sendLotFailedNotifications(admin: AdminClient, lotId: string, hub
 
     for (const buyer of buyers || []) {
       if (!buyer.email) continue;
+      const key = buyer.email.toLowerCase();
+      if (sentTo.has(key)) continue;
+      sentTo.add(key);
       emailPromises.push(
         sendLotFailedEmail({
           recipient: { email: buyer.email, contact_name: buyer.contact_name },
@@ -233,6 +242,9 @@ async function sendLotFailedNotifications(admin: AdminClient, lotId: string, hub
 
     for (const owner of hubOwners) {
       if (!owner.email) continue;
+      const key = owner.email.toLowerCase();
+      if (sentTo.has(key)) continue;
+      sentTo.add(key);
       emailPromises.push(
         sendLotFailedEmail({
           recipient: { email: owner.email, contact_name: owner.contact_name },

--- a/app/api/payments/settle-deadlines/route.ts
+++ b/app/api/payments/settle-deadlines/route.ts
@@ -4,7 +4,7 @@ import {
   sendLotClosedEmailsBatch,
   sendLotFailedEmail,
 } from "@/lib/email";
-import { recycleLot } from "@/lib/lots/recycle-lot";
+import { finalizeCampaign } from "@/lib/lots/finalize-campaign";
 import { createShipmentForLot } from "@/lib/shipments";
 import {
   createRefund,
@@ -485,20 +485,15 @@ async function settleDeadlines(request: Request) {
       }
 
       if (!debug) {
-        // Campaign is always marked failed when minimum not met
-        await admin
-          .from("campaigns")
-          .update({ status: "failed" })
-          .eq("id", campaign.id);
-
-        // Recycle the lot back to the seller for review regardless of the
-        // lot's expiry_date — every failed campaign now ends in awaiting_relist
-        // so the seller decides whether to relist.
-        const recycleResult = await recycleLot(admin, lot.id);
-        if (!recycleResult.ok) {
+        // Atomically mark the campaign failed AND recycle the lot. The
+        // per-commitment refund/cancel work above already ran; if finalize
+        // fails the campaign stays 'active' and the next cron tick retries
+        // (refunds and commitment cancels are both idempotent).
+        const finalizeResult = await finalizeCampaign(admin, campaign.id, "failed");
+        if (!finalizeResult.ok) {
           console.error(
-            `settle-deadlines: failed to recycle lot ${lot.id} after failed campaign`,
-            recycleResult.error
+            `settle-deadlines: finalize_campaign failed for failed campaign ${campaign.id}`,
+            finalizeResult.error
           );
         }
       }
@@ -943,20 +938,19 @@ async function settleDeadlines(request: Request) {
     }
 
     if (!debug) {
-      const campaignOutcome = failedCount > 0 ? "failed" : "settled";
-
-      await admin
-        .from("campaigns")
-        .update({
-          status: campaignOutcome === "settled" ? "settled" : "failed",
-          settled_at: campaignOutcome === "settled" ? nowIso : null,
-        })
-        .eq("id", campaign.id);
-
       if (failedCount > 0) {
-        // Transfer failures leave the lot in a stuck-closed state for
-        // manual investigation; do NOT recycle while transfers are still
-        // incomplete — recycling would clear hub_lots mid-Stripe-flow.
+        // Transfer failures leave the lot in a stuck-closed state for manual
+        // investigation. We do NOT call finalize_campaign here — recycling
+        // mid-Stripe-flow would clear hub_lots while transfers are still
+        // incomplete. Mark the campaign failed inline (no retry hazard since
+        // there's nothing left to recycle) and leave the lot 'closed' for
+        // operator triage.
+        await admin
+          .from("campaigns")
+          .update({ status: "failed" })
+          .eq("id", campaign.id)
+          .eq("status", "active");
+
         await admin
           .from("lots")
           .update({
@@ -966,12 +960,15 @@ async function settleDeadlines(request: Request) {
           })
           .eq("id", lot.id);
       } else {
-        // Clean settle: recycle the lot back to the seller for review.
-        const recycleResult = await recycleLot(admin, lot.id);
-        if (!recycleResult.ok) {
+        // Clean settle: atomically mark the campaign settled AND recycle
+        // the lot. If finalize fails, the campaign stays 'active' and the
+        // next cron tick re-attempts (the per-commitment confirmed updates
+        // above are idempotent).
+        const finalizeResult = await finalizeCampaign(admin, campaign.id, "settled");
+        if (!finalizeResult.ok) {
           console.error(
-            `settle-deadlines: failed to recycle lot ${lot.id} after settled campaign`,
-            recycleResult.error
+            `settle-deadlines: finalize_campaign failed for settled campaign ${campaign.id}`,
+            finalizeResult.error
           );
         }
       }

--- a/app/api/payments/settle-deadlines/route.ts
+++ b/app/api/payments/settle-deadlines/route.ts
@@ -342,6 +342,7 @@ async function settleDeadlines(request: Request) {
   }
 
   const results: Array<Record<string, unknown>> = [];
+  const finalizeFailures: Array<{ campaign_id: string; outcome: string; error: string }> = [];
   const backgroundTasks: Promise<unknown>[] = [];
 
   for (const campaign of dueCampaigns || []) {
@@ -503,6 +504,11 @@ async function settleDeadlines(request: Request) {
             `settle-deadlines: finalize_campaign failed for failed campaign ${campaign.id}`,
             finalizeResult.error
           );
+          finalizeFailures.push({
+            campaign_id: campaign.id,
+            outcome: "failed",
+            error: finalizeResult.error,
+          });
         }
       }
 
@@ -989,6 +995,11 @@ async function settleDeadlines(request: Request) {
             `settle-deadlines: finalize_campaign failed for settled campaign ${campaign.id}`,
             finalizeResult.error
           );
+          finalizeFailures.push({
+            campaign_id: campaign.id,
+            outcome: "settled",
+            error: finalizeResult.error,
+          });
         }
       }
     }
@@ -1022,8 +1033,12 @@ async function settleDeadlines(request: Request) {
     {
       processed_campaigns: results.length,
       results,
+      finalize_failures: finalizeFailures,
     },
-    { status: 200 }
+    // 207 (Multi-Status) when any finalize_campaign call failed; the cron
+    // runner can use the non-2xx status to surface partial failure while
+    // the body still reports per-campaign progress.
+    { status: finalizeFailures.length > 0 ? 207 : 200 }
   );
 }
 

--- a/app/api/payments/settle-deadlines/route.ts
+++ b/app/api/payments/settle-deadlines/route.ts
@@ -208,6 +208,7 @@ async function sendLotFailedNotifications(admin: AdminClient, lotId: string, hub
         sendLotFailedEmail({
           recipient: { email: seller.email, contact_name: seller.contact_name },
           lot: { id: lot.id, title: lot.title },
+          isSeller: true,
         }).catch(console.error)
       );
     }

--- a/app/api/payments/settle-deadlines/route.ts
+++ b/app/api/payments/settle-deadlines/route.ts
@@ -376,7 +376,7 @@ async function settleDeadlines(request: Request) {
     const { data: lot, error: lotFetchError } = await admin
       .from("lots")
       .select(
-        "id, seller_id, status, currency, price_per_kg, committed_quantity_kg, min_commitment_kg, commitment_deadline, settlement_status, expiry_date"
+        "id, seller_id, status, currency, price_per_kg, committed_quantity_kg, min_commitment_kg, commitment_deadline"
       )
       .eq("id", campaign.lot_id)
       .single();
@@ -527,11 +527,17 @@ async function settleDeadlines(request: Request) {
       .single();
 
     if (!sellerProfile?.stripe_connect_account_id) {
+      // Seller never finished Stripe Connect onboarding — we can't transfer
+      // funds. Deliberately do NOT recycle here: the lot is in a stuck state
+      // that needs operator + seller intervention before any retry. Mark the
+      // campaign failed and tag the lot with settlement_status='failed' so
+      // the admin payouts dashboard can surface it.
       if (!debug) {
         await admin
           .from("campaigns")
           .update({ status: "failed" })
-          .eq("id", campaign.id);
+          .eq("id", campaign.id)
+          .eq("status", "active");
 
         await admin
           .from("lots")
@@ -561,11 +567,16 @@ async function settleDeadlines(request: Request) {
     }
 
     if (!sellerTransfersEnabled) {
+      // Same as the missing-account branch above: don't recycle a lot whose
+      // settlement is structurally blocked by the seller's Stripe Connect
+      // state. The lot stays 'closed' with settlement_status='failed' for
+      // operator triage; no retry will succeed until onboarding is fixed.
       if (!debug) {
         await admin
           .from("campaigns")
           .update({ status: "failed" })
-          .eq("id", campaign.id);
+          .eq("id", campaign.id)
+          .eq("status", "active");
 
         await admin
           .from("lots")

--- a/app/dashboard/hub/catalog/[id]/page.tsx
+++ b/app/dashboard/hub/catalog/[id]/page.tsx
@@ -65,7 +65,7 @@ export default async function HubLotDetailPage({
     ? (
         await supabase
           .from("campaigns")
-          .select("id")
+          .select("id, deadline")
           .eq("lot_id", id)
           .eq("hub_id", hubId)
           .eq("status", "active")
@@ -113,6 +113,7 @@ export default async function HubLotDetailPage({
       }}
       pricingTiers={(tiers as PricingTier[]) || []}
       commitments={(commitments as unknown as Commitment[]) || []}
+      campaignDeadline={currentCampaign?.deadline ?? null}
       backHref="/dashboard/hub/catalog"
       backLabel="Back to Catalog"
     />

--- a/app/dashboard/hub/catalog/[id]/page.tsx
+++ b/app/dashboard/hub/catalog/[id]/page.tsx
@@ -57,14 +57,32 @@ export default async function HubLotDetailPage({
     .eq("lot_id", id)
     .order("min_quantity_kg", { ascending: true });
 
-  const { data: commitments } = await supabase
-    .from("commitments")
-    .select(
-      "*, buyer:profiles!commitments_buyer_id_fkey(company_name, contact_name)"
-    )
-    .eq("lot_id", id)
-    .not("stripe_payment_intent_id", "is", null)
-    .order("created_at", { ascending: true });
+  // Scope the Backers list to the *current* campaign for this lot+hub.
+  // Historical commitment rows from prior campaigns stay in the DB for the
+  // Stripe paper trail, but they should not show up on a recycled or fresh
+  // lot's detail page.
+  const currentCampaign = hubId
+    ? (
+        await supabase
+          .from("campaigns")
+          .select("id")
+          .eq("lot_id", id)
+          .eq("hub_id", hubId)
+          .eq("status", "active")
+          .maybeSingle()
+      ).data
+    : null;
+
+  const { data: commitments } = currentCampaign
+    ? await supabase
+        .from("commitments")
+        .select(
+          "*, buyer:profiles!commitments_buyer_id_fkey(company_name, contact_name)"
+        )
+        .eq("campaign_id", currentCampaign.id)
+        .not("stripe_payment_intent_id", "is", null)
+        .order("created_at", { ascending: true })
+    : { data: [] };
 
   const existingSampleRequest = hubId
     ? (

--- a/app/dashboard/seller/lots/[id]/edit/page.tsx
+++ b/app/dashboard/seller/lots/[id]/edit/page.tsx
@@ -48,8 +48,7 @@ export default function EditLotPage({
   const [sellerId, setSellerId] = useState("");
   const [headerImageUrl, setHeaderImageUrl] = useState("");
   const [supportingImages, setSupportingImages] = useState<string[]>([]);
-  const [hasCommitments, setHasCommitments] = useState(false);
-  const [commitmentCount, setCommitmentCount] = useState(0);
+  const [hasActiveCampaign, setHasActiveCampaign] = useState(false);
   const [form, setForm] = useState({
     title: "",
     origin_country: "",
@@ -87,8 +86,7 @@ export default function EditLotPage({
       }
       const data = await res.json();
       const lot = data.lot;
-      setHasCommitments(data.has_commitments);
-      setCommitmentCount(data.commitment_count);
+      setHasActiveCampaign(Boolean(data.has_active_campaign));
       const existingImages = (lot.images || []) as string[];
       setHeaderImageUrl(existingImages[0] || "");
       setSupportingImages(existingImages.slice(1));
@@ -250,19 +248,15 @@ export default function EditLotPage({
         Back to Lots
       </Link>
 
-      {hasCommitments && (
+      {hasActiveCampaign && (
         <Card className="mb-6 border-amber-500/50 bg-amber-50 dark:bg-amber-950/20">
           <CardContent className="flex items-start gap-3 pt-6">
             <Lock className="h-5 w-5 text-amber-600 shrink-0 mt-0.5" />
             <div>
               <p className="font-medium text-foreground">Editing Locked</p>
               <p className="text-sm text-muted-foreground mt-1">
-                This lot has{" "}
-                <span className="font-semibold">
-                  {commitmentCount} commitment{commitmentCount !== 1 ? "s" : ""}
-                </span>{" "}
-                from buyers. You cannot modify a lot once buyers have committed to
-                it. This protects the terms buyers agreed to.
+                A hub owner is currently running a campaign on this lot. You can
+                edit it again once the campaign closes.
               </p>
             </div>
           </CardContent>
@@ -273,7 +267,7 @@ export default function EditLotPage({
         <CardHeader>
           <div className="flex items-center gap-3">
             <CardTitle>Edit Lot</CardTitle>
-            {hasCommitments && (
+            {hasActiveCampaign && (
               <Badge variant="secondary" className="gap-1">
                 <Lock className="h-3 w-3" />
                 Locked
@@ -281,15 +275,15 @@ export default function EditLotPage({
             )}
           </div>
           <CardDescription>
-            {hasCommitments
-              ? "This lot cannot be edited because buyers have already committed."
+            {hasActiveCampaign
+              ? "This lot cannot be edited while a campaign is active."
               : "Update your lot details. Changes will remove this lot from hub catalogs so hub owners can review before re-adding."}
           </CardDescription>
         </CardHeader>
         <CardContent>
           <form onSubmit={handleSubmit} className="space-y-6">
-            <fieldset disabled={hasCommitments} className="space-y-6">
-              {!hasCommitments && (
+            <fieldset disabled={hasActiveCampaign} className="space-y-6">
+              {!hasActiveCampaign && (
                 <div className="rounded-lg border border-amber-500/30 bg-amber-50/50 dark:bg-amber-950/10 p-3 flex items-start gap-2">
                   <AlertTriangle className="h-4 w-4 text-amber-600 shrink-0 mt-0.5" />
                   <p className="text-sm text-muted-foreground">
@@ -506,7 +500,7 @@ export default function EditLotPage({
                     variant="outline"
                     size="sm"
                     onClick={addTier}
-                    disabled={hasCommitments}
+                    disabled={hasActiveCampaign}
                   >
                     <Plus className="mr-1 h-4 w-4" />
                     Add Tier
@@ -612,7 +606,7 @@ export default function EditLotPage({
                     setHeaderImageUrl(nextHeader);
                     setSupportingImages(nextSupporting);
                   }}
-                  disabled={hasCommitments || isLoading}
+                  disabled={hasActiveCampaign || isLoading}
                 />
               </div>
 
@@ -642,7 +636,7 @@ export default function EditLotPage({
               </div>
             </fieldset>
 
-            {!hasCommitments && (
+            {!hasActiveCampaign && (
               <div className="flex gap-3">
                 <Button type="submit" disabled={isLoading}>
                   {isLoading ? "Saving..." : "Save Changes"}

--- a/app/dashboard/seller/lots/page.tsx
+++ b/app/dashboard/seller/lots/page.tsx
@@ -130,19 +130,31 @@ export default async function SellerLotsPage() {
 
     let summaryByCampaignId = new Map<string, { committedKg: number; buyerCount: number }>();
     if (terminalCampaignIds.length > 0) {
+      // Exclude cancelled commitments so failed and cancelled campaigns
+      // don't over-count refunded buyers, and dedupe per-campaign by
+      // buyer_id so the buyerCount reflects distinct buyers, not rows.
       const { data: commitmentRows } = await supabase
         .from("commitments")
         .select("campaign_id, buyer_id, quantity_kg")
-        .in("campaign_id", terminalCampaignIds);
+        .in("campaign_id", terminalCampaignIds)
+        .neq("status", "cancelled");
 
+      const buyerSets = new Map<string, Set<string>>();
+      const kgByCampaign = new Map<string, number>();
       for (const row of (commitmentRows as { campaign_id: string; buyer_id: string; quantity_kg: number }[]) || []) {
-        const existing = summaryByCampaignId.get(row.campaign_id) ?? {
-          committedKg: 0,
-          buyerCount: 0,
-        };
-        existing.committedKg += Number(row.quantity_kg) || 0;
-        existing.buyerCount += 1;
-        summaryByCampaignId.set(row.campaign_id, existing);
+        kgByCampaign.set(
+          row.campaign_id,
+          (kgByCampaign.get(row.campaign_id) ?? 0) + (Number(row.quantity_kg) || 0)
+        );
+        const buyers = buyerSets.get(row.campaign_id) ?? new Set<string>();
+        if (row.buyer_id) buyers.add(row.buyer_id);
+        buyerSets.set(row.campaign_id, buyers);
+      }
+      for (const id of terminalCampaignIds) {
+        summaryByCampaignId.set(id, {
+          committedKg: kgByCampaign.get(id) ?? 0,
+          buyerCount: buyerSets.get(id)?.size ?? 0,
+        });
       }
     }
 

--- a/app/dashboard/seller/lots/page.tsx
+++ b/app/dashboard/seller/lots/page.tsx
@@ -84,6 +84,23 @@ export default async function SellerLotsPage() {
   const awaitingRelistLots = allLots.filter((l) => l.status === "awaiting_relist");
   const myLots = allLots.filter((l) => l.status !== "awaiting_relist");
 
+  // Look up which of the seller's lots have an active campaign so we can hide
+  // the active/draft toggle and mirror the API's 409 behavior in the UI.
+  const togglableLotIds = myLots
+    .filter((l) => l.status === "active" || l.status === "draft")
+    .map((l) => l.id);
+  const activeCampaignLotIds = new Set<string>();
+  if (togglableLotIds.length > 0) {
+    const { data: activeCampaigns } = await supabase
+      .from("campaigns")
+      .select("lot_id")
+      .in("lot_id", togglableLotIds)
+      .eq("status", "active");
+    for (const row of (activeCampaigns as { lot_id: string }[]) || []) {
+      activeCampaignLotIds.add(row.lot_id);
+    }
+  }
+
   // Pull all campaigns for the awaiting_relist lots in one round-trip.
   // For each lot we surface the most-recent terminal campaign (if any).
   let reviewCards: ReviewCard[] = [];
@@ -244,7 +261,7 @@ export default async function SellerLotsPage() {
                         <SellerLotStatusToggle
                           lotId={lot.id}
                           currentStatus={lot.status}
-                          hasContributors={Number(lot.committed_quantity_kg || 0) > 0}
+                          hasActiveCampaign={activeCampaignLotIds.has(lot.id)}
                         />
                       )}
                       <Button asChild size="sm" variant="outline" className="hidden sm:flex bg-transparent">

--- a/app/dashboard/seller/lots/page.tsx
+++ b/app/dashboard/seller/lots/page.tsx
@@ -89,33 +89,38 @@ export default async function SellerLotsPage() {
   const awaitingRelistLots = allLots.filter((l) => l.status === "awaiting_relist");
   const myLots = allLots.filter((l) => l.status !== "awaiting_relist");
 
-  // Look up which of the seller's lots have an active campaign so we can hide
-  // the active/draft toggle and mirror the API's 409 behavior in the UI.
   const togglableLotIds = myLots
     .filter((l) => l.status === "active" || l.status === "draft")
     .map((l) => l.id);
+  const reviewLotIds = awaitingRelistLots.map((l) => l.id);
+
+  // Two independent queries (active campaigns for togglable lots vs. all
+  // campaigns for awaiting_relist lots) — fetch in parallel.
+  const [activeCampaignsResult, campaignRowsResult] = await Promise.all([
+    togglableLotIds.length > 0
+      ? supabase
+          .from("campaigns")
+          .select("lot_id")
+          .in("lot_id", togglableLotIds)
+          .eq("status", "active")
+      : Promise.resolve({ data: [] as { lot_id: string }[], error: null }),
+    reviewLotIds.length > 0
+      ? supabase
+          .from("campaigns")
+          .select("id, lot_id, hub_id, status, deadline, settled_at, created_at, hub:hubs(name)")
+          .in("lot_id", reviewLotIds)
+      : Promise.resolve({ data: [], error: null }),
+  ]);
+
   const activeCampaignLotIds = new Set<string>();
-  if (togglableLotIds.length > 0) {
-    const { data: activeCampaigns } = await supabase
-      .from("campaigns")
-      .select("lot_id")
-      .in("lot_id", togglableLotIds)
-      .eq("status", "active");
-    for (const row of (activeCampaigns as { lot_id: string }[]) || []) {
-      activeCampaignLotIds.add(row.lot_id);
-    }
+  for (const row of (activeCampaignsResult.data as { lot_id: string }[]) || []) {
+    activeCampaignLotIds.add(row.lot_id);
   }
 
-  // Pull all campaigns for the awaiting_relist lots in one round-trip.
-  // For each lot we surface the most-recent terminal campaign (if any).
+  // Build review cards from the awaiting_relist lots + their campaign history.
   let reviewCards: ReviewCard[] = [];
   if (awaitingRelistLots.length > 0) {
-    const lotIds = awaitingRelistLots.map((l) => l.id);
-
-    const { data: campaignRows } = await supabase
-      .from("campaigns")
-      .select("id, lot_id, hub_id, status, deadline, settled_at, created_at, hub:hubs(name)")
-      .in("lot_id", lotIds);
+    const campaignRows = campaignRowsResult.data;
 
     // Supabase returns related records as an array even on a 1:1 join.
     type CampaignWithHubRaw = CampaignRow & {
@@ -128,10 +133,15 @@ export default async function SellerLotsPage() {
       byLot.set(row.lot_id, list);
     }
 
-    // Aggregate commitment counts and committed kg for each terminal campaign in one pass.
-    const terminalCampaignIds = Array.from(byLot.values())
-      .map((rows) => pickMostRecentTerminalCampaign(rows)?.id)
-      .filter((id): id is string => Boolean(id));
+    // Pick the most recent terminal campaign per lot once and cache it so
+    // the sort doesn't run twice (once for the id list, once inside the
+    // reviewCards.map below).
+    const terminalByLotId = new Map<string, CampaignWithHubRaw>();
+    for (const [lotId, rows] of byLot) {
+      const terminal = pickMostRecentTerminalCampaign(rows);
+      if (terminal) terminalByLotId.set(lotId, terminal as CampaignWithHubRaw);
+    }
+    const terminalCampaignIds = Array.from(terminalByLotId.values()).map((c) => c.id);
 
     let summaryByCampaignId = new Map<string, { committedKg: number; buyerCount: number }>();
     if (terminalCampaignIds.length > 0) {
@@ -164,10 +174,9 @@ export default async function SellerLotsPage() {
     }
 
     reviewCards = awaitingRelistLots.map((lot) => {
-      const rows = byLot.get(lot.id) ?? [];
-      const terminal = pickMostRecentTerminalCampaign(rows);
+      const terminal = terminalByLotId.get(lot.id) ?? null;
       const summary = terminal ? summaryByCampaignId.get(terminal.id) : undefined;
-      const hubField = terminal ? (terminal as CampaignWithHubRaw).hub : null;
+      const hubField = terminal ? terminal.hub : null;
       const hubName = Array.isArray(hubField)
         ? hubField[0]?.name ?? null
         : hubField?.name ?? null;

--- a/app/dashboard/seller/lots/page.tsx
+++ b/app/dashboard/seller/lots/page.tsx
@@ -10,12 +10,62 @@ import type { Lot } from "@/lib/types";
 import { UnitPriceText, UnitWeightText } from "@/components/unit-value";
 import { SellerLotCsvUploadModal } from "@/components/seller-lot-csv-upload-modal";
 import { SellerLotStatusToggle } from "@/components/seller-lot-status-toggle";
+import {
+  SellerAwaitingRelistCard,
+  type RelistOutcome,
+} from "@/components/seller-awaiting-relist-card";
 
 const statusStyles: Record<string, string> = {
   active: "bg-emerald-50 text-emerald-700 border-emerald-200",
   fully_committed: "bg-blue-50 text-blue-700 border-blue-200",
   draft: "bg-secondary text-secondary-foreground",
+  awaiting_relist: "bg-amber-50 text-amber-700 border-amber-200",
 };
+
+type CampaignRow = {
+  id: string;
+  lot_id: string;
+  hub_id: string;
+  status: string;
+  deadline: string | null;
+  settled_at: string | null;
+  created_at: string;
+};
+
+type ReviewCard = {
+  lotId: string;
+  lotTitle: string;
+  expiryDate: string | null;
+  outcome: RelistOutcome;
+  campaign: {
+    hubName: string | null;
+    deadline: string | null;
+    committedKg: number;
+    buyerCount: number;
+  } | null;
+};
+
+function pickMostRecentTerminalCampaign(
+  rows: CampaignRow[]
+): CampaignRow | null {
+  const terminal = rows.filter((r) =>
+    ["settled", "failed", "cancelled"].includes(r.status)
+  );
+  if (terminal.length === 0) return null;
+  // Sort by settled_at (when present) then created_at, both descending.
+  return terminal.sort((a, b) => {
+    const aTime = new Date(a.settled_at || a.created_at).getTime();
+    const bTime = new Date(b.settled_at || b.created_at).getTime();
+    return bTime - aTime;
+  })[0];
+}
+
+function statusToOutcome(status: string): RelistOutcome {
+  if (status === "settled") return "settled";
+  if (status === "failed") return "failed";
+  if (status === "cancelled") return "cancelled";
+  return "expired";
+}
 
 export default async function SellerLotsPage() {
   const supabase = await createClient();
@@ -30,7 +80,79 @@ export default async function SellerLotsPage() {
     .eq("seller_id", user.id)
     .order("created_at", { ascending: false });
 
-  const myLots = (lots as Lot[]) || [];
+  const allLots = (lots as Lot[]) || [];
+  const awaitingRelistLots = allLots.filter((l) => l.status === "awaiting_relist");
+  const myLots = allLots.filter((l) => l.status !== "awaiting_relist");
+
+  // Pull all campaigns for the awaiting_relist lots in one round-trip.
+  // For each lot we surface the most-recent terminal campaign (if any).
+  let reviewCards: ReviewCard[] = [];
+  if (awaitingRelistLots.length > 0) {
+    const lotIds = awaitingRelistLots.map((l) => l.id);
+
+    const { data: campaignRows } = await supabase
+      .from("campaigns")
+      .select("id, lot_id, hub_id, status, deadline, settled_at, created_at, hub:hubs(name)")
+      .in("lot_id", lotIds);
+
+    // Supabase returns related records as an array even on a 1:1 join.
+    type CampaignWithHubRaw = CampaignRow & {
+      hub: { name: string }[] | { name: string } | null;
+    };
+    const byLot = new Map<string, CampaignWithHubRaw[]>();
+    for (const row of (campaignRows as unknown as CampaignWithHubRaw[]) || []) {
+      const list = byLot.get(row.lot_id) ?? [];
+      list.push(row);
+      byLot.set(row.lot_id, list);
+    }
+
+    // Aggregate commitment counts and committed kg for each terminal campaign in one pass.
+    const terminalCampaignIds = Array.from(byLot.values())
+      .map((rows) => pickMostRecentTerminalCampaign(rows)?.id)
+      .filter((id): id is string => Boolean(id));
+
+    let summaryByCampaignId = new Map<string, { committedKg: number; buyerCount: number }>();
+    if (terminalCampaignIds.length > 0) {
+      const { data: commitmentRows } = await supabase
+        .from("commitments")
+        .select("campaign_id, buyer_id, quantity_kg")
+        .in("campaign_id", terminalCampaignIds);
+
+      for (const row of (commitmentRows as { campaign_id: string; buyer_id: string; quantity_kg: number }[]) || []) {
+        const existing = summaryByCampaignId.get(row.campaign_id) ?? {
+          committedKg: 0,
+          buyerCount: 0,
+        };
+        existing.committedKg += Number(row.quantity_kg) || 0;
+        existing.buyerCount += 1;
+        summaryByCampaignId.set(row.campaign_id, existing);
+      }
+    }
+
+    reviewCards = awaitingRelistLots.map((lot) => {
+      const rows = byLot.get(lot.id) ?? [];
+      const terminal = pickMostRecentTerminalCampaign(rows);
+      const summary = terminal ? summaryByCampaignId.get(terminal.id) : undefined;
+      const hubField = terminal ? (terminal as CampaignWithHubRaw).hub : null;
+      const hubName = Array.isArray(hubField)
+        ? hubField[0]?.name ?? null
+        : hubField?.name ?? null;
+      return {
+        lotId: lot.id,
+        lotTitle: lot.title,
+        expiryDate: lot.expiry_date,
+        outcome: terminal ? statusToOutcome(terminal.status) : "expired",
+        campaign: terminal
+          ? {
+              hubName,
+              deadline: terminal.deadline,
+              committedKg: summary?.committedKg ?? 0,
+              buyerCount: summary?.buyerCount ?? 0,
+            }
+          : null,
+      };
+    });
+  }
 
   return (
     <div>
@@ -50,7 +172,23 @@ export default async function SellerLotsPage() {
         </div>
       </div>
 
-      {myLots.length === 0 ? (
+      {reviewCards.length > 0 && (
+        <section id="needs-review" className="mb-10">
+          <div className="mb-3 flex items-baseline justify-between">
+            <h2 className="text-lg font-semibold text-foreground">Needs Review</h2>
+            <span className="text-xs text-muted-foreground">
+              {reviewCards.length} lot{reviewCards.length !== 1 ? "s" : ""} to decide on
+            </span>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {reviewCards.map((card) => (
+              <SellerAwaitingRelistCard key={card.lotId} {...card} />
+            ))}
+          </div>
+        </section>
+      )}
+
+      {myLots.length === 0 && reviewCards.length === 0 ? (
         <Card className="shadow-sm">
           <CardContent className="flex flex-col items-center py-10 px-4">
             <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-secondary text-muted-foreground mb-4">
@@ -67,7 +205,7 @@ export default async function SellerLotsPage() {
             </div>
           </CardContent>
         </Card>
-      ) : (
+      ) : myLots.length === 0 ? null : (
         <div className="space-y-3">
           {myLots.map((lot) => {
             const pct =

--- a/app/dashboard/seller/lots/page.tsx
+++ b/app/dashboard/seller/lots/page.tsx
@@ -52,7 +52,12 @@ function pickMostRecentTerminalCampaign(
     ["settled", "failed", "cancelled"].includes(r.status)
   );
   if (terminal.length === 0) return null;
-  // Sort by settled_at (when present) then created_at, both descending.
+  // Sort by settled_at (only populated for the 'settled' outcome) then
+  // created_at descending. The campaigns table has no terminated_at /
+  // updated_at column, so for failed/cancelled campaigns we fall back to
+  // created_at — accurate enough since only one terminal campaign of a
+  // given outcome can exist on a lot at a time (the recycle ends each
+  // cycle), so created_at preserves the actual ordering across cycles.
   return terminal.sort((a, b) => {
     const aTime = new Date(a.settled_at || a.created_at).getTime();
     const bTime = new Date(b.settled_at || b.created_at).getTime();

--- a/components/__tests__/seller-awaiting-relist-card.test.tsx
+++ b/components/__tests__/seller-awaiting-relist-card.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+// Stub the mocked router, toast, and Button/Dialog primitives so we can render the
+// component in isolation without pulling in real navigation or toast transports.
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
+}));
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import { SellerAwaitingRelistCard } from "@/components/seller-awaiting-relist-card";
+
+const baseProps = {
+  lotId: "lot-1",
+  lotTitle: "Ethiopian Yirgacheffe",
+  expiryDate: new Date(Date.now() + 30 * 86_400_000).toISOString(),
+  campaign: {
+    hubName: "Portland Hub",
+    deadline: new Date(Date.now() - 86_400_000).toISOString(),
+    committedKg: 42.5,
+    buyerCount: 7,
+  },
+};
+
+describe("SellerAwaitingRelistCard", () => {
+  it("shows the settled banner copy when outcome is settled", () => {
+    render(<SellerAwaitingRelistCard {...baseProps} outcome="settled" />);
+    expect(screen.getByText(/Settled/i)).toBeInTheDocument();
+    expect(screen.getByText("Ethiopian Yirgacheffe")).toBeInTheDocument();
+    expect(screen.getByText("Portland Hub")).toBeInTheDocument();
+  });
+
+  it("shows the failed banner copy when outcome is failed", () => {
+    render(<SellerAwaitingRelistCard {...baseProps} outcome="failed" />);
+    expect(screen.getByText(/Did not meet minimum/i)).toBeInTheDocument();
+  });
+
+  it("shows the cancelled banner copy when outcome is cancelled", () => {
+    render(<SellerAwaitingRelistCard {...baseProps} outcome="cancelled" />);
+    expect(screen.getByText(/Cancelled by hub/i)).toBeInTheDocument();
+  });
+
+  it("shows the expired banner copy and supports a null campaign summary", () => {
+    render(
+      <SellerAwaitingRelistCard
+        {...baseProps}
+        outcome="expired"
+        campaign={null}
+      />
+    );
+    expect(screen.getByText(/Expired without a campaign/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Committed/i)).not.toBeInTheDocument();
+  });
+
+  it("disables the Relist button and shows a hint when expiry has passed", () => {
+    render(
+      <SellerAwaitingRelistCard
+        {...baseProps}
+        outcome="settled"
+        expiryDate={new Date(Date.now() - 86_400_000).toISOString()}
+      />
+    );
+    const relistButton = screen.getByRole("button", { name: /relist/i });
+    expect(relistButton).toBeDisabled();
+    expect(
+      screen.getByText(/Update the expiry date before relisting/i)
+    ).toBeInTheDocument();
+  });
+
+  it("enables Relist when expiry is in the future", () => {
+    render(<SellerAwaitingRelistCard {...baseProps} outcome="settled" />);
+    const relistButton = screen.getByRole("button", { name: /relist/i });
+    expect(relistButton).not.toBeDisabled();
+  });
+});

--- a/components/__tests__/seller-lot-status-toggle.test.tsx
+++ b/components/__tests__/seller-lot-status-toggle.test.tsx
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
+}));
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import { SellerLotStatusToggle } from "@/components/seller-lot-status-toggle";
+
+describe("SellerLotStatusToggle", () => {
+  it("renders Set Inactive when current status is active and no live campaign", () => {
+    render(
+      <SellerLotStatusToggle
+        lotId="lot-1"
+        currentStatus="active"
+        hasActiveCampaign={false}
+      />
+    );
+    expect(screen.getByRole("button", { name: /Set Inactive/i })).toBeInTheDocument();
+  });
+
+  it("renders Set Active when current status is draft", () => {
+    render(<SellerLotStatusToggle lotId="lot-1" currentStatus="draft" />);
+    expect(screen.getByRole("button", { name: /Set Active/i })).toBeInTheDocument();
+  });
+
+  it("renders nothing when an active campaign exists for the lot", () => {
+    const { container } = render(
+      <SellerLotStatusToggle
+        lotId="lot-1"
+        currentStatus="active"
+        hasActiveCampaign={true}
+      />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/components/seller-awaiting-relist-card.tsx
+++ b/components/seller-awaiting-relist-card.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { toast } from "sonner";
+import { Button } from "@merninos/ui";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Pencil } from "lucide-react";
+
+export type RelistOutcome = "settled" | "failed" | "cancelled" | "expired";
+
+export interface SellerAwaitingRelistCardProps {
+  lotId: string;
+  lotTitle: string;
+  expiryDate: string | null;
+  outcome: RelistOutcome;
+  /** Most-recent terminal campaign summary. Null if the lot reached awaiting_relist via expiry without any campaign. */
+  campaign: {
+    hubName: string | null;
+    deadline: string | null;
+    committedKg: number;
+    buyerCount: number;
+  } | null;
+}
+
+const outcomeCopy: Record<
+  RelistOutcome,
+  { label: string; description: string; bannerClass: string }
+> = {
+  settled: {
+    label: "Settled",
+    description: "The campaign hit its goal and payouts are complete. Decide if you have more inventory to sell.",
+    bannerClass: "bg-emerald-50 text-emerald-800 border-emerald-200",
+  },
+  failed: {
+    label: "Did not meet minimum",
+    description: "The campaign closed before reaching the minimum commitment. Buyers were refunded.",
+    bannerClass: "bg-rose-50 text-rose-800 border-rose-200",
+  },
+  cancelled: {
+    label: "Cancelled by hub",
+    description: "The hub owner cancelled the campaign before the deadline. No charges were made.",
+    bannerClass: "bg-zinc-50 text-zinc-700 border-zinc-200",
+  },
+  expired: {
+    label: "Expired without a campaign",
+    description: "Your lot's expiry date passed before any hub claimed it. Adjust the lot or shelve it.",
+    bannerClass: "bg-zinc-50 text-zinc-700 border-zinc-200",
+  },
+};
+
+export function SellerAwaitingRelistCard({
+  lotId,
+  lotTitle,
+  expiryDate,
+  outcome,
+  campaign,
+}: SellerAwaitingRelistCardProps) {
+  const router = useRouter();
+  const [pendingAction, setPendingAction] = useState<"relist" | "shelve" | null>(null);
+  const [confirmOpen, setConfirmOpen] = useState<"relist" | "shelve" | null>(null);
+
+  const expiryPassed = !!(expiryDate && new Date(expiryDate) <= new Date());
+  const copy = outcomeCopy[outcome];
+
+  const submit = async (next: "relist" | "shelve") => {
+    setPendingAction(next);
+    try {
+      const res = await fetch(`/api/lots/${lotId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: next === "relist" ? "active" : "draft" }),
+      });
+      const payload = await res.json();
+      if (!res.ok) throw new Error(payload?.error || "Something went sideways");
+      toast.success(
+        next === "relist" ? "Lot is back on the marketplace." : "Lot saved as draft."
+      );
+      router.refresh();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Something went sideways");
+    } finally {
+      setPendingAction(null);
+      setConfirmOpen(null);
+    }
+  };
+
+  return (
+    <div className="rounded-lg border bg-card shadow-sm">
+      <div className={`rounded-t-lg border-b px-4 py-2 text-xs font-medium ${copy.bannerClass}`}>
+        {copy.label}
+      </div>
+      <div className="space-y-4 p-4">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0 flex-1">
+            <Link
+              href={`/dashboard/seller/lots/${lotId}/edit`}
+              className="text-sm font-semibold text-foreground hover:text-primary transition-colors"
+            >
+              {lotTitle}
+            </Link>
+            <p className="text-xs text-muted-foreground mt-1">{copy.description}</p>
+          </div>
+        </div>
+
+        {campaign && (
+          <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-xs">
+            {campaign.hubName && (
+              <>
+                <dt className="text-muted-foreground">Hub</dt>
+                <dd className="font-medium text-foreground text-right">{campaign.hubName}</dd>
+              </>
+            )}
+            {campaign.deadline && (
+              <>
+                <dt className="text-muted-foreground">Deadline</dt>
+                <dd className="font-medium text-foreground text-right">
+                  {new Date(campaign.deadline).toLocaleDateString()}
+                </dd>
+              </>
+            )}
+            <dt className="text-muted-foreground">Committed</dt>
+            <dd className="font-medium text-foreground text-right">
+              {campaign.committedKg.toFixed(1)} kg
+            </dd>
+            <dt className="text-muted-foreground">Buyers</dt>
+            <dd className="font-medium text-foreground text-right">{campaign.buyerCount}</dd>
+          </dl>
+        )}
+
+        <div className="flex flex-wrap gap-2">
+          <Button asChild size="sm" variant="outline" className="bg-transparent">
+            <Link href={`/dashboard/seller/lots/${lotId}/edit`}>
+              <Pencil className="mr-1 h-3 w-3" />
+              Edit
+            </Link>
+          </Button>
+          <Button
+            size="sm"
+            disabled={expiryPassed || pendingAction !== null}
+            onClick={() => setConfirmOpen("relist")}
+          >
+            {pendingAction === "relist" ? "Relisting..." : "Relist"}
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            className="bg-transparent"
+            disabled={pendingAction !== null}
+            onClick={() => setConfirmOpen("shelve")}
+          >
+            {pendingAction === "shelve" ? "Shelving..." : "Shelve"}
+          </Button>
+        </div>
+
+        {expiryPassed && (
+          <p className="text-xs text-amber-700">
+            Update the expiry date before relisting.
+          </p>
+        )}
+      </div>
+
+      <AlertDialog open={confirmOpen !== null} onOpenChange={(open) => !open && setConfirmOpen(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {confirmOpen === "relist" ? `Relist "${lotTitle}"?` : `Shelve "${lotTitle}"?`}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {confirmOpen === "relist"
+                ? "Hub owners will be able to add this lot to their catalogs again."
+                : "The lot will be saved as a draft, hidden from hub owners and buyers."}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={pendingAction !== null}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => confirmOpen && submit(confirmOpen)}
+              disabled={pendingAction !== null}
+            >
+              {confirmOpen === "relist" ? "Relist" : "Shelve"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/components/seller-lot-status-toggle.tsx
+++ b/components/seller-lot-status-toggle.tsx
@@ -8,16 +8,20 @@ import { Button } from "@merninos/ui";
 export function SellerLotStatusToggle({
   lotId,
   currentStatus,
-  hasContributors,
+  hasActiveCampaign,
 }: {
   lotId: string;
   currentStatus: "active" | "draft";
-  hasContributors: boolean;
+  /** A live campaign blocks any active↔draft toggle. Defaults to false. */
+  hasActiveCampaign?: boolean;
 }) {
   const router = useRouter();
   const [isLoading, setIsLoading] = useState(false);
 
-  if (hasContributors) {
+  // The toggle is for active↔draft only. awaiting_relist transitions live on
+  // SellerAwaitingRelistCard. While a campaign is active, the API also returns
+  // 409 — hide the toggle to keep the UI consistent with the server.
+  if (hasActiveCampaign) {
     return null;
   }
 

--- a/lib/email/__tests__/email-functions.test.ts
+++ b/lib/email/__tests__/email-functions.test.ts
@@ -370,6 +370,31 @@ describe("sendLotFailedEmail", () => {
     expect(result.success).toBe(false);
     expect(mockSendEmail).not.toHaveBeenCalled();
   });
+
+  it("passes relistReviewUrl to the template only when isSeller is true", async () => {
+    const { renderLotClosedFailedHtml } = await import(
+      "@/lib/email/templates/LotClosedFailed"
+    );
+
+    await sendLotFailedEmail({
+      recipient: { email: "seller@farm.com", contact_name: "Maria" },
+      lot: { id: "lot-1", title: "X" },
+      isSeller: true,
+    });
+    expect(renderLotClosedFailedHtml).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        relistReviewUrl: expect.stringContaining("/dashboard/seller/lots#needs-review"),
+      })
+    );
+
+    await sendLotFailedEmail({
+      recipient: { email: "buyer@example.com", contact_name: "Alice" },
+      lot: { id: "lot-1", title: "X" },
+    });
+    expect(renderLotClosedFailedHtml).toHaveBeenLastCalledWith(
+      expect.objectContaining({ relistReviewUrl: undefined })
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/lib/email/components/AwaitingRelistCTA.tsx
+++ b/lib/email/components/AwaitingRelistCTA.tsx
@@ -1,0 +1,71 @@
+import { Button, Hr, Section, Text } from "@react-email/components";
+import React from "react";
+
+export interface AwaitingRelistCTAProps {
+  lotTitle: string;
+  reviewUrl: string;
+}
+
+/**
+ * Shared CTA block dropped into seller terminal-state emails (settled,
+ * failed, expired). Reminds the seller their lot is now in the review
+ * queue and links to /dashboard/seller/lots#needs-review where they can
+ * relist or shelve.
+ */
+export function AwaitingRelistCTA({ lotTitle, reviewUrl }: AwaitingRelistCTAProps) {
+  return (
+    <Section style={section}>
+      <Hr style={hr} />
+      <Text style={text}>
+        <strong>What's next for {lotTitle}?</strong>
+      </Text>
+      <Text style={subtext}>
+        We've moved it to your <strong>Needs Review</strong> queue. Open it to
+        edit the lot, then choose to relist it on the marketplace or shelve it
+        as a draft.
+      </Text>
+      <Section style={ctaSection}>
+        <Button href={reviewUrl} style={button}>
+          Review your lot
+        </Button>
+      </Section>
+    </Section>
+  );
+}
+
+const section: React.CSSProperties = {
+  margin: "24px 0 0",
+};
+const hr: React.CSSProperties = {
+  borderColor: "#e5e7eb",
+  margin: "0 0 20px",
+};
+const text: React.CSSProperties = {
+  fontSize: "15px",
+  lineHeight: "1.6",
+  color: "#111827",
+  margin: "0 0 8px",
+};
+const subtext: React.CSSProperties = {
+  fontSize: "14px",
+  lineHeight: "1.6",
+  color: "#374151",
+  margin: "0 0 12px",
+};
+const ctaSection: React.CSSProperties = {
+  textAlign: "center",
+  margin: "16px 0 0",
+};
+const button: React.CSSProperties = {
+  backgroundColor: "#1c0f05",
+  color: "#f5f0d8",
+  padding: "12px 24px",
+  borderRadius: "9999px",
+  fontSize: "13px",
+  fontWeight: "700",
+  letterSpacing: "0.08em",
+  textTransform: "uppercase",
+  textDecoration: "none",
+  display: "inline-block",
+  border: "2px solid #1c0f05",
+};

--- a/lib/email/components/__tests__/AwaitingRelistCTA.test.tsx
+++ b/lib/email/components/__tests__/AwaitingRelistCTA.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@react-email/render";
+import { AwaitingRelistCTA } from "../AwaitingRelistCTA";
+
+describe("AwaitingRelistCTA", () => {
+  it("renders the review button with the provided url", async () => {
+    const html = await render(
+      <AwaitingRelistCTA
+        lotTitle="Ethiopian Yirgacheffe"
+        reviewUrl="https://example.com/dashboard/seller/lots#needs-review"
+      />
+    );
+
+    expect(html).toContain("Review your lot");
+    expect(html).toContain("https://example.com/dashboard/seller/lots#needs-review");
+  });
+
+  it("includes the lot title in the body copy", async () => {
+    const html = await render(
+      <AwaitingRelistCTA
+        lotTitle="Colombian Supremo"
+        reviewUrl="https://example.com/x"
+      />
+    );
+
+    expect(html).toContain("Colombian Supremo");
+    expect(html).toContain("Needs Review");
+  });
+});

--- a/lib/email/index.ts
+++ b/lib/email/index.ts
@@ -279,6 +279,7 @@ export async function sendLotClosedEmailsBatch(
 ): Promise<SendEmailResult> {
   const orderUrl = `${APP_URL}/dashboard/buyer/commitments`;
   const fulfillmentUrl = `${APP_URL}/dashboard/seller/lots`;
+  const relistReviewUrl = `${APP_URL}/dashboard/seller/lots#needs-review`;
   const dashboardUrl = `${APP_URL}/dashboard/hub`;
 
   const payloads: { to: string; subject: string; html: string }[] = [];
@@ -312,6 +313,7 @@ export async function sendLotClosedEmailsBatch(
         totalQuantityKg: params.lot.total_quantity_kg,
         hubAddress,
         fulfillmentUrl,
+        relistReviewUrl,
       }),
     });
   }
@@ -339,6 +341,8 @@ export async function sendLotClosedEmailsBatch(
 export interface LotFailedEmailParams {
   recipient: Pick<Profile, "email" | "contact_name">;
   lot: Pick<Lot, "id" | "title">;
+  /** Pass `true` for the seller send to add the awaiting_relist CTA. */
+  isSeller?: boolean;
 }
 
 export async function sendLotFailedEmail(
@@ -348,6 +352,9 @@ export async function sendLotFailedEmail(
   const html = await renderLotClosedFailedHtml({
     recipientName: params.recipient.contact_name || "there",
     lotTitle: params.lot.title,
+    relistReviewUrl: params.isSeller
+      ? `${APP_URL}/dashboard/seller/lots#needs-review`
+      : undefined,
   });
   return sendEmail({
     to: params.recipient.email,
@@ -372,6 +379,7 @@ export async function sendLotExpiredEmail(
   const html = await renderLotClosedFailedHtml({
     recipientName: params.seller.contact_name || "there",
     lotTitle: params.lot.title,
+    relistReviewUrl: `${APP_URL}/dashboard/seller/lots#needs-review`,
   });
   return sendEmail({
     to: params.seller.email,

--- a/lib/email/templates/LotClosedFailed.tsx
+++ b/lib/email/templates/LotClosedFailed.tsx
@@ -10,13 +10,20 @@ import {
 } from "@react-email/components";
 import { render } from "@react-email/render";
 import React from "react";
+import { AwaitingRelistCTA } from "@/lib/email/components/AwaitingRelistCTA";
 
 export interface LotClosedFailedProps {
   recipientName: string;
   lotTitle: string;
+  /** When set, a "review your lot" CTA renders. Pass only on the seller send. */
+  relistReviewUrl?: string;
 }
 
-export function LotClosedFailed({ recipientName, lotTitle }: LotClosedFailedProps) {
+export function LotClosedFailed({
+  recipientName,
+  lotTitle,
+  relistReviewUrl,
+}: LotClosedFailedProps) {
   return (
     <Html>
       <Head />
@@ -37,6 +44,10 @@ export function LotClosedFailed({ recipientName, lotTitle }: LotClosedFailedProp
             Thank you for your participation on CrowdRoast. New lots are added regularly
             — check back to find your next opportunity.
           </Text>
+
+          {relistReviewUrl && (
+            <AwaitingRelistCTA lotTitle={lotTitle} reviewUrl={relistReviewUrl} />
+          )}
 
           <Hr style={hr} />
           <Text style={footer}>

--- a/lib/email/templates/LotClosedSuccess.tsx
+++ b/lib/email/templates/LotClosedSuccess.tsx
@@ -12,6 +12,7 @@ import {
 } from "@react-email/components";
 import { render } from "@react-email/render";
 import React from "react";
+import { AwaitingRelistCTA } from "@/lib/email/components/AwaitingRelistCTA";
 
 // ---------------------------------------------------------------------------
 // Buyer variant (AC-6a)
@@ -85,6 +86,8 @@ export interface LotClosedSellerProps {
   totalQuantityKg: number;
   hubAddress: string;
   fulfillmentUrl: string;
+  /** When set, a "review your lot" CTA renders below fulfillment. */
+  relistReviewUrl?: string;
 }
 
 export function LotClosedSeller({
@@ -93,6 +96,7 @@ export function LotClosedSeller({
   totalQuantityKg,
   hubAddress,
   fulfillmentUrl,
+  relistReviewUrl,
 }: LotClosedSellerProps) {
   return (
     <Html>
@@ -123,6 +127,10 @@ export function LotClosedSeller({
               Manage fulfillment
             </Button>
           </Section>
+
+          {relistReviewUrl && (
+            <AwaitingRelistCTA lotTitle={lotTitle} reviewUrl={relistReviewUrl} />
+          )}
 
           <Hr style={hr} />
           <Text style={footer}>

--- a/lib/lots/__tests__/finalize-campaign.test.ts
+++ b/lib/lots/__tests__/finalize-campaign.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vitest";
+import { finalizeCampaign } from "../finalize-campaign";
+
+type RpcCall = { fn: string; args: unknown };
+
+function buildAdminClient(rpcResult: { data: unknown; error: unknown }) {
+  const calls: RpcCall[] = [];
+  const admin = {
+    rpc: vi.fn((fn: string, args: unknown) => {
+      calls.push({ fn, args });
+      return Promise.resolve(rpcResult);
+    }),
+  } as unknown as Parameters<typeof finalizeCampaign>[0];
+  return { admin, calls };
+}
+
+describe("finalizeCampaign", () => {
+  it("invokes finalize_campaign rpc with the campaign id and outcome", async () => {
+    const { admin, calls } = buildAdminClient({ data: null, error: null });
+
+    const result = await finalizeCampaign(admin, "camp-1", "settled");
+
+    expect(calls).toEqual([
+      {
+        fn: "finalize_campaign",
+        args: { p_campaign_id: "camp-1", p_outcome: "settled" },
+      },
+    ]);
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("forwards each terminal outcome verbatim", async () => {
+    for (const outcome of ["settled", "failed", "cancelled"] as const) {
+      const { admin, calls } = buildAdminClient({ data: null, error: null });
+      await finalizeCampaign(admin, "camp-x", outcome);
+      expect(calls[0].args).toMatchObject({ p_outcome: outcome });
+    }
+  });
+
+  it("returns a tagged failure with structured Postgres error metadata", async () => {
+    const { admin } = buildAdminClient({
+      data: null,
+      error: { message: "row locked", code: "55P03", hint: "try again" },
+    });
+
+    const result = await finalizeCampaign(admin, "camp-1", "settled");
+
+    expect(result).toEqual({
+      ok: false,
+      error: "55P03 — row locked — try again",
+    });
+  });
+
+  it("falls back to a generic error message when the rpc error has no fields", async () => {
+    const { admin } = buildAdminClient({ data: null, error: {} });
+
+    const result = await finalizeCampaign(admin, "camp-1", "failed");
+
+    expect(result).toEqual({
+      ok: false,
+      error: "finalize_campaign rpc failed",
+    });
+  });
+});

--- a/lib/lots/__tests__/recycle-lot.test.ts
+++ b/lib/lots/__tests__/recycle-lot.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+import { recycleLot } from "../recycle-lot";
+
+type RpcCall = { fn: string; args: unknown };
+
+function buildAdminClient(rpcResult: { data: unknown; error: unknown }) {
+  const calls: RpcCall[] = [];
+  const admin = {
+    rpc: vi.fn((fn: string, args: unknown) => {
+      calls.push({ fn, args });
+      return Promise.resolve(rpcResult);
+    }),
+  } as unknown as Parameters<typeof recycleLot>[0];
+  return { admin, calls };
+}
+
+describe("recycleLot", () => {
+  it("invokes recycle_lot rpc with the lot id and returns ok", async () => {
+    const { admin, calls } = buildAdminClient({ data: null, error: null });
+
+    const result = await recycleLot(admin, "lot-123");
+
+    expect(calls).toEqual([
+      { fn: "recycle_lot", args: { p_lot_id: "lot-123" } },
+    ]);
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("returns a tagged failure when the rpc errors", async () => {
+    const { admin } = buildAdminClient({
+      data: null,
+      error: { message: "permission denied" },
+    });
+
+    const result = await recycleLot(admin, "lot-123");
+
+    expect(result).toEqual({ ok: false, error: "permission denied" });
+  });
+
+  it("falls back to a generic error message when the rpc error has no message", async () => {
+    const { admin } = buildAdminClient({ data: null, error: {} });
+
+    const result = await recycleLot(admin, "lot-123");
+
+    expect(result).toEqual({ ok: false, error: "recycle_lot rpc failed" });
+  });
+});

--- a/lib/lots/__tests__/recycle-lot.test.ts
+++ b/lib/lots/__tests__/recycle-lot.test.ts
@@ -26,18 +26,21 @@ describe("recycleLot", () => {
     expect(result).toEqual({ ok: true });
   });
 
-  it("returns a tagged failure when the rpc errors", async () => {
+  it("returns a tagged failure with structured Postgres error metadata", async () => {
     const { admin } = buildAdminClient({
       data: null,
-      error: { message: "permission denied" },
+      error: { message: "permission denied", code: "42501", hint: "check grants" },
     });
 
     const result = await recycleLot(admin, "lot-123");
 
-    expect(result).toEqual({ ok: false, error: "permission denied" });
+    expect(result).toEqual({
+      ok: false,
+      error: "42501 — permission denied — check grants",
+    });
   });
 
-  it("falls back to a generic error message when the rpc error has no message", async () => {
+  it("falls back to a generic error message when the rpc error has no fields", async () => {
     const { admin } = buildAdminClient({ data: null, error: {} });
 
     const result = await recycleLot(admin, "lot-123");

--- a/lib/lots/finalize-campaign.ts
+++ b/lib/lots/finalize-campaign.ts
@@ -1,0 +1,49 @@
+import type { createAdminClient } from "@/lib/supabase/admin";
+
+type AdminClient = ReturnType<typeof createAdminClient>;
+
+export type FinalizeOutcome = "settled" | "failed" | "cancelled";
+
+export type FinalizeCampaignResult = { ok: true } | { ok: false; error: string };
+
+/**
+ * Atomically transition a campaign to a terminal state and recycle its lot.
+ * Wraps the finalize_campaign Postgres function which:
+ *   1. Locks the campaign row (FOR UPDATE) and no-ops if it's not 'active'
+ *      — this gives us idempotency on retry and safety against concurrent
+ *      callers without us doing our own check-then-act.
+ *   2. For 'cancelled' outcomes, cancels any non-cancelled commitments.
+ *      For 'settled' and 'failed', the caller is expected to have already
+ *      handled per-commitment Stripe work before calling this.
+ *   3. Updates the campaign row to its terminal status.
+ *   4. Clears hub_lots for the lot, sets lots.status='awaiting_relist',
+ *      resets committed_quantity_kg, and nulls hubs.featured_lot_id.
+ *
+ * All four happen inside a single Postgres transaction, so partial failure
+ * rolls back. On retry the campaign is still 'active' and the call repeats.
+ */
+export async function finalizeCampaign(
+  admin: AdminClient,
+  campaignId: string,
+  outcome: FinalizeOutcome
+): Promise<FinalizeCampaignResult> {
+  const { error } = await admin.rpc("finalize_campaign", {
+    p_campaign_id: campaignId,
+    p_outcome: outcome,
+  });
+
+  if (error) {
+    const pgErr = error as {
+      message?: string;
+      code?: string;
+      details?: string;
+      hint?: string;
+    };
+    const detail = [pgErr.code, pgErr.message, pgErr.details, pgErr.hint]
+      .filter(Boolean)
+      .join(" — ");
+    return { ok: false, error: detail || "finalize_campaign rpc failed" };
+  }
+
+  return { ok: true };
+}

--- a/lib/lots/recycle-lot.ts
+++ b/lib/lots/recycle-lot.ts
@@ -18,10 +18,16 @@ export async function recycleLot(
   const { error } = await admin.rpc("recycle_lot", { p_lot_id: lotId });
 
   if (error) {
-    return {
-      ok: false,
-      error: (error as { message?: string }).message || "recycle_lot rpc failed",
+    const pgErr = error as {
+      message?: string;
+      code?: string;
+      details?: string;
+      hint?: string;
     };
+    const detail = [pgErr.code, pgErr.message, pgErr.details, pgErr.hint]
+      .filter(Boolean)
+      .join(" — ");
+    return { ok: false, error: detail || "recycle_lot rpc failed" };
   }
 
   return { ok: true };

--- a/lib/lots/recycle-lot.ts
+++ b/lib/lots/recycle-lot.ts
@@ -1,0 +1,28 @@
+import type { createAdminClient } from "@/lib/supabase/admin";
+
+type AdminClient = ReturnType<typeof createAdminClient>;
+
+export type RecycleLotResult = { ok: true } | { ok: false; error: string };
+
+/**
+ * Atomically recycle a lot after a campaign reaches a terminal state:
+ * clears every hub_lots row for the lot, transitions it to 'awaiting_relist'
+ * with committed_quantity_kg=0, and nulls hubs.featured_lot_id wherever it
+ * pointed at this lot. All three mutations run inside the recycle_lot
+ * Postgres function, so partial failure rolls back.
+ */
+export async function recycleLot(
+  admin: AdminClient,
+  lotId: string
+): Promise<RecycleLotResult> {
+  const { error } = await admin.rpc("recycle_lot", { p_lot_id: lotId });
+
+  if (error) {
+    return {
+      ok: false,
+      error: (error as { message?: string }).message || "recycle_lot rpc failed",
+    };
+  }
+
+  return { ok: true };
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -3,6 +3,7 @@ export type UserRole = "buyer" | "seller" | "hub_owner" | "admin";
 export type LotStatus =
   | "draft"
   | "active"
+  | "awaiting_relist"
   | "fully_committed"
   | "shipped"
   | "delivered"

--- a/scripts/cron-lot-expiry.ts
+++ b/scripts/cron-lot-expiry.ts
@@ -4,7 +4,8 @@
  *
  * Calls the route with the Bearer auth path (same as Vercel cron),
  * then queries the local DB to assert the seeded "Expired Test Lot"
- * transitioned from status='active' → status='expired'.
+ * transitioned from status='active' → status='awaiting_relist' (the
+ * recycle path, replacing the legacy 'expired' transition).
  *
  * The seed creates a second lot with no campaign and a past
  * expiry_date specifically so this cron has work to do; the main
@@ -78,14 +79,14 @@ async function assertExpiredLotMarked(supabase: SupabaseClient): Promise<void> {
     process.exit(1);
   }
   const lot = lots[0];
-  if (lot.status !== "expired") {
+  if (lot.status !== "awaiting_relist") {
     console.error(
-      `\nFAIL: expected lot ${lot.id} to be status='expired' after lot-expiry, got status='${lot.status}'.`,
+      `\nFAIL: expected lot ${lot.id} to be status='awaiting_relist' after lot-expiry, got status='${lot.status}'.`,
     );
     process.exit(1);
   }
   console.log(
-    `\n✓ Lot transitioned to 'expired'. settlement_status='${lot.settlement_status}', settlement_processed_at=${lot.settlement_processed_at}`,
+    `\n✓ Lot recycled to 'awaiting_relist'. settlement_processed_at=${lot.settlement_processed_at}`,
   );
 }
 

--- a/supabase/migrations/20240101000023_awaiting_relist_status.sql
+++ b/supabase/migrations/20240101000023_awaiting_relist_status.sql
@@ -1,0 +1,97 @@
+-- Campaign Close — Lot Recycling
+-- See: ~/Documents/crowdroast/campaign-close-lot-recycling/spec.md
+--
+-- Adds 'awaiting_relist' status, guards the committed-quantity trigger from
+-- flipping status away from non-flippable states, and introduces the
+-- public.recycle_lot RPC that atomically:
+--   1. removes a lot from every hub_lots row
+--   2. transitions the lot to 'awaiting_relist' with committed_quantity_kg=0
+--   3. nulls hubs.featured_lot_id wherever it referenced this lot
+--
+-- The RPC runs as SECURITY DEFINER and is granted only to service_role so it
+-- can never be invoked from the client.
+
+-- 1. Extend the lots status check to include awaiting_relist.
+-- 'expired' stays in the constraint per spec (no longer set by app code, but
+-- existing data and back-compat reads remain valid).
+alter table public.lots
+  drop constraint if exists lots_status_check;
+
+alter table public.lots
+  add constraint lots_status_check
+  check (status in (
+    'draft',
+    'active',
+    'awaiting_relist',
+    'fully_committed',
+    'shipped',
+    'delivered',
+    'closed',
+    'expired'
+  ));
+
+-- 2. Replace update_lot_committed_quantity with a status-guarded version.
+-- committed_quantity_kg always recomputes (correct for audit). The status
+-- flip only fires when current status is one of the flippable values; this
+-- prevents late refund webhooks or manual data fixes from silently flipping
+-- a recycled lot back to 'active'.
+create or replace function public.update_lot_committed_quantity()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  update public.lots
+  set committed_quantity_kg = (
+    select coalesce(sum(quantity_kg), 0)
+    from public.commitments
+    where lot_id = coalesce(new.lot_id, old.lot_id)
+    and status not in ('cancelled')
+  ),
+  status = case
+    when status not in ('active', 'fully_committed') then status
+    when (
+      select coalesce(sum(quantity_kg), 0)
+      from public.commitments
+      where lot_id = coalesce(new.lot_id, old.lot_id)
+      and status not in ('cancelled')
+    ) >= total_quantity_kg then 'fully_committed'
+    else 'active'
+  end,
+  updated_at = now()
+  where id = coalesce(new.lot_id, old.lot_id);
+
+  return coalesce(new, old);
+end;
+$$;
+
+-- 3. recycle_lot RPC. Single transactional unit — partial failure rolls back.
+create or replace function public.recycle_lot(p_lot_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  delete from public.hub_lots
+  where lot_id = p_lot_id;
+
+  update public.lots
+  set status = 'awaiting_relist',
+      committed_quantity_kg = 0,
+      settlement_processed_at = now(),
+      updated_at = now()
+  where id = p_lot_id;
+
+  update public.hubs
+  set featured_lot_id = null
+  where featured_lot_id = p_lot_id;
+end;
+$$;
+
+-- Lock the RPC down: never invokable by anon or authenticated, only by
+-- the backend service role.
+revoke all on function public.recycle_lot(uuid) from public;
+revoke all on function public.recycle_lot(uuid) from anon, authenticated;
+grant execute on function public.recycle_lot(uuid) to service_role;

--- a/supabase/migrations/20240101000024_finalize_campaign.sql
+++ b/supabase/migrations/20240101000024_finalize_campaign.sql
@@ -1,0 +1,152 @@
+-- Atomic campaign finalize + tighter committed-quantity trigger guard.
+-- Addresses three blocking issues found in code review:
+--   1. Campaign-cancel PATCH flipped status before recycle → on RPC failure
+--      the campaign was permanently cancelled but the lot was unstranded only
+--      via manual SQL.
+--   2. Settle-deadlines settled-branch had the same hazard.
+--   3. Settle-deadlines failed-branch had the same hazard.
+--
+-- Plus two majors:
+--   * Concurrent settle-deadlines runs could clobber each other's writes
+--     because the campaign update lacked a 'status=active' guard.
+--   * The committed-quantity trigger preserved status on recycled lots but
+--     still recomputed committed_quantity_kg from the live commitments
+--     table — a refund webhook racing the recycle could leave an
+--     awaiting_relist lot with a non-zero committed_quantity_kg.
+--
+-- This migration:
+--   * Introduces public.finalize_campaign(p_campaign_id, p_outcome) which
+--     locks the campaign row, no-ops if it isn't 'active' (idempotency +
+--     concurrent-run safety), then atomically updates campaign + recycles
+--     the lot in a single transaction.
+--   * Tightens update_lot_committed_quantity to skip the entire UPDATE
+--     when the lot is in a non-flippable status (awaiting_relist, draft,
+--     closed, expired) — both status AND committed_quantity_kg are
+--     preserved, instead of just status.
+
+-- 1. Tighten the committed-quantity trigger.
+-- The previous version preserved status on non-flippable lots but still
+-- recomputed committed_quantity_kg from a live SUM of commitments, which
+-- could resurrect a non-zero quantity on a recycled lot.
+create or replace function public.update_lot_committed_quantity()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_lot_id uuid;
+  v_status text;
+begin
+  v_lot_id := coalesce(new.lot_id, old.lot_id);
+
+  select status into v_status
+  from public.lots
+  where id = v_lot_id;
+
+  -- Skip the entire recompute on non-flippable lots. recycle_lot owns the
+  -- canonical committed_quantity_kg=0 write for those states.
+  if v_status not in ('active', 'fully_committed') then
+    return coalesce(new, old);
+  end if;
+
+  update public.lots
+  set committed_quantity_kg = (
+    select coalesce(sum(quantity_kg), 0)
+    from public.commitments
+    where lot_id = v_lot_id
+      and status not in ('cancelled')
+  ),
+  status = case
+    when (
+      select coalesce(sum(quantity_kg), 0)
+      from public.commitments
+      where lot_id = v_lot_id
+        and status not in ('cancelled')
+    ) >= total_quantity_kg then 'fully_committed'
+    else 'active'
+  end,
+  updated_at = now()
+  where id = v_lot_id;
+
+  return coalesce(new, old);
+end;
+$$;
+
+-- 2. finalize_campaign RPC. Atomic terminal-state transition.
+-- Outcome must be one of: 'settled', 'failed', 'cancelled'.
+-- If the campaign is not currently 'active' (already finalized, or
+-- concurrent run beat us to it), the function is a no-op. The row-level
+-- lock prevents two concurrent callers from both winning.
+create or replace function public.finalize_campaign(
+  p_campaign_id uuid,
+  p_outcome text
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_lot_id uuid;
+  v_current_status text;
+begin
+  if p_outcome not in ('settled', 'failed', 'cancelled') then
+    raise exception 'Invalid outcome: %', p_outcome;
+  end if;
+
+  -- Lock the campaign row and read its current state.
+  select lot_id, status
+    into v_lot_id, v_current_status
+  from public.campaigns
+  where id = p_campaign_id
+  for update;
+
+  if v_current_status is null then
+    raise exception 'Campaign not found: %', p_campaign_id;
+  end if;
+
+  -- Idempotent + concurrent-safe: only act when the campaign is still active.
+  if v_current_status <> 'active' then
+    return;
+  end if;
+
+  -- For 'cancelled' outcomes, the route doesn't pre-cancel commitments —
+  -- this RPC owns that write. For 'settled' and 'failed', the
+  -- settle-deadlines route already updated commitments per-Stripe-action
+  -- before calling here, so we leave them alone.
+  if p_outcome = 'cancelled' then
+    update public.commitments
+    set status = 'cancelled',
+        payment_error = 'Campaign was cancelled by hub owner'
+    where campaign_id = p_campaign_id
+      and status <> 'cancelled';
+  end if;
+
+  -- Update campaign to terminal status.
+  update public.campaigns
+  set status = p_outcome,
+      settled_at = case when p_outcome = 'settled' then now() else null end
+  where id = p_campaign_id;
+
+  -- Recycle the lot: clear hub catalogs, transition status, null featured-lot
+  -- references. Inlined here (rather than calling recycle_lot) because we're
+  -- inside one transaction already.
+  delete from public.hub_lots where lot_id = v_lot_id;
+
+  update public.lots
+  set status = 'awaiting_relist',
+      committed_quantity_kg = 0,
+      settlement_processed_at = now(),
+      updated_at = now()
+  where id = v_lot_id;
+
+  update public.hubs
+  set featured_lot_id = null
+  where featured_lot_id = v_lot_id;
+end;
+$$;
+
+revoke all on function public.finalize_campaign(uuid, text) from public;
+revoke all on function public.finalize_campaign(uuid, text) from anon, authenticated;
+grant execute on function public.finalize_campaign(uuid, text) to service_role;


### PR DESCRIPTION
## Summary

When a CrowdRoast campaign reaches a terminal state (`settled`, `failed`, `cancelled`, or the lot's `expiry_date` passes), the lot now recycles back to the seller for review instead of staying in hub catalogs with stale commitments. Sellers see closed campaigns in a new "Needs Review" section on `/dashboard/seller/lots`, where they choose to **Relist** (→ `active`, available for hubs to claim again) or **Shelve** (→ `draft`).

Closes #49.

### Behavior changes worth flagging

- **Failed campaigns no longer auto-relist.** Previously, a failed-min-not-met campaign whose lot's `expiry_date` was still in the future left the lot `active` so other hubs could re-claim. After this PR, every failed campaign recycles to `awaiting_relist` and waits for the seller to act.
- **Backers list on the lot detail page** is now scoped to the *current* campaign (or empty when no campaign is active). Historical commitment rows stay in the DB for the Stripe paper trail.
- **PATCH `/api/lots/[id]`** previously rejected any edit if the lot had any commitment with a payment intent. Now blocks only while a campaign is `active` or the lot is in a terminal state (`shipped`/`delivered`/`closed`/`expired`).
- **Hub cancellation API** (`PATCH /api/campaigns/[id]` with `{status: "cancelled"}`) now also recycles the lot atomically via the new RPC. UI for cancellation is still a future ticket.

### Architecture highlights

- **`finalize_campaign(uuid, text)` Postgres function** wraps three writes (campaign update, commitments cancel, lot recycle) in a single transaction. Uses `FOR UPDATE` on the campaign row plus a `status = 'active'` no-op gate, giving idempotent retries and concurrent-cron safety for free.
- **`recycle_lot(uuid) RPC`** for the lot-expiry path (no campaign exists). Both functions are `SECURITY DEFINER` with execute granted only to `service_role`.
- **`update_lot_committed_quantity` trigger guard** — the entire UPDATE is now skipped on non-flippable lot statuses, preventing late refund webhooks from resurrecting `committed_quantity_kg` on recycled lots.

## Code review fixes folded into this PR

The branch went through `/casaflow:review` (specialist swarm + opus logic reviewer) which surfaced 4 blocking + 5 major + 12+ minor issues. All blocking and major items are fixed in commits prefixed with `fix(...)`; minors are in `chore(...)` commits. Notable fixes:

- **Three blocking ordering bugs** where the campaign was flipped to a terminal status before the recycle ran — collapsed into the atomic `finalize_campaign` RPC.
- **Settled email reported "Total quantity sold: 0.0 kg"** because the recycle zeroed `committed_quantity_kg` before the email read it. Now sums confirmed commitments.
- **Lot edit endpoint missing status allowlist** — sellers could mutate `shipped`/`delivered`/`closed` lots. Status check added.
- **Review card over-counted refunded commitments + double-counted buyers** — added `.neq("status", "cancelled")` and per-campaign buyer dedup.

## Test plan

- [ ] Seller creates a lot, hub adds it to catalog, hub starts a campaign — happy path still works.
- [ ] **Settled outcome**: hub starts campaign, buyers commit to meet minimum, deadline passes, settle-deadlines cron runs.
  - [ ] Seller email "Your lot has closed successfully" shows correct total kg (not 0).
  - [ ] Lot disappears from hub catalog (`hub_lots` cleared) and from `/browse`.
  - [ ] Seller sees lot in "Needs Review" section on `/dashboard/seller/lots`.
  - [ ] Seller clicks **Relist** → lot is back as claimable in hub catalog.
- [ ] **Failed outcome (min not met)**: same flow but with insufficient commitments; expiry date in the future.
  - [ ] Buyers refunded; seller email "Campaign ended without funding" includes the review CTA.
  - [ ] Lot recycles to `awaiting_relist` (not back to `active` — this is the behavior change).
  - [ ] Backers list on the lot detail page is empty even though historical (cancelled) commitment rows still exist.
- [ ] **Cancelled outcome**: hub owner calls `PATCH /api/campaigns/[id]` directly (no UI yet).
  - [ ] Commitments cancelled; lot recycled; no email sent (deferred to UI ticket per spec).
- [ ] **Expired outcome**: lot's `expiry_date` passes with no campaign; lot-expiry cron runs.
  - [ ] Lot recycles to `awaiting_relist`; seller email sent with review CTA.
- [ ] **Edit during awaiting_relist**: seller opens an `awaiting_relist` lot's edit page.
  - [ ] Form is editable (no longer locked by historical commitments).
  - [ ] Saving changes updates the lot; clears `hub_lots` per existing PATCH side effect.
- [ ] **Edit during active campaign**: seller tries to edit a lot with a live campaign.
  - [ ] Form shows "Editing Locked — A hub owner is currently running a campaign on this lot."
  - [ ] API returns 409.
- [ ] **Concurrent cron runs** (manual: hit the cron endpoint twice in quick succession): second call is a no-op due to `finalize_campaign` row lock + `status='active'` gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)