### PR TITLE
fix(shipments): remove ship/deliver actions from hub owner page

### DIFF
--- a/components/shipment-status-buttons.tsx
+++ b/components/shipment-status-buttons.tsx
@@ -6,9 +6,7 @@ import { useRouter } from "next/navigation";
 import Link from "next/link";
 
 const nextStatus: Record<string, { label: string; status: string }> = {
-  pending: { label: "Mark Shipped", status: "in_transit" },
   in_transit: { label: "Mark Received", status: "at_hub" },
-  out_for_delivery: { label: "Mark Delivered", status: "delivered" },
 };
 
 export function ShipmentStatusButtons({


### PR DESCRIPTION
Hub owners only receive shipments — the ShipmentStatusButtons component
(used solely on the hub owner shipments page) was rendering "Mark Shipped"
and "Mark Delivered" buttons. Sellers handle shipping via SellerShipmentForm
on their own page; hub owners should only see "Mark Received" for in_transit
shipments.