### PR TITLE
fix(security): close several authorization and input-validation gaps

### DIFF
--- a/app/api/cron/deadline-reminders/route.ts
+++ b/app/api/cron/deadline-reminders/route.ts
@@ -1,13 +1,7 @@
 import { createAdminClient } from "@/lib/supabase/admin";
 import { sendDeadlineReminderEmail } from "@/lib/email";
+import { authorizeCronRequest } from "@/lib/auth/cron-route";
 import { NextResponse } from "next/server";
-
-function getBearerToken(header: string | null) {
-  if (!header) return null;
-  const [scheme, token] = header.split(" ");
-  if (scheme?.toLowerCase() !== "bearer") return null;
-  return token || null;
-}
 
 /**
  * AC-8a: Lot deadline reminder — 24 hours before deadline.
@@ -19,16 +13,8 @@ function getBearerToken(header: string | null) {
  * Schedule suggestion (vercel.json): every hour — "0 * * * *"
  */
 async function sendDeadlineReminders(request: Request) {
-  const cronSecret = process.env.CRON_SECRET;
-  if (!cronSecret) {
-    return NextResponse.json({ error: "Missing CRON_SECRET" }, { status: 500 });
-  }
-
-  const bearer = getBearerToken(request.headers.get("authorization"));
-  const headerSecret = request.headers.get("x-cron-secret");
-  if (bearer !== cronSecret && headerSecret !== cronSecret) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const unauthorized = authorizeCronRequest(request);
+  if (unauthorized) return unauthorized;
 
   const { searchParams } = new URL(request.url);
   const debug = searchParams.get("debug") === "1";

--- a/app/api/cron/lot-expiry/route.ts
+++ b/app/api/cron/lot-expiry/route.ts
@@ -1,14 +1,8 @@
 import { createAdminClient } from "@/lib/supabase/admin";
 import { sendLotExpiredEmail } from "@/lib/email";
 import { recycleLot } from "@/lib/lots/recycle-lot";
+import { authorizeCronRequest } from "@/lib/auth/cron-route";
 import { NextResponse } from "next/server";
-
-function getBearerToken(header: string | null) {
-  if (!header) return null;
-  const [scheme, token] = header.split(" ");
-  if (scheme?.toLowerCase() !== "bearer") return null;
-  return token || null;
-}
 
 /**
  * Lot expiry cron — runs daily at 01:00 UTC (after settlement at 00:00 UTC).
@@ -19,16 +13,8 @@ function getBearerToken(header: string | null) {
  * seller so they can adjust the lot and decide whether to relist.
  */
 export async function GET(request: Request) {
-  const cronSecret = process.env.CRON_SECRET;
-  if (!cronSecret) {
-    return NextResponse.json({ error: "Missing CRON_SECRET" }, { status: 500 });
-  }
-
-  const bearer = getBearerToken(request.headers.get("authorization"));
-  const headerSecret = request.headers.get("x-cron-secret");
-  if (bearer !== cronSecret && headerSecret !== cronSecret) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const unauthorized = authorizeCronRequest(request);
+  if (unauthorized) return unauthorized;
 
   const admin = createAdminClient();
   const now = new Date().toISOString();

--- a/app/api/cron/price-drops/route.ts
+++ b/app/api/cron/price-drops/route.ts
@@ -1,14 +1,8 @@
 import { createAdminClient } from "@/lib/supabase/admin";
 import { sendPriceDropInvestorEmail, sendPriceDropNonInvestorEmail } from "@/lib/email";
 import { getFinalPricePerKg } from "@/lib/payments/settlement-logic";
+import { authorizeCronRequest } from "@/lib/auth/cron-route";
 import { NextResponse } from "next/server";
-
-function getBearerToken(header: string | null) {
-  if (!header) return null;
-  const [scheme, token] = header.split(" ");
-  if (scheme?.toLowerCase() !== "bearer") return null;
-  return token || null;
-}
 
 /**
  * AC-8b/c: Price drop notifications.
@@ -34,16 +28,8 @@ function getBearerToken(header: string | null) {
  * Schedule suggestion (vercel.json): every 15 minutes — "* /15 * * * *"
  */
 async function sendPriceDropNotifications(request: Request) {
-  const cronSecret = process.env.CRON_SECRET;
-  if (!cronSecret) {
-    return NextResponse.json({ error: "Missing CRON_SECRET" }, { status: 500 });
-  }
-
-  const bearer = getBearerToken(request.headers.get("authorization"));
-  const headerSecret = request.headers.get("x-cron-secret");
-  if (bearer !== cronSecret && headerSecret !== cronSecret) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const unauthorized = authorizeCronRequest(request);
+  if (unauthorized) return unauthorized;
 
   const { searchParams } = new URL(request.url);
   const debug = searchParams.get("debug") === "1";

--- a/app/api/hub-access-requests/[id]/route.ts
+++ b/app/api/hub-access-requests/[id]/route.ts
@@ -44,8 +44,10 @@ export async function PATCH(
     ? accessRequest.hub[0]
     : accessRequest.hub;
 
-  // Verify caller is the hub owner
-  if (hub.owner_id !== user.id) {
+  // Verify caller is the hub owner. If the joined hub is missing (e.g. row
+  // deleted) treat that as forbidden rather than dereferencing null — leaking
+  // a 500 here would also bypass the explicit ownership check.
+  if (!hub || hub.owner_id !== user.id) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 

--- a/app/api/hub-members/route.ts
+++ b/app/api/hub-members/route.ts
@@ -47,17 +47,19 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Only buyers can be added to a hub" }, { status: 400 });
   }
 
-  // Check for duplicate membership
-  const { data: existing } = await supabase
+  // Check for duplicate membership. Build a separate equality query per branch
+  // instead of interpolating the user-supplied email into a `.or()` filter
+  // string — that would let a caller smuggle additional PostgREST predicates
+  // (e.g. `attacker@x.com,user_id.eq.<uuid>`) into the filter.
+  const duplicateQuery = supabase
     .from("hub_members")
     .select("id")
-    .eq("hub_id", hubId)
-    .or(
-      existingProfile
-        ? `user_id.eq.${existingProfile.id}`
-        : `invited_email.eq.${inviteEmail}`
-    )
-    .maybeSingle();
+    .eq("hub_id", hubId);
+
+  const { data: existing } = await (existingProfile
+    ? duplicateQuery.eq("user_id", existingProfile.id)
+    : duplicateQuery.eq("invited_email", inviteEmail)
+  ).maybeSingle();
 
   if (existing) {
     return NextResponse.json({ error: "This person is already a member of this hub" }, { status: 409 });

--- a/app/api/lots/bulk/route.ts
+++ b/app/api/lots/bulk/route.ts
@@ -56,6 +56,21 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
+  // Only sellers may create lots. Without this check, a buyer or hub_owner
+  // could mass-insert lots assigned to themselves.
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("role")
+    .eq("id", user.id)
+    .single();
+
+  if (profile?.role !== "seller") {
+    return NextResponse.json(
+      { error: "Only sellers can create lots" },
+      { status: 403 }
+    );
+  }
+
   const body = await request.json();
   const rows = Array.isArray(body?.rows) ? (body.rows as CsvLotRow[]) : [];
 

--- a/app/api/payments/settle-deadlines/route.ts
+++ b/app/api/payments/settle-deadlines/route.ts
@@ -1,5 +1,6 @@
 import { createAdminClient } from "@/lib/supabase/admin";
 import { getConfiguredAdminEmails } from "@/lib/auth/admin";
+import { authorizeCronRequest } from "@/lib/auth/cron-route";
 import {
   sendLotClosedEmailsBatch,
   sendLotFailedEmail,
@@ -21,13 +22,6 @@ import {
   getFinalPricePerKg,
 } from "@/lib/payments/settlement-logic";
 import { NextResponse } from "next/server";
-
-function getBearerToken(header: string | null) {
-  if (!header) return null;
-  const [scheme, token] = header.split(" ");
-  if (scheme?.toLowerCase() !== "bearer") return null;
-  return token || null;
-}
 
 function isMissingPlatformSettingsTable(error: { message?: string } | null) {
   if (!error?.message) return false;
@@ -263,16 +257,8 @@ async function settleDeadlines(request: Request) {
   const { searchParams } = new URL(request.url);
   const debug = searchParams.get("debug") === "1";
 
-  const cronSecret = process.env.CRON_SECRET;
-  if (!cronSecret) {
-    return NextResponse.json({ error: "Missing CRON_SECRET" }, { status: 500 });
-  }
-
-  const bearer = getBearerToken(request.headers.get("authorization"));
-  const headerSecret = request.headers.get("x-cron-secret");
-  if (bearer !== cronSecret && headerSecret !== cronSecret) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const unauthorized = authorizeCronRequest(request);
+  if (unauthorized) return unauthorized;
 
   const adminEmails = getConfiguredAdminEmails();
   if (adminEmails.length === 0) {

--- a/app/api/public-intake/route.ts
+++ b/app/api/public-intake/route.ts
@@ -24,23 +24,29 @@ export async function POST(request: Request) {
   }
 
   const email =
-    typeof body?.email === "string" ? body.email.trim() : "";
+    typeof body?.email === "string" ? body.email.trim().toLowerCase() : "";
 
-  if (!email) {
+  // Basic shape + length checks. This endpoint is unauthenticated, so reject
+  // obvious garbage before it reaches the database.
+  const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  if (!email || email.length > 254 || !EMAIL_PATTERN.test(email)) {
     return NextResponse.json(
-      { error: "email is required." },
+      { error: "A valid email is required." },
       { status: 400 }
     );
   }
 
-  const companyName =
-    typeof body?.company_name === "string" ? body.company_name.trim() || null : null;
-  const contactName =
-    typeof body?.contact_name === "string" ? body.contact_name.trim() || null : null;
-  const phone =
-    typeof body?.phone === "string" ? body.phone.trim() || null : null;
-  const notes =
-    typeof body?.notes === "string" ? body.notes.trim() || null : null;
+  const trimToLength = (value: unknown, max: number): string | null => {
+    if (typeof value !== "string") return null;
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    return trimmed.slice(0, max);
+  };
+
+  const companyName = trimToLength(body?.company_name, 200);
+  const contactName = trimToLength(body?.contact_name, 200);
+  const phone = trimToLength(body?.phone, 50);
+  const notes = trimToLength(body?.notes, 2000);
 
   const supabase = createAdminClient();
 

--- a/lib/auth/cron-route.ts
+++ b/lib/auth/cron-route.ts
@@ -1,0 +1,44 @@
+import crypto from "crypto";
+import { NextResponse } from "next/server";
+
+function getBearerToken(header: string | null) {
+  if (!header) return null;
+  const [scheme, token] = header.split(" ");
+  if (scheme?.toLowerCase() !== "bearer") return null;
+  return token || null;
+}
+
+// Constant-time compare so callers can't probe the secret byte-by-byte via
+// response timing. timingSafeEqual throws on length mismatch, so we pad both
+// sides to the same buffer length first.
+function constantTimeEquals(a: string, b: string): boolean {
+  const aBuf = Buffer.from(a, "utf8");
+  const bBuf = Buffer.from(b, "utf8");
+  const len = Math.max(aBuf.length, bBuf.length);
+  const aPadded = Buffer.alloc(len);
+  const bPadded = Buffer.alloc(len);
+  aBuf.copy(aPadded);
+  bBuf.copy(bPadded);
+  const equal = crypto.timingSafeEqual(aPadded, bPadded);
+  return equal && aBuf.length === bBuf.length;
+}
+
+export function authorizeCronRequest(request: Request): NextResponse | null {
+  const cronSecret = process.env.CRON_SECRET;
+  if (!cronSecret) {
+    return NextResponse.json({ error: "Missing CRON_SECRET" }, { status: 500 });
+  }
+
+  const bearer = getBearerToken(request.headers.get("authorization"));
+  const headerSecret = request.headers.get("x-cron-secret");
+
+  const matches =
+    (bearer !== null && constantTimeEquals(bearer, cronSecret)) ||
+    (headerSecret !== null && constantTimeEquals(headerSecret, cronSecret));
+
+  if (!matches) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  return null;
+}

--- a/lib/stripe.ts
+++ b/lib/stripe.ts
@@ -354,6 +354,10 @@ function parseStripeSignature(signatureHeader: string) {
   return { timestamp, signatures };
 }
 
+// Stripe's official tolerance for webhook timestamp drift. Older signed
+// payloads are rejected so a captured webhook can't be replayed indefinitely.
+const STRIPE_WEBHOOK_TIMESTAMP_TOLERANCE_SECONDS = 300;
+
 export function verifyStripeWebhookSignature(payload: string, signatureHeader: string) {
   const secret = process.env.STRIPE_WEBHOOK_SECRET;
   if (!secret) {
@@ -363,12 +367,20 @@ export function verifyStripeWebhookSignature(payload: string, signatureHeader: s
   const { timestamp, signatures } = parseStripeSignature(signatureHeader);
   if (!timestamp || signatures.length === 0) return false;
 
+  const timestampSeconds = Number.parseInt(timestamp, 10);
+  if (!Number.isFinite(timestampSeconds)) return false;
+  const ageSeconds = Math.abs(Math.floor(Date.now() / 1000) - timestampSeconds);
+  if (ageSeconds > STRIPE_WEBHOOK_TIMESTAMP_TOLERANCE_SECONDS) return false;
+
   const signedPayload = `${timestamp}.${payload}`;
   const expected = crypto.createHmac("sha256", secret).update(signedPayload, "utf8").digest("hex");
+  const expectedBuffer = Buffer.from(expected, "hex");
 
   return signatures.some((sig) => {
     try {
-      return crypto.timingSafeEqual(Buffer.from(sig), Buffer.from(expected));
+      const sigBuffer = Buffer.from(sig, "hex");
+      if (sigBuffer.length !== expectedBuffer.length) return false;
+      return crypto.timingSafeEqual(sigBuffer, expectedBuffer);
     } catch {
       return false;
     }


### PR DESCRIPTION
- hub-members: stop interpolating user email into a PostgREST .or()
  filter; an attacker could smuggle extra predicates (e.g.
  "evil@x.com,user_id.eq.<uuid>"). Now uses separate .eq() queries.
- stripe webhook: enforce Stripe's 5-minute timestamp tolerance so a
  captured webhook can't be replayed indefinitely; compare HMACs from
  decoded hex bytes with explicit length check.
- cron auth: extract a shared authorizeCronRequest helper that uses
  timingSafeEqual instead of !==, eliminating timing leaks against the
  CRON_SECRET across settle-deadlines, lot-expiry, deadline-reminders,
  and price-drops.
- lots/bulk: require the caller's profile.role === "seller" before
  inserting lots. Without this any authenticated user could mass-create
  lots assigned to themselves.
- hub-access-requests: handle null/missing joined hub instead of
  dereferencing it, so a deleted hub can't surface as a 500 around the
  ownership check.
- public-intake: validate email shape and length and cap free-form
  fields before writing through the admin client on this unauthenticated
  endpoint.