### PR TITLE
fix(commitments): hide cancelled commitments from buyer page

### DIFF
--- a/app/dashboard/buyer/commitments/page.tsx
+++ b/app/dashboard/buyer/commitments/page.tsx
@@ -105,6 +105,7 @@ export default async function BuyerCommitmentsPage({
     )
     .eq("buyer_id", user.id)
     .not("stripe_payment_intent_id", "is", null)
+    .neq("status", "cancelled")
     .order("created_at", { ascending: false });
 
   const items = (commitments || []) as Commitment[];


### PR DESCRIPTION
## Summary

A buyer reported seeing a phantom **"Min Not Met dated 5/1"** card on their commitments page for the *Andres Martinez Caturra Floral* lot, alongside the legitimate in-motion card from the same lot's most recent successful campaign.

### Root cause

The lot had three campaigns:

| Campaign | Status | Buyer's commitments |
|---|---|---|
| `8fd52321…` | **failed** (4/26) | 2 cancelled (refunded) |
| `3f745623…` | settled (4/29) | 2 confirmed |
| `14a857f6…` | settled (5/1) | 3 confirmed |

The page query at `app/dashboard/buyer/commitments/page.tsx` filtered `stripe_payment_intent_id IS NOT NULL` but did **not** filter `status = 'cancelled'`. After `finalize_campaign(..., 'failed')` ran, the failed-campaign commitments were left as `status='cancelled'` — and one of them retained its PI, leaking through and rendering an entire "Min Not Met" card for a campaign the buyer was already refunded for. The card was misdated to 5/1 because `closedDateOf` falls back to `lot.settlement_processed_at`, which had been overwritten by the *most recent* (successful) campaign's settle-time.

This was also internally inconsistent: the failed campaign's other cancelled commitment had a `null` PI and was already hidden, so only half the failed group was surfacing.

### Fix

Add `.neq("status", "cancelled")` to the buyer commitments query. After this:
- All commitments under a fully-failed/cancelled campaign drop out at the query level — the entire group disappears.
- Successful campaigns (`status='confirmed'`) are unaffected.
- Per-campaign grouping (one card per campaign instance) is unchanged — `groupKey = c.campaign_id` still batches every confirmed commitment into a single card per campaign, as intended.
- Aligns with `derivePortfolioStats` which already excludes cancelled commitments from financial totals.

## Test plan

- [ ] Sign in as the affected buyer and verify the "Min Not Met dated 5/1" card no longer renders for *Andres Martinez Caturra Floral*.
- [ ] Verify the In Motion card for campaign `14a857f6…` still shows all 3 confirmed commitments batched as one card.
- [ ] Verify the Closed/Picked Up card for campaign `3f745623…` still shows both commitments batched as one card.
- [ ] Spot-check another buyer who has only successful commitments — no regressions.
- [ ] Spot-check a buyer with only cancelled/refunded commitments — page renders empty state, not stale failed cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)