### PR TITLE
fix(commitments): resolve hub-owner authority via commitments.hub_id

### DIFF
--- a/app/api/commitments/[id]/route.ts
+++ b/app/api/commitments/[id]/route.ts
@@ -24,7 +24,7 @@ export async function PATCH(
 
   const { data: commitment, error: fetchError } = await supabase
     .from("commitments")
-    .select("id, lot_id, buyer_id, picked_up_at")
+    .select("id, lot_id, buyer_id, hub_id, picked_up_at")
     .eq("id", id)
     .single();
 
@@ -38,24 +38,18 @@ export async function PATCH(
 
   // The caller is allowed if they are either:
   //   (a) the buyer who placed the commitment (self-pickup at hub), or
-  //   (b) the hub owner for the lot's hub (hub-side confirmation).
+  //   (b) the hub owner of the commitment's hub (hub-side confirmation).
+  // Resolve via commitments.hub_id, not lots.hub_id — the latter is frequently
+  // NULL since a lot can be campaigned at different hubs across cycles.
   let allowed = commitment.buyer_id === user.id;
 
-  if (!allowed) {
-    const { data: lot } = await supabase
-      .from("lots")
-      .select("hub_id")
-      .eq("id", commitment.lot_id)
+  if (!allowed && commitment.hub_id) {
+    const { data: hub } = await supabase
+      .from("hubs")
+      .select("owner_id")
+      .eq("id", commitment.hub_id)
       .single();
-
-    if (lot?.hub_id) {
-      const { data: hub } = await supabase
-        .from("hubs")
-        .select("owner_id")
-        .eq("id", lot.hub_id)
-        .single();
-      if (hub?.owner_id === user.id) allowed = true;
-    }
+    if (hub?.owner_id === user.id) allowed = true;
   }
 
   if (!allowed) {

--- a/supabase/migrations/20240101000027_commitments_hub_owner_via_commitment_hub_id.sql
+++ b/supabase/migrations/20240101000027_commitments_hub_owner_via_commitment_hub_id.sql
@@ -1,0 +1,31 @@
+-- Resolve hub-owner authority on commitments via commitments.hub_id directly,
+-- not via the lots → hubs join. lots.hub_id is unreliable (frequently NULL —
+-- it's only populated on lot creation when the seller picks a hub, but a lot
+-- can be campaigned at multiple hubs over its lifetime). The canonical
+-- per-cycle hub lives on commitments.hub_id (set when the commit is placed
+-- against a campaign at that hub).
+--
+-- Symptom this fixes: a hub owner gets 403 trying to PATCH a commitment
+-- (e.g. mark as picked up) on a lot whose lots.hub_id happens to be NULL.
+
+drop policy if exists "commitments_select_hub_owner" on public.commitments;
+create policy "commitments_select_hub_owner"
+  on public.commitments for select
+  using (
+    auth.uid() in (
+      select h.owner_id
+      from public.hubs h
+      where h.id = commitments.hub_id
+    )
+  );
+
+drop policy if exists "commitments_update_hub_owner" on public.commitments;
+create policy "commitments_update_hub_owner"
+  on public.commitments for update
+  using (
+    auth.uid() in (
+      select h.owner_id
+      from public.hubs h
+      where h.id = commitments.hub_id
+    )
+  );


### PR DESCRIPTION
## Summary

- Hub owner clicking **Mark as Picked Up** got a 403 Forbidden because both the route handler and the underlying RLS policies resolved the lot's hub by joining `lots → hubs ON l.hub_id = h.id`. `lots.hub_id` is unreliable — it's only set when a seller picks a hub at lot creation, and a lot can be campaigned at different hubs across cycles.
- Switches the auth resolution to use `commitments.hub_id` (the canonical per-cycle hub, populated when the buyer commits). Touches both the API route and the RLS policies (`commitments_select_hub_owner`, `commitments_update_hub_owner`).

## Why this manifested now

Andres Martinez Caturra Floral lot has `lots.hub_id = NULL`, so the join in both the route check and the RLS policy returned an empty set, blocking the hub owner. Geisha lot happens to have `lots.hub_id` populated, so it worked there — which is why this looked random.

## Database

Migration `20240101000027_commitments_hub_owner_via_commitment_hub_id.sql` already applied to dev (`supabase migration up --local`) and prod (`supabase db push --linked`). Pure RLS replacement — no schema change.

## Test plan

- [x] All 160 vitest tests pass.
- [x] Local migration applied.
- [x] Prod migration applied.
- [ ] On the deployed app, log in as the Austin Hub owner and click **Mark as Picked Up** on a confirmed Caturra Floral commitment — expect 200 + `picked_up_at` set.
- [ ] Same action on a Geisha commitment (the path that already worked) — expect 200, no regression.
- [ ] Buyer self-pickup path is unchanged — still allowed by `commitment.buyer_id === user.id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)