### PR TITLE
fix(shipments): scope idempotency by campaign so relisted lots get a shipment

### DIFF
--- a/app/api/payments/settle-deadlines/route.ts
+++ b/app/api/payments/settle-deadlines/route.ts
@@ -1030,7 +1030,7 @@ async function settleDeadlines(request: Request) {
     console.log("[settle-deadlines] campaign", campaign.id, "lot", lot.id, "— debug:", debug, "transferFailedCount:", transferFailedCount, "failedCount:", failedCount, "succeededCount:", succeededCount, "orphansCancelled:", orphansCancelled);
     if (!debug && transferFailedCount === 0) {
       backgroundTasks.push(sendLotSuccessNotifications(admin, lot.id, campaign.hub_id));
-      backgroundTasks.push(createShipmentForLot(lot.id, campaign.hub_id));
+      backgroundTasks.push(createShipmentForLot(lot.id, campaign.hub_id, campaign.id));
     } else {
       console.log("[settle-deadlines] skipping success emails and shipment creation — condition not met");
     }

--- a/lib/shipments.ts
+++ b/lib/shipments.ts
@@ -1,34 +1,40 @@
 import { createAdminClient } from "@/lib/supabase/admin";
 
 /**
- * Creates a pending shipment record for a lot when it successfully settles.
- * Idempotent — if a non-cancelled shipment already exists for this lot/hub
- * pair, returns it without inserting a duplicate.
+ * Creates a pending shipment record for a lot when its campaign successfully
+ * settles. Idempotent per (lot_id, campaign_id) — re-running the cron for the
+ * same campaign returns the existing row instead of inserting a duplicate.
+ *
+ * Scoping by campaign_id (not lot_id alone) is what lets a lot that's been
+ * relisted after a prior cycle get a brand-new shipment for the new campaign,
+ * even if the prior cycle left a shipment row behind.
  *
  * Never throws. Returns null on error so callers can fire-and-forget safely.
  */
 export async function createShipmentForLot(
   lotId: string,
-  hubId: string | null
+  hubId: string | null,
+  campaignId: string | null
 ): Promise<{ id: string } | null> {
   const admin = createAdminClient();
 
   try {
-    // Idempotency check: return existing shipment if one already exists
-    const { data: existing } = await admin
-      .from("shipments")
-      .select("id")
-      .eq("lot_id", lotId)
-      .neq("status", "cancelled")
-      .maybeSingle();
+    if (campaignId) {
+      const { data: existing } = await admin
+        .from("shipments")
+        .select("id")
+        .eq("lot_id", lotId)
+        .eq("campaign_id", campaignId)
+        .maybeSingle();
 
-    if (existing) {
-      return existing;
+      if (existing) {
+        return existing;
+      }
     }
 
     const { data, error } = await admin
       .from("shipments")
-      .insert({ lot_id: lotId, hub_id: hubId, status: "pending" })
+      .insert({ lot_id: lotId, hub_id: hubId, campaign_id: campaignId, status: "pending" })
       .select("id")
       .single();
 

--- a/supabase/migrations/20240101000025_shipments_campaign_id.sql
+++ b/supabase/migrations/20240101000025_shipments_campaign_id.sql
@@ -1,0 +1,25 @@
+-- Scope shipments to the campaign that produced them.
+-- Without this, createShipmentForLot's idempotency check (lot_id + non-cancelled
+-- status) finds a stale shipment from a prior campaign cycle and returns it
+-- instead of inserting a new pending row. The seller's shipments dashboard
+-- then never gets a new entry for the latest settled campaign.
+
+alter table public.shipments
+  add column if not exists campaign_id uuid references public.campaigns(id) on delete set null;
+
+-- Backfill: link existing shipments to their lot's most recent settled campaign.
+-- distinct on picks the first row per lot after ordering, so we get exactly one
+-- campaign per shipment (the latest 'settled' one, falling back to created_at).
+update public.shipments s
+set campaign_id = c.id
+from (
+  select distinct on (lot_id) id, lot_id
+  from public.campaigns
+  where status = 'settled'
+  order by lot_id, settled_at desc nulls last, created_at desc
+) c
+where s.lot_id = c.lot_id
+  and s.campaign_id is null;
+
+create index if not exists idx_shipments_lot_campaign
+  on public.shipments (lot_id, campaign_id);


### PR DESCRIPTION
## Summary

- Fixes a bug where a lot whose first campaign failed and second campaign settled successfully would get its funds transferred and recycled, but no new pending shipment would appear on the seller's shipments dashboard.
- Root cause: `createShipmentForLot`'s idempotency check looked up existing shipments by `lot_id` only, with a `.neq("status", "cancelled")` filter that's a no-op (the `shipments.status` check constraint doesn't allow `'cancelled'`). Any pre-existing shipment for the lot — from a prior cycle, manual data, etc. — caused the function to short-circuit and return the stale row instead of inserting a fresh one.
- Adds `campaign_id` to `shipments` (backfilled from each lot's most recent settled campaign), scopes the idempotency check to `(lot_id, campaign_id)`, and threads `campaign.id` through from settle-deadlines.

## Database

Migration `20240101000025_shipments_campaign_id.sql` has already been applied to dev and prod (`crowdroast-supabase`). The migration is additive — adds a nullable column with `on delete set null` and an index — so existing flows continue working without code changes.

## Test plan

- [x] `npx vitest run` — all 160 tests pass
- [x] Local migration applied via `supabase migration up --local`
- [x] Prod migration applied via `supabase db push --linked`
- [ ] In dev, simulate the scenario: lot A → campaign 1 (fail at deadline) → relist → campaign 2 (settle at deadline) → confirm a new pending shipment row appears on the seller shipments page for the lot
- [ ] In dev, run cron twice for the same settled campaign and confirm it doesn't insert a duplicate shipment (idempotency still holds within a single campaign cycle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)