### PR TITLE
fix(db): scope lot committed-quantity sum to the active campaign

### DIFF
--- a/supabase/migrations/20240101000026_lot_quantity_active_campaign_only.sql
+++ b/supabase/migrations/20240101000026_lot_quantity_active_campaign_only.sql
@@ -1,0 +1,95 @@
+-- Tighten update_lot_committed_quantity to only count commitments tied to
+-- the lot's currently-active campaign.
+--
+-- Before this change, the trigger summed every commitment with
+-- status <> 'cancelled'. That included status='confirmed' commits from a
+-- prior settled cycle. After the lot was recycled to 'awaiting_relist'
+-- and the seller relisted (lot → 'active'), the very next commitment on
+-- a new campaign re-fired the trigger and rolled the prior cycle's
+-- confirmed commits back into committed_quantity_kg — inflating the lot's
+-- progress and the settle cron's minimumMet check.
+--
+-- New semantic: a commitment counts if it's not cancelled AND it belongs to
+-- the lot's active campaign (or has no campaign at all — pre-campaigns-era
+-- legacy data still counts).
+--
+-- Status guard on lot.status is unchanged: recycle_lot still owns the
+-- canonical zero-write for awaiting_relist / draft / closed / expired lots.
+
+create or replace function public.update_lot_committed_quantity()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_lot_id uuid;
+  v_status text;
+  v_total numeric;
+  v_sum numeric;
+begin
+  v_lot_id := coalesce(new.lot_id, old.lot_id);
+
+  select status, total_quantity_kg
+    into v_status, v_total
+  from public.lots
+  where id = v_lot_id;
+
+  if v_status not in ('active', 'fully_committed') then
+    return coalesce(new, old);
+  end if;
+
+  select coalesce(sum(cm.quantity_kg), 0)
+    into v_sum
+  from public.commitments cm
+  where cm.lot_id = v_lot_id
+    and cm.status <> 'cancelled'
+    and (
+      cm.campaign_id is null
+      or exists (
+        select 1
+        from public.campaigns c
+        where c.id = cm.campaign_id
+          and c.status = 'active'
+      )
+    );
+
+  update public.lots
+  set committed_quantity_kg = v_sum,
+      status = case when v_sum >= v_total then 'fully_committed' else 'active' end,
+      updated_at = now()
+  where id = v_lot_id;
+
+  return coalesce(new, old);
+end;
+$$;
+
+-- Backfill: any currently-active lot whose committed_quantity_kg was inflated
+-- by a prior cycle's confirmed commits gets recomputed under the new rule.
+update public.lots l
+set committed_quantity_kg = sub.v_sum,
+    status = case when sub.v_sum >= l.total_quantity_kg then 'fully_committed' else 'active' end,
+    updated_at = now()
+from (
+  select
+    l2.id as lot_id,
+    coalesce((
+      select sum(cm.quantity_kg)
+      from public.commitments cm
+      where cm.lot_id = l2.id
+        and cm.status <> 'cancelled'
+        and (
+          cm.campaign_id is null
+          or exists (
+            select 1
+            from public.campaigns c
+            where c.id = cm.campaign_id
+              and c.status = 'active'
+          )
+        )
+    ), 0) as v_sum
+  from public.lots l2
+  where l2.status in ('active', 'fully_committed')
+) sub
+where l.id = sub.lot_id
+  and l.committed_quantity_kg is distinct from sub.v_sum;


### PR DESCRIPTION
## Summary

- Closes a stale-counter bug: after a campaign settles successfully and its lot is recycled + relisted, the prior cycle's `confirmed` commitments were being re-added to `lot.committed_quantity_kg` the moment a buyer committed to the new campaign.
- The lot trigger summed every commitment where `status <> 'cancelled'`. The settle cron leaves successful commits at `status='confirmed'`, so they kept counting forever — unlike the failure path, which marks them `'cancelled'` and they correctly drop out.
- New rule: a commitment counts if it's not cancelled **and** it belongs to the lot's currently-active campaign (or has `campaign_id IS NULL`, preserving pre-campaigns-era legacy data).
- Migration also backfills `committed_quantity_kg` for any `active`/`fully_committed` lot whose value was already inflated by the old logic.

## Why this matters

The settle cron's `minimumMet` check at `app/api/payments/settle-deadlines/route.ts:407` reads `lot.committed_quantity_kg` to decide whether to settle a campaign. Under the old trigger, a relisted lot would inherit its predecessor's commitment volume, so the new campaign could get green-lit even if its own buyers were below the lot's `min_commitment_kg`.

## Real-world validation

Verified against the lot that prompted this thread (`Andres Martinez Caturra Floral`, `76a78874-…f24cefbe6`):

- Campaign 2 (`3f745623-…f065ca2dc28e`) settled with 2 confirmed commits totaling **106.59 kg**.
- Lot was relisted, Campaign 3 (`14a857f6-…7de43cead`) opened with a single **10 kg** pending commit.
- Post-migration `lot.committed_quantity_kg` reads **10**, not 116.59. ✓

## Database

Migration `20240101000026_lot_quantity_active_campaign_only.sql` is already applied to dev (`supabase migration up --local`) and prod (`supabase db push --linked`). The migration replaces the trigger function and runs a backfill query — no schema changes, no application changes required.

## Test plan

- [x] All 160 vitest tests pass.
- [x] Local migration applied.
- [x] Prod migration applied.
- [x] Verified live: `Andres Martinez Caturra Floral` lot's new campaign reads `committed_quantity_kg = 10` (just the new commit), not `116.59` (10 + prior settled cycle's 106.59).
- [ ] Optional: run a scripted full-cycle scenario (campaign → settle → relist → new commit → confirm `committed_quantity_kg` matches just the new commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)