### PR TITLE
fix(commitments): restore Min-Not-Met cards for standalone failed campaigns

### DIFF
--- a/app/dashboard/buyer/commitments/page.tsx
+++ b/app/dashboard/buyer/commitments/page.tsx
@@ -105,7 +105,6 @@ export default async function BuyerCommitmentsPage({
     )
     .eq("buyer_id", user.id)
     .not("stripe_payment_intent_id", "is", null)
-    .neq("status", "cancelled")
     .order("created_at", { ascending: false });
 
   const items = (commitments || []) as Commitment[];
@@ -209,7 +208,21 @@ export default async function BuyerCommitmentsPage({
     }
   }
 
-  const groups = Array.from(grouped.values());
+  // A "live" group has at least one non-cancelled commitment. We use this to
+  // drop redundant Min-Not-Met cards when a later campaign on the same lot
+  // succeeded — but keep them when the failed campaign is the only thing the
+  // buyer has on that lot (so they still see the refund in their history).
+  const lotsWithLiveGroup = new Set<string>();
+  for (const g of grouped.values()) {
+    if (g.commitments.some((c) => c.status !== "cancelled")) {
+      lotsWithLiveGroup.add(g.lotId);
+    }
+  }
+
+  const groups = Array.from(grouped.values()).filter((g) => {
+    const allCancelled = g.commitments.every((c) => c.status === "cancelled");
+    return !(allCancelled && lotsWithLiveGroup.has(g.lotId));
+  });
   const buckets = bucketByLifecycle(groups);
   const stats = derivePortfolioStats(groups, addPlatformFee);
 


### PR DESCRIPTION
## Summary

Follow-up to #55. The previous fix dropped **every** cancelled commitment at the query level, which also hid legitimate "Min Not Met" cards on lots whose only campaign failed (the buyer wants those visible as refund history).

This PR moves the filter from the query to a post-grouping step that drops a fully-cancelled group **only when the same lot has another group with non-cancelled commitments**.

### Behavior table

| Lot scenario | Outcome |
|---|---|
| Failed campaign + later successful campaign on same lot | Failed group dropped (the original duplicate-card bug), success group rendered |
| Lot whose only campaign failed | Min-Not-Met card **kept** so buyer sees the refund |
| Lot with two failed campaigns, no success | Both Min-Not-Met cards kept |
| Active campaign with one cancelled + others confirmed | Group kept; cancelled commitments still flow through (existing behavior of `derivePortfolioStats` already excludes them from totals) |

### Changes

- `app/dashboard/buyer/commitments/page.tsx`
  - Reverted the `.neq("status", "cancelled")` query filter from #55
  - Added a `lotsWithLiveGroup` set computed after grouping
  - Filter groups: drop when `every(commitments).status === 'cancelled'` AND the lot is in `lotsWithLiveGroup`

## Test plan

- [ ] Buyer with a lot that had a failed-then-successful campaign sees only the successful card (no phantom Min Not Met)
- [ ] Buyer whose only commitment was to a failed campaign still sees the Min Not Met card
- [ ] Buyer with a campaign that has mixed cancelled/confirmed commitments still sees the active card
- [ ] Empty-state rendering (buyer with no commitments at all) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)