### PR TITLE
feat(commitments): per-lot drawers on the buyer commitments page

### DIFF
--- a/app/dashboard/buyer/commitments/page.tsx
+++ b/app/dashboard/buyer/commitments/page.tsx
@@ -13,9 +13,7 @@ import {
 } from "@/components/buyer-commitments/bucket-by-lifecycle";
 import { PortfolioStrip } from "@/components/buyer-commitments/portfolio-strip";
 import { NeedsAttentionCard } from "@/components/buyer-commitments/needs-attention-card";
-import { RaisingLotCard } from "@/components/buyer-commitments/raising-lot-card";
-import { InMotionLotCard } from "@/components/buyer-commitments/in-motion-lot-card";
-import { ClosedLotsTable } from "@/components/buyer-commitments/closed-lots-table";
+import { BuyerCommitmentsBoard } from "@/components/buyer-commitments/buyer-commitments-board";
 
 async function syncPendingSetupCommitments(
   supabase: Awaited<ReturnType<typeof createClient>>,
@@ -266,54 +264,12 @@ export default async function BuyerCommitmentsPage({
         </section>
       )}
 
-      {buckets.raising.length > 0 && (
-        <section className="mb-9">
-          <SectionHead
-            title="Still Raising"
-            count={buckets.raising.length}
-            accent="tomato"
-          />
-          <div className="mt-4 flex flex-col gap-4">
-            {buckets.raising.map((g) => (
-              <RaisingLotCard
-                key={g.groupKey}
-                group={g}
-                pricingTiers={tiersByLotId[g.lotId] || []}
-              />
-            ))}
-          </div>
-        </section>
-      )}
-
-      {buckets.inMotion.length > 0 && (
-        <section className="mb-9">
-          <SectionHead
-            title="In Motion"
-            count={buckets.inMotion.length}
-            accent="sky"
-            note={`${stats.landingKg.toLocaleString()} lb landing soon`}
-          />
-          <div className="mt-4 flex flex-col gap-3.5">
-            {buckets.inMotion.map((g) => (
-              <InMotionLotCard key={g.groupKey} group={g} />
-            ))}
-          </div>
-        </section>
-      )}
-
-      {buckets.closed.length > 0 && (
-        <section>
-          <SectionHead
-            title="Closed Lots"
-            count={buckets.closed.length}
-            accent="fog"
-            note={`${new Intl.NumberFormat("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 0 }).format(stats.ytdSpend)} YTD`}
-          />
-          <div className="mt-4">
-            <ClosedLotsTable groups={buckets.closed} />
-          </div>
-        </section>
-      )}
+      <BuyerCommitmentsBoard
+        buckets={buckets}
+        tiersByLotId={tiersByLotId}
+        landingKg={stats.landingKg}
+        ytdSpend={stats.ytdSpend}
+      />
     </div>
   );
 }

--- a/components/buyer-commitments/__tests__/bucket-by-lifecycle.test.ts
+++ b/components/buyer-commitments/__tests__/bucket-by-lifecycle.test.ts
@@ -51,6 +51,12 @@ const mkCommit = (over: Partial<Commitment> = {}): Commitment => {
     notes: null,
     picked_up_at: null,
     picked_up_by: null,
+    refund_status: "not_refunded",
+    refunded_amount_cents: 0,
+    refunded_at: null,
+    refunded_by: null,
+    last_refund_id: null,
+    refund_reason: null,
     created_at: dayOffset(-30),
     updated_at: new Date().toISOString(),
   };

--- a/components/buyer-commitments/__tests__/buyer-commitments-board.test.tsx
+++ b/components/buyer-commitments/__tests__/buyer-commitments-board.test.tsx
@@ -1,0 +1,220 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React, { useState } from "react";
+
+// Mock @merninos/ui Drawer parts to avoid the npm-link / dupe-React symlink
+// issue in unit tests. We're testing the wrapper's state management; Radix
+// Dialog's own behavior is verified via the manual cross-browser sweep in
+// Stage 4. The mock preserves the contract: Drawer fires onOpenChange(false)
+// when the user dispatches a Dialog-style close (Esc keydown on the body).
+vi.mock("@merninos/ui", () => {
+  const React = require("react") as typeof import("react");
+  const Drawer = ({
+    open,
+    onOpenChange,
+    children,
+  }: {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    children: React.ReactNode;
+  }) => {
+    React.useEffect(() => {
+      if (!open) return;
+      const handler = (e: KeyboardEvent) => {
+        if (e.key === "Escape") onOpenChange(false);
+      };
+      document.addEventListener("keydown", handler);
+      return () => document.removeEventListener("keydown", handler);
+    }, [open, onOpenChange]);
+    if (!open) return null;
+    return <div role="dialog">{children}</div>;
+  };
+  const Passthrough = ({ children, ...rest }: any) => <div {...rest}>{children}</div>;
+  return {
+    Drawer,
+    DrawerContent: Passthrough,
+    DrawerHeader: Passthrough,
+    DrawerTitle: ({ children }: any) => <h2>{children}</h2>,
+    DrawerDescription: ({ children }: any) => <p>{children}</p>,
+    DrawerBody: Passthrough,
+    DrawerClose: Passthrough,
+    DrawerFooter: Passthrough,
+    DrawerOverlay: Passthrough,
+    DrawerPortal: Passthrough,
+    DrawerTrigger: Passthrough,
+  };
+});
+
+import { BuyerCommitmentsBoard } from "@/components/buyer-commitments/buyer-commitments-board";
+import type {
+  BucketedGroups,
+  CommitmentGroup,
+} from "@/components/buyer-commitments/bucket-by-lifecycle";
+
+// The cards are heavy — stub them so this test stays scoped to the wrapper.
+vi.mock("@/components/buyer-commitments/raising-lot-card", () => ({
+  RaisingLotCard: ({ group }: { group: CommitmentGroup }) => (
+    <div data-testid={`raising-card-${group.groupKey}`}>{group.lot?.title}</div>
+  ),
+}));
+vi.mock("@/components/buyer-commitments/in-motion-lot-card", () => ({
+  InMotionLotCard: ({ group }: { group: CommitmentGroup }) => (
+    <div data-testid={`in-motion-card-${group.groupKey}`}>{group.lot?.title}</div>
+  ),
+}));
+vi.mock("@/components/buyer-commitments/closed-lots-table", () => ({
+  ClosedLotsTable: ({ groups }: { groups: CommitmentGroup[] }) => (
+    <div data-testid="closed-lots-table">
+      {groups.map((g) => (
+        <div key={g.groupKey} data-testid={`closed-row-${g.groupKey}`}>
+          {g.lot?.title}
+        </div>
+      ))}
+    </div>
+  ),
+}));
+
+function makeGroup(overrides: Partial<CommitmentGroup>): CommitmentGroup {
+  return {
+    groupKey: "default-key",
+    lotId: "lot-1",
+    campaignId: "camp-1",
+    hubId: null,
+    lot: {
+      id: "lot-1",
+      seller_id: "s-1",
+      title: "Default Lot",
+      origin_country: "Ethiopia",
+      region: "Yirgacheffe",
+      farm: null,
+      variety: null,
+      process: null,
+      altitude_min: null,
+      altitude_max: null,
+      crop_year: null,
+      score: null,
+      description: null,
+      total_quantity_kg: 1000,
+      committed_quantity_kg: 500,
+      min_commitment_kg: 600,
+      price_per_kg: 10,
+      currency: "USD",
+      status: "active",
+      commitment_deadline: null,
+      expiry_date: null,
+      settlement_status: "pending",
+      settlement_processed_at: null,
+      images: [],
+      flavor_notes: [],
+      certifications: [],
+      created_at: "2026-04-01T00:00:00Z",
+      updated_at: "2026-04-01T00:00:00Z",
+    } as any,
+    campaign: {
+      id: "camp-1",
+      status: "active",
+      deadline: new Date(Date.now() + 5 * 86_400_000).toISOString(),
+      settled_at: null,
+    },
+    commitments: [],
+    shipment: null,
+    ...overrides,
+  };
+}
+
+function makeBuckets(overrides: Partial<BucketedGroups> = {}): BucketedGroups {
+  return {
+    needsAttention: [],
+    raising: [],
+    inMotion: [],
+    closed: [],
+    ...overrides,
+  };
+}
+
+describe("BuyerCommitmentsBoard", () => {
+  it("renders each section when its bucket has groups", () => {
+    const buckets = makeBuckets({
+      raising: [makeGroup({ groupKey: "g-r", lotId: "lot-r" })],
+      inMotion: [],
+      closed: [],
+    });
+    render(
+      <BuyerCommitmentsBoard
+        buckets={buckets}
+        tiersByLotId={{}}
+        landingKg={0}
+        ytdSpend={0}
+      />
+    );
+    expect(screen.getByTestId("section-raising")).toBeInTheDocument();
+    expect(screen.queryByTestId("section-in-motion")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("section-closed")).not.toBeInTheDocument();
+  });
+
+  it("does not render the drawer when no group is open (controlled mode)", () => {
+    render(
+      <BuyerCommitmentsBoard
+        buckets={makeBuckets({ raising: [makeGroup({ groupKey: "g-1" })] })}
+        tiersByLotId={{}}
+        landingKg={0}
+        ytdSpend={0}
+        openGroupKey={null}
+        onOpenGroupKeyChange={() => {}}
+      />
+    );
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("mounts the drawer with the correct group when openGroupKey is set", () => {
+    const group = makeGroup({
+      groupKey: "g-1",
+      lot: { ...(makeGroup({}).lot as any), title: "Yirgacheffe Spring 2026" },
+    });
+    render(
+      <BuyerCommitmentsBoard
+        buckets={makeBuckets({ raising: [group] })}
+        tiersByLotId={{}}
+        landingKg={0}
+        ytdSpend={0}
+        openGroupKey="g-1"
+        onOpenGroupKeyChange={() => {}}
+      />
+    );
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toBeInTheDocument();
+    expect(dialog.textContent).toContain("Yirgacheffe Spring 2026");
+    // Raising stage → Raising body placeholder
+    expect(screen.getByTestId("drawer-body-raising")).toBeInTheDocument();
+  });
+
+  it("notifies the parent when the drawer is closed (controlled mode)", async () => {
+    const onChange = vi.fn();
+    function Harness() {
+      const [key, setKey] = useState<string | null>("g-1");
+      return (
+        <BuyerCommitmentsBoard
+          buckets={makeBuckets({ raising: [makeGroup({ groupKey: "g-1" })] })}
+          tiersByLotId={{}}
+          landingKg={0}
+          ytdSpend={0}
+          openGroupKey={key}
+          onOpenGroupKeyChange={(k) => {
+            onChange(k);
+            setKey(k);
+          }}
+        />
+      );
+    }
+    render(<Harness />);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    // Simulate user pressing Escape — Radix Dialog's standard close behavior.
+    const { fireEvent } = await import("@testing-library/react");
+    fireEvent.keyDown(document.activeElement || document.body, { key: "Escape" });
+
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+});

--- a/components/buyer-commitments/__tests__/buyer-commitments-board.test.tsx
+++ b/components/buyer-commitments/__tests__/buyer-commitments-board.test.tsx
@@ -44,6 +44,7 @@ vi.mock("@merninos/ui", () => {
     DrawerOverlay: Passthrough,
     DrawerPortal: Passthrough,
     DrawerTrigger: Passthrough,
+    Button: ({ children, asChild, ...rest }: any) => <div {...rest}>{children}</div>,
   };
 });
 

--- a/components/buyer-commitments/__tests__/buyer-commitments-board.test.tsx
+++ b/components/buyer-commitments/__tests__/buyer-commitments-board.test.tsx
@@ -4,6 +4,10 @@ import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import React, { useState } from "react";
 
+vi.mock("@/components/unit-provider", () => ({
+  useUnitPreference: () => ({ unit: "kg", setUnit: () => {} }),
+}));
+
 // Mock @merninos/ui Drawer parts to avoid the npm-link / dupe-React symlink
 // issue in unit tests. We're testing the wrapper's state management; Radix
 // Dialog's own behavior is verified via the manual cross-browser sweep in

--- a/components/buyer-commitments/buyer-commitments-board.tsx
+++ b/components/buyer-commitments/buyer-commitments-board.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+import { RaisingLotCard } from "@/components/buyer-commitments/raising-lot-card";
+import { InMotionLotCard } from "@/components/buyer-commitments/in-motion-lot-card";
+import { ClosedLotsTable } from "@/components/buyer-commitments/closed-lots-table";
+import { CommitmentDrawer } from "@/components/buyer-commitments/commitment-drawer";
+import type { BucketedGroups, CommitmentGroup } from "@/components/buyer-commitments/bucket-by-lifecycle";
+import type { PricingTier } from "@/lib/types";
+
+export interface BuyerCommitmentsBoardProps {
+  buckets: BucketedGroups;
+  tiersByLotId: Record<string, Pick<PricingTier, "min_quantity_kg" | "price_per_kg">[]>;
+  landingKg: number;
+  ytdSpend: number;
+  /**
+   * Controlled-mode props (optional). When both are provided, the parent owns
+   * drawer state. When omitted, the board manages its own internal state.
+   * Tests use the controlled form to synthetically open the drawer before
+   * Stage 4 wires the chevrons.
+   */
+  openGroupKey?: string | null;
+  onOpenGroupKeyChange?: (key: string | null) => void;
+}
+
+const sectionAccent = {
+  tomato: "bg-tomato",
+  sky:    "bg-sky",
+  fog:    "bg-fog",
+} as const;
+type SectionAccent = keyof typeof sectionAccent;
+
+const fmtMoney = (n: number) =>
+  new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  }).format(n || 0);
+
+export function BuyerCommitmentsBoard({
+  buckets,
+  tiersByLotId,
+  landingKg,
+  ytdSpend,
+  openGroupKey: controlledKey,
+  onOpenGroupKeyChange,
+}: BuyerCommitmentsBoardProps) {
+  const [internalKey, setInternalKey] = useState<string | null>(null);
+  const isControlled = controlledKey !== undefined;
+  const openGroupKey = isControlled ? controlledKey : internalKey;
+  const setOpenGroupKey = (key: string | null) => {
+    if (isControlled) {
+      onOpenGroupKeyChange?.(key);
+    } else {
+      setInternalKey(key);
+    }
+  };
+
+  // Map of groupKey → ref of the originating trigger element. Stage 4 will
+  // write into this map from each card's chevron via an `onSelect`-and-`triggerRef`
+  // pattern. For now it's wired so that closing the drawer can restore focus.
+  const triggerRefs = useRef<Map<string, HTMLElement | null>>(new Map());
+
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) {
+        const key = openGroupKey;
+        setOpenGroupKey(null);
+        // Restore focus on the next tick so the trigger is in the DOM
+        // when we call focus() on it.
+        if (key) {
+          const el = triggerRefs.current.get(key);
+          if (el && typeof el.focus === "function") {
+            queueMicrotask(() => el.focus());
+          }
+        }
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [openGroupKey, isControlled]
+  );
+
+  const findGroup = (key: string | null): CommitmentGroup | null => {
+    if (!key) return null;
+    for (const list of [buckets.raising, buckets.inMotion, buckets.closed]) {
+      const found = list.find((g) => g.groupKey === key);
+      if (found) return found;
+    }
+    return null;
+  };
+
+  const openGroup = findGroup(openGroupKey);
+  const openTiers = openGroup
+    ? (tiersByLotId[openGroup.lotId] || []).map((t) => ({
+        id: `${openGroup.lotId}-${t.min_quantity_kg}`,
+        lot_id: openGroup.lotId,
+        min_quantity_kg: t.min_quantity_kg,
+        price_per_kg: t.price_per_kg,
+        created_at: "",
+      }))
+    : [];
+
+  return (
+    <>
+      {buckets.raising.length > 0 && (
+        <section className="mb-9" data-testid="section-raising">
+          <SectionHead title="Still Raising" count={buckets.raising.length} accent="tomato" />
+          <div className="mt-4 flex flex-col gap-4">
+            {buckets.raising.map((g) => (
+              <RaisingLotCard
+                key={g.groupKey}
+                group={g}
+                pricingTiers={tiersByLotId[g.lotId] || []}
+              />
+            ))}
+          </div>
+        </section>
+      )}
+
+      {buckets.inMotion.length > 0 && (
+        <section className="mb-9" data-testid="section-in-motion">
+          <SectionHead
+            title="In Motion"
+            count={buckets.inMotion.length}
+            accent="sky"
+            note={`${landingKg.toLocaleString()} lb landing soon`}
+          />
+          <div className="mt-4 flex flex-col gap-3.5">
+            {buckets.inMotion.map((g) => (
+              <InMotionLotCard key={g.groupKey} group={g} />
+            ))}
+          </div>
+        </section>
+      )}
+
+      {buckets.closed.length > 0 && (
+        <section data-testid="section-closed">
+          <SectionHead
+            title="Closed Lots"
+            count={buckets.closed.length}
+            accent="fog"
+            note={`${fmtMoney(ytdSpend)} YTD`}
+          />
+          <div className="mt-4">
+            <ClosedLotsTable groups={buckets.closed} />
+          </div>
+        </section>
+      )}
+
+      <CommitmentDrawer
+        open={!!openGroupKey}
+        onOpenChange={handleOpenChange}
+        group={openGroup}
+        tiers={openTiers}
+      />
+    </>
+  );
+}
+
+function SectionHead({
+  title,
+  count,
+  accent,
+  note,
+}: {
+  title: string;
+  count: number;
+  accent: SectionAccent;
+  note?: string;
+}) {
+  return (
+    <div className="flex flex-wrap items-baseline gap-x-2.5 gap-y-1 border-b-2 border-espresso/80 pb-2">
+      <span
+        className={`mb-px inline-block h-2.5 w-2.5 self-center rounded-full border-2 border-espresso ${sectionAccent[accent]}`}
+        aria-hidden
+      />
+      <h2 className="m-0 font-headline text-[18px] font-bold leading-none text-espresso">{title}</h2>
+      <span className="font-headline text-[14px] font-bold leading-none text-espresso/45">
+        {count}
+      </span>
+      {note && (
+        <span className="ml-auto font-headline text-[11px] font-bold lowercase text-espresso/55">
+          {note}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/components/buyer-commitments/buyer-commitments-board.tsx
+++ b/components/buyer-commitments/buyer-commitments-board.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useRef, useState, type ReactNode } from "react";
 import { RaisingLotCard } from "@/components/buyer-commitments/raising-lot-card";
 import { InMotionLotCard } from "@/components/buyer-commitments/in-motion-lot-card";
 import { ClosedLotsTable } from "@/components/buyer-commitments/closed-lots-table";
 import { CommitmentDrawer } from "@/components/buyer-commitments/commitment-drawer";
+import { UnitWeightText } from "@/components/unit-value";
 import type { BucketedGroups, CommitmentGroup } from "@/components/buyer-commitments/bucket-by-lifecycle";
 import type { PricingTier } from "@/lib/types";
 
@@ -111,6 +112,11 @@ export function BuyerCommitmentsBoard({
                 key={g.groupKey}
                 group={g}
                 pricingTiers={tiersByLotId[g.lotId] || []}
+                onSelect={() => setOpenGroupKey(g.groupKey)}
+                triggerRef={(el) => {
+                  if (el) triggerRefs.current.set(g.groupKey, el);
+                  else triggerRefs.current.delete(g.groupKey);
+                }}
               />
             ))}
           </div>
@@ -123,11 +129,23 @@ export function BuyerCommitmentsBoard({
             title="In Motion"
             count={buckets.inMotion.length}
             accent="sky"
-            note={`${landingKg.toLocaleString()} lb landing soon`}
+            note={
+              <>
+                <UnitWeightText kg={landingKg} maximumFractionDigits={0} /> landing soon
+              </>
+            }
           />
           <div className="mt-4 flex flex-col gap-3.5">
             {buckets.inMotion.map((g) => (
-              <InMotionLotCard key={g.groupKey} group={g} />
+              <InMotionLotCard
+                key={g.groupKey}
+                group={g}
+                onSelect={() => setOpenGroupKey(g.groupKey)}
+                triggerRef={(el) => {
+                  if (el) triggerRefs.current.set(g.groupKey, el);
+                  else triggerRefs.current.delete(g.groupKey);
+                }}
+              />
             ))}
           </div>
         </section>
@@ -142,7 +160,14 @@ export function BuyerCommitmentsBoard({
             note={`${fmtMoney(ytdSpend)} YTD`}
           />
           <div className="mt-4">
-            <ClosedLotsTable groups={buckets.closed} />
+            <ClosedLotsTable
+              groups={buckets.closed}
+              onSelect={(key) => setOpenGroupKey(key)}
+              registerTriggerRef={(key, el) => {
+                if (el) triggerRefs.current.set(key, el);
+                else triggerRefs.current.delete(key);
+              }}
+            />
           </div>
         </section>
       )}
@@ -166,7 +191,7 @@ function SectionHead({
   title: string;
   count: number;
   accent: SectionAccent;
-  note?: string;
+  note?: ReactNode;
 }) {
   return (
     <div className="flex flex-wrap items-baseline gap-x-2.5 gap-y-1 border-b-2 border-espresso/80 pb-2">

--- a/components/buyer-commitments/closed-lots-table.tsx
+++ b/components/buyer-commitments/closed-lots-table.tsx
@@ -1,9 +1,12 @@
 import Link from "next/link";
+import { ChevronRight } from "lucide-react";
 import { UnitPriceText, UnitWeightText } from "@/components/unit-value";
 import { stageOfGroup, STAGE_META, type CommitmentGroup, type StageColor } from "./bucket-by-lifecycle";
 
 export interface ClosedLotsTableProps {
   groups: CommitmentGroup[];
+  onSelect?: (groupKey: string) => void;
+  registerTriggerRef?: (groupKey: string, el: HTMLButtonElement | null) => void;
 }
 
 const fmtMoney = (n: number) =>
@@ -53,7 +56,7 @@ function buildRow(g: CommitmentGroup) {
   return { stage, securedKg, avg, totalCell, date };
 }
 
-export function ClosedLotsTable({ groups }: ClosedLotsTableProps) {
+export function ClosedLotsTable({ groups, onSelect, registerTriggerRef }: ClosedLotsTableProps) {
   return (
     <>
       {/* Phone: stacked card list (the 6-col table won't fit) */}
@@ -67,12 +70,25 @@ export function ClosedLotsTable({ groups }: ClosedLotsTableProps) {
             >
               <div className="flex items-start justify-between gap-3">
                 <div className="min-w-0 flex-1">
-                  <Link
-                    href={`/dashboard/buyer/lot/${g.lotId}${g.hubId ? `?hub=${g.hubId}` : ""}`}
-                    className="font-headline text-[16px] font-bold leading-tight text-espresso hover:text-tomato"
-                  >
-                    {g.lot?.title || "Unknown lot"}
-                  </Link>
+                  {onSelect ? (
+                    <button
+                      ref={(el) => registerTriggerRef?.(g.groupKey, el)}
+                      type="button"
+                      onClick={() => onSelect(g.groupKey)}
+                      data-testid={`closed-card-trigger-${g.groupKey}`}
+                      className="inline-flex items-center gap-1.5 text-left font-headline text-[16px] font-bold leading-tight text-espresso transition-colors hover:text-tomato focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-tomato focus-visible:ring-offset-2 focus-visible:ring-offset-chalk rounded-sm"
+                    >
+                      {g.lot?.title || "Unknown lot"}
+                      <ChevronRight className="h-3.5 w-3.5 shrink-0 text-espresso/55" strokeWidth={2.5} />
+                    </button>
+                  ) : (
+                    <Link
+                      href={`/dashboard/buyer/lot/${g.lotId}${g.hubId ? `?hub=${g.hubId}` : ""}`}
+                      className="font-headline text-[16px] font-bold leading-tight text-espresso hover:text-tomato"
+                    >
+                      {g.lot?.title || "Unknown lot"}
+                    </Link>
+                  )}
                   <div className="mt-0.5 font-headline text-[11px] text-espresso/60">
                     {[g.lot?.region, g.lot?.origin_country].filter(Boolean).join(" · ")}
                   </div>
@@ -127,12 +143,25 @@ export function ClosedLotsTable({ groups }: ClosedLotsTableProps) {
               }`}
             >
               <div>
-                <Link
-                  href={`/dashboard/buyer/lot/${g.lotId}${g.hubId ? `?hub=${g.hubId}` : ""}`}
-                  className="font-headline text-[15px] font-bold leading-tight text-espresso transition-colors hover:text-tomato"
-                >
-                  {g.lot?.title || "Unknown lot"}
-                </Link>
+                {onSelect ? (
+                  <button
+                    ref={(el) => registerTriggerRef?.(g.groupKey, el)}
+                    type="button"
+                    onClick={() => onSelect(g.groupKey)}
+                    data-testid={`closed-row-trigger-${g.groupKey}`}
+                    className="inline-flex items-center gap-1.5 text-left font-headline text-[15px] font-bold leading-tight text-espresso transition-colors hover:text-tomato focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-tomato focus-visible:ring-offset-2 focus-visible:ring-offset-chalk rounded-sm"
+                  >
+                    {g.lot?.title || "Unknown lot"}
+                    <ChevronRight className="h-3.5 w-3.5 shrink-0 text-espresso/55" strokeWidth={2.5} />
+                  </button>
+                ) : (
+                  <Link
+                    href={`/dashboard/buyer/lot/${g.lotId}${g.hubId ? `?hub=${g.hubId}` : ""}`}
+                    className="font-headline text-[15px] font-bold leading-tight text-espresso transition-colors hover:text-tomato"
+                  >
+                    {g.lot?.title || "Unknown lot"}
+                  </Link>
+                )}
                 <div className="mt-0.5 text-[11px] text-espresso/60">
                   {[g.lot?.region, g.lot?.origin_country].filter(Boolean).join(" · ")}
                 </div>

--- a/components/buyer-commitments/commitment-drawer/__tests__/closed-body.test.tsx
+++ b/components/buyer-commitments/commitment-drawer/__tests__/closed-body.test.tsx
@@ -1,0 +1,193 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import type { Commitment, Lot } from "@/lib/types";
+import type { CommitmentGroup } from "@/components/buyer-commitments/bucket-by-lifecycle";
+import { ClosedDrawerBody } from "@/components/buyer-commitments/commitment-drawer/closed-body";
+
+function makeCommit(over: Partial<Commitment> = {}): Commitment {
+  return {
+    id: "c-1",
+    lot_id: "lot-1",
+    buyer_id: "b-1",
+    hub_id: null,
+    campaign_id: "camp-1",
+    quantity_kg: 30,
+    price_per_kg: 9,
+    total_price: 297,
+    status: "confirmed",
+    payment_status: "charge_succeeded",
+    charge_amount_cents: 29700,
+    charge_currency: "usd",
+    stripe_checkout_session_id: null,
+    stripe_setup_intent_id: null,
+    stripe_payment_method_id: null,
+    stripe_customer_id: null,
+    stripe_payment_intent_id: "pi_x",
+    stripe_charge_id: null,
+    payment_error: null,
+    charged_at: "2026-04-15T12:00:00Z",
+    notes: null,
+    picked_up_at: "2026-04-25T12:00:00Z",
+    picked_up_by: "b-1",
+    refund_status: "not_refunded",
+    refunded_amount_cents: 0,
+    refunded_at: null,
+    refunded_by: null,
+    last_refund_id: null,
+    refund_reason: null,
+    created_at: "2026-04-15T12:00:00Z",
+    updated_at: "2026-04-25T12:00:00Z",
+    ...over,
+  };
+}
+
+function makeLot(over: Partial<Lot> = {}): Lot {
+  return {
+    id: "lot-1",
+    seller_id: "s-1",
+    title: "Sample Lot",
+    origin_country: "Ethiopia",
+    region: null,
+    farm: null,
+    variety: null,
+    process: null,
+    altitude_min: null,
+    altitude_max: null,
+    crop_year: null,
+    score: null,
+    description: null,
+    total_quantity_kg: 1500,
+    committed_quantity_kg: 1100,
+    min_commitment_kg: 600,
+    price_per_kg: 10,
+    currency: "USD",
+    status: "active",
+    commitment_deadline: null,
+    expiry_date: null,
+    settlement_status: "settled",
+    settlement_processed_at: "2026-04-20T00:00:00Z",
+    images: [],
+    flavor_notes: [],
+    certifications: [],
+    created_at: "2026-04-01T00:00:00Z",
+    updated_at: "2026-04-20T00:00:00Z",
+    ...over,
+  } as Lot;
+}
+
+function makeGroup(over: Partial<CommitmentGroup> = {}): CommitmentGroup {
+  return {
+    groupKey: "g-1",
+    lotId: "lot-1",
+    campaignId: "camp-1",
+    hubId: "hub-1",
+    lot: makeLot(),
+    campaign: {
+      id: "camp-1",
+      status: "settled",
+      deadline: "2026-04-15T00:00:00Z",
+      settled_at: "2026-04-20T00:00:00Z",
+    },
+    commitments: [makeCommit({ id: "c-1" }), makeCommit({ id: "c-2" })],
+    shipment: null,
+    ...over,
+  };
+}
+
+describe("ClosedDrawerBody — value mode", () => {
+  it("leads with savings and quantity in the header (C12)", () => {
+    // 2 commitments × 30kg @ $9 seller = $9.90 buyer = $297 each = $594 paid
+    // base $10 → $11/kg buyer × 60kg = $660 baseline
+    // saved = $660 − $594 = $66
+    const group = makeGroup();
+    render(<ClosedDrawerBody group={group} mode="value" />);
+    const header = screen.getByTestId("closed-drawer-header");
+    expect(header.textContent).toContain("$66.00");
+    expect(header.textContent).toContain("60 kg");
+  });
+
+  it("hides the savings line and leads with quantity when savings = 0 (C12 edge)", () => {
+    // No tier hit: commitments paid the base price exactly.
+    // base $10 × 1.10 × 30kg = $330; charge_amount_cents matches.
+    const group = makeGroup({
+      commitments: [
+        makeCommit({
+          quantity_kg: 30,
+          charge_amount_cents: 33000,
+        }),
+      ],
+    });
+    render(<ClosedDrawerBody group={group} mode="value" />);
+    const header = screen.getByTestId("closed-drawer-header");
+    expect(header.textContent).not.toContain("You saved");
+    expect(header.textContent).toContain("30 kg");
+    expect(screen.queryByTestId("closed-savings")).not.toBeInTheDocument();
+  });
+
+  it("renders the tier-unlocked summary with threshold and final price (C13)", () => {
+    // 2 tiers: 500 @ $10, 1000 @ $9. Campaign settled at 1100 → tier 2 unlocked.
+    const group = makeGroup({
+      lot: makeLot({ committed_quantity_kg: 1100, price_per_kg: 10 }),
+    });
+    render(
+      <ClosedDrawerBody
+        group={group}
+        mode="value"
+        tiers={[
+          { min_quantity_kg: 500, price_per_kg: 10 },
+          { min_quantity_kg: 1000, price_per_kg: 9 },
+        ]}
+      />
+    );
+    const tierBox = screen.getByTestId("closed-tier-summary");
+    expect(tierBox).toBeInTheDocument();
+    expect(screen.getByTestId("closed-tier-threshold").textContent).toContain("1,000 kg");
+    expect(screen.getByTestId("closed-tier-threshold").textContent).toContain("$9.90/kg");
+  });
+
+  it("hides the tier-unlocked summary when no tier was reached (C13 edge)", () => {
+    const group = makeGroup({
+      lot: makeLot({ committed_quantity_kg: 200 }),
+    });
+    render(
+      <ClosedDrawerBody
+        group={group}
+        mode="value"
+        tiers={[{ min_quantity_kg: 500, price_per_kg: 10 }]}
+      />
+    );
+    expect(screen.queryByTestId("closed-tier-summary")).not.toBeInTheDocument();
+  });
+});
+
+describe("ClosedDrawerBody — refund mode", () => {
+  it("leads with the refund total and suppresses tier UI / savings / Commit more (C14)", () => {
+    const group = makeGroup({
+      commitments: [
+        makeCommit({
+          status: "cancelled",
+          refunded_amount_cents: 30000,
+          refunded_at: "2026-04-22T12:00:00Z",
+        }),
+      ],
+    });
+    render(
+      <ClosedDrawerBody
+        group={group}
+        mode="refund"
+        tiers={[{ min_quantity_kg: 500, price_per_kg: 10 }]}
+      />
+    );
+    const header = screen.getByTestId("closed-refund-header");
+    expect(header.textContent).toContain("$300.00");
+    expect(header.textContent).toContain("refunded");
+
+    // Savings, tier summary, and Commit more must all be absent
+    expect(screen.queryByTestId("closed-savings")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("closed-tier-summary")).not.toBeInTheDocument();
+    expect(screen.queryByText(/Commit more/i)).not.toBeInTheDocument();
+  });
+});

--- a/components/buyer-commitments/commitment-drawer/__tests__/closed-body.test.tsx
+++ b/components/buyer-commitments/commitment-drawer/__tests__/closed-body.test.tsx
@@ -1,8 +1,13 @@
 // @vitest-environment jsdom
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import React from "react";
+
+vi.mock("@/components/unit-provider", () => ({
+  useUnitPreference: () => ({ unit: "kg", setUnit: () => {} }),
+}));
+
 import type { Commitment, Lot } from "@/lib/types";
 import type { CommitmentGroup } from "@/components/buyer-commitments/bucket-by-lifecycle";
 import { ClosedDrawerBody } from "@/components/buyer-commitments/commitment-drawer/closed-body";

--- a/components/buyer-commitments/commitment-drawer/__tests__/commitment-drawer.test.tsx
+++ b/components/buyer-commitments/commitment-drawer/__tests__/commitment-drawer.test.tsx
@@ -1,0 +1,137 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+vi.mock("@/components/unit-provider", () => ({
+  useUnitPreference: () => ({ unit: "kg", setUnit: () => {} }),
+}));
+
+// Capture which `side` the DrawerContent receives so we can assert on it.
+// The real Drawer (Radix-based) drives slide direction off this prop, so it's
+// what determines responsive rendering. Mocking the package keeps the test
+// out of the npm-link / dupe-React rabbit hole and isolates the side decision.
+const sideSpy = vi.fn();
+vi.mock("@merninos/ui", () => {
+  const Pass = ({ children, asChild, ...rest }: any) => <div {...rest}>{children}</div>;
+  return {
+    Drawer: ({ open, children }: any) => (open ? <div role="dialog">{children}</div> : null),
+    DrawerContent: ({ side, children, ...rest }: any) => {
+      sideSpy(side);
+      return (
+        <div data-side={side} {...rest}>
+          {children}
+        </div>
+      );
+    },
+    DrawerHeader: Pass,
+    DrawerTitle: ({ children }: any) => <h2>{children}</h2>,
+    DrawerDescription: ({ children }: any) => <p>{children}</p>,
+    DrawerBody: Pass,
+    DrawerClose: Pass,
+    DrawerFooter: Pass,
+    DrawerOverlay: Pass,
+    DrawerPortal: Pass,
+    DrawerTrigger: Pass,
+    Button: ({ children, asChild, ...rest }: any) => <div {...rest}>{children}</div>,
+  };
+});
+
+import { CommitmentDrawer } from "@/components/buyer-commitments/commitment-drawer";
+import type { CommitmentGroup } from "@/components/buyer-commitments/bucket-by-lifecycle";
+
+function makeGroup(): CommitmentGroup {
+  return {
+    groupKey: "g-1",
+    lotId: "lot-1",
+    campaignId: "camp-1",
+    hubId: "hub-1",
+    lot: {
+      id: "lot-1",
+      seller_id: "s-1",
+      title: "Test Lot",
+      origin_country: "Ethiopia",
+      region: null,
+      farm: null,
+      variety: null,
+      process: null,
+      altitude_min: null,
+      altitude_max: null,
+      crop_year: null,
+      score: null,
+      description: null,
+      total_quantity_kg: 1000,
+      committed_quantity_kg: 500,
+      min_commitment_kg: 600,
+      price_per_kg: 10,
+      currency: "USD",
+      status: "active",
+      commitment_deadline: null,
+      expiry_date: null,
+      settlement_status: "pending",
+      settlement_processed_at: null,
+      images: [],
+      flavor_notes: [],
+      certifications: [],
+      created_at: "2026-04-01T00:00:00Z",
+      updated_at: "2026-04-01T00:00:00Z",
+    } as any,
+    campaign: {
+      id: "camp-1",
+      status: "active",
+      deadline: new Date(Date.now() + 5 * 86_400_000).toISOString(),
+      settled_at: null,
+    },
+    commitments: [],
+    shipment: null,
+  };
+}
+
+function setMatchMedia(mobile: boolean) {
+  // mobile = below 768px → matchMedia("(min-width: 768px)").matches === false
+  window.matchMedia = ((query: string) =>
+    ({
+      matches: mobile ? false : true,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    } as MediaQueryList)) as any;
+}
+
+describe("CommitmentDrawer responsive (C3)", () => {
+  beforeEach(() => {
+    sideSpy.mockClear();
+  });
+
+  it("uses side='right' when viewport is at or above 768px", () => {
+    setMatchMedia(false); // matches: true → desktop
+    render(
+      <CommitmentDrawer
+        open={true}
+        onOpenChange={() => {}}
+        group={makeGroup()}
+        tiers={[]}
+      />
+    );
+    expect(sideSpy).toHaveBeenLastCalledWith("right");
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("uses side='bottom' when viewport is below 768px", () => {
+    setMatchMedia(true); // matches: false → mobile
+    render(
+      <CommitmentDrawer
+        open={true}
+        onOpenChange={() => {}}
+        group={makeGroup()}
+        tiers={[]}
+      />
+    );
+    expect(sideSpy).toHaveBeenLastCalledWith("bottom");
+  });
+});

--- a/components/buyer-commitments/commitment-drawer/__tests__/contributions-table.test.tsx
+++ b/components/buyer-commitments/commitment-drawer/__tests__/contributions-table.test.tsx
@@ -1,8 +1,13 @@
 // @vitest-environment jsdom
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import React from "react";
+
+vi.mock("@/components/unit-provider", () => ({
+  useUnitPreference: () => ({ unit: "kg", setUnit: () => {} }),
+}));
+
 import type { Commitment } from "@/lib/types";
 import { ContributionsTable } from "@/components/buyer-commitments/commitment-drawer/contributions-table";
 

--- a/components/buyer-commitments/commitment-drawer/__tests__/contributions-table.test.tsx
+++ b/components/buyer-commitments/commitment-drawer/__tests__/contributions-table.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import type { Commitment } from "@/lib/types";
+import { ContributionsTable } from "@/components/buyer-commitments/commitment-drawer/contributions-table";
+
+function makeCommitment(overrides: Partial<Commitment> = {}): Commitment {
+  return {
+    id: "c-default",
+    lot_id: "lot-1",
+    buyer_id: "buyer-1",
+    hub_id: null,
+    campaign_id: "camp-1",
+    quantity_kg: 10,
+    price_per_kg: 12,
+    total_price: 132,
+    status: "confirmed",
+    payment_status: "charge_succeeded",
+    charge_amount_cents: 13200,
+    charge_currency: "usd",
+    stripe_checkout_session_id: null,
+    stripe_setup_intent_id: null,
+    stripe_payment_method_id: null,
+    stripe_customer_id: null,
+    stripe_payment_intent_id: "pi_x",
+    stripe_charge_id: null,
+    payment_error: null,
+    charged_at: "2026-04-15T00:00:00Z",
+    notes: null,
+    picked_up_at: null,
+    picked_up_by: null,
+    refund_status: "not_refunded",
+    refunded_amount_cents: 0,
+    refunded_at: null,
+    refunded_by: null,
+    last_refund_id: null,
+    refund_reason: null,
+    created_at: "2026-04-15T00:00:00Z",
+    updated_at: "2026-04-15T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("ContributionsTable", () => {
+  it("renders one row per non-charge_failed commitment", () => {
+    const commitments: Commitment[] = [
+      makeCommitment({ id: "c-1" }),
+      makeCommitment({ id: "c-2" }),
+      makeCommitment({ id: "c-3" }),
+      makeCommitment({ id: "c-4-failed", payment_status: "charge_failed" }),
+    ];
+    render(<ContributionsTable commitments={commitments} />);
+    expect(screen.getByTestId("commitment-row-c-1")).toBeInTheDocument();
+    expect(screen.getByTestId("commitment-row-c-2")).toBeInTheDocument();
+    expect(screen.getByTestId("commitment-row-c-3")).toBeInTheDocument();
+    expect(screen.queryByTestId("commitment-row-c-4-failed")).not.toBeInTheDocument();
+  });
+
+  it("renders a refund line beneath a refunded commitment with the cumulative amount and date", () => {
+    const commitments: Commitment[] = [
+      makeCommitment({
+        id: "c-with-refund",
+        refunded_amount_cents: 5500,
+        refunded_at: "2026-04-28T12:00:00Z",
+      }),
+    ];
+    render(<ContributionsTable commitments={commitments} />);
+    const refundRow = screen.getByTestId("commitment-refund-c-with-refund");
+    expect(refundRow).toBeInTheDocument();
+    expect(refundRow.textContent).toContain("$55.00");
+    expect(refundRow.textContent).toContain("Apr 28, 2026");
+  });
+
+  it("does not render a refund line when refunded_amount_cents is 0", () => {
+    const commitments: Commitment[] = [makeCommitment({ id: "c-none" })];
+    render(<ContributionsTable commitments={commitments} />);
+    expect(screen.queryByTestId("commitment-refund-c-none")).not.toBeInTheDocument();
+  });
+
+  it("falls back to total_price when charge_amount_cents is null", () => {
+    const commitments: Commitment[] = [
+      makeCommitment({
+        id: "c-fallback",
+        charge_amount_cents: null,
+        total_price: 99,
+      }),
+    ];
+    render(<ContributionsTable commitments={commitments} />);
+    const row = screen.getByTestId("commitment-row-c-fallback");
+    expect(row.textContent).toContain("$99.00");
+  });
+
+  it("renders an empty-state message when only charge_failed commitments are passed", () => {
+    const commitments: Commitment[] = [
+      makeCommitment({ id: "c-fail-1", payment_status: "charge_failed" }),
+      makeCommitment({ id: "c-fail-2", payment_status: "charge_failed" }),
+    ];
+    render(<ContributionsTable commitments={commitments} />);
+    expect(screen.getByText(/No contributions/i)).toBeInTheDocument();
+  });
+});

--- a/components/buyer-commitments/commitment-drawer/__tests__/in-motion-body.test.tsx
+++ b/components/buyer-commitments/commitment-drawer/__tests__/in-motion-body.test.tsx
@@ -1,8 +1,13 @@
 // @vitest-environment jsdom
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import React from "react";
+
+vi.mock("@/components/unit-provider", () => ({
+  useUnitPreference: () => ({ unit: "kg", setUnit: () => {} }),
+}));
+
 import type { Commitment, Lot } from "@/lib/types";
 import type { CommitmentGroup } from "@/components/buyer-commitments/bucket-by-lifecycle";
 import { InMotionDrawerBody } from "@/components/buyer-commitments/commitment-drawer/in-motion-body";

--- a/components/buyer-commitments/commitment-drawer/__tests__/in-motion-body.test.tsx
+++ b/components/buyer-commitments/commitment-drawer/__tests__/in-motion-body.test.tsx
@@ -1,0 +1,180 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import type { Commitment, Lot } from "@/lib/types";
+import type { CommitmentGroup } from "@/components/buyer-commitments/bucket-by-lifecycle";
+import { InMotionDrawerBody } from "@/components/buyer-commitments/commitment-drawer/in-motion-body";
+
+function makeCommit(over: Partial<Commitment> = {}): Commitment {
+  return {
+    id: "c-1",
+    lot_id: "lot-1",
+    buyer_id: "b-1",
+    hub_id: null,
+    campaign_id: "camp-1",
+    quantity_kg: 40,
+    price_per_kg: 9,
+    total_price: 396,
+    status: "confirmed",
+    payment_status: "charge_succeeded",
+    charge_amount_cents: 39600,
+    charge_currency: "usd",
+    stripe_checkout_session_id: null,
+    stripe_setup_intent_id: null,
+    stripe_payment_method_id: null,
+    stripe_customer_id: null,
+    stripe_payment_intent_id: "pi_x",
+    stripe_charge_id: null,
+    payment_error: null,
+    charged_at: "2026-04-15T12:00:00Z",
+    notes: null,
+    picked_up_at: null,
+    picked_up_by: null,
+    refund_status: "not_refunded",
+    refunded_amount_cents: 0,
+    refunded_at: null,
+    refunded_by: null,
+    last_refund_id: null,
+    refund_reason: null,
+    created_at: "2026-04-15T12:00:00Z",
+    updated_at: "2026-04-15T12:00:00Z",
+    ...over,
+  };
+}
+
+function makeLot(over: Partial<Lot> = {}): Lot {
+  return {
+    id: "lot-1",
+    seller_id: "s-1",
+    title: "Sample Lot",
+    origin_country: "Ethiopia",
+    region: null,
+    farm: null,
+    variety: null,
+    process: null,
+    altitude_min: null,
+    altitude_max: null,
+    crop_year: null,
+    score: null,
+    description: null,
+    total_quantity_kg: 1000,
+    committed_quantity_kg: 800,
+    min_commitment_kg: 600,
+    price_per_kg: 10,
+    currency: "USD",
+    status: "active",
+    commitment_deadline: null,
+    expiry_date: null,
+    settlement_status: "settled",
+    settlement_processed_at: "2026-04-20T00:00:00Z",
+    images: [],
+    flavor_notes: [],
+    certifications: [],
+    created_at: "2026-04-01T00:00:00Z",
+    updated_at: "2026-04-01T00:00:00Z",
+    ...over,
+  } as Lot;
+}
+
+function makeGroup(over: Partial<CommitmentGroup> = {}): CommitmentGroup {
+  return {
+    groupKey: "g-1",
+    lotId: "lot-1",
+    campaignId: "camp-1",
+    hubId: "hub-1",
+    lot: makeLot(),
+    campaign: {
+      id: "camp-1",
+      status: "settled",
+      deadline: "2026-04-15T00:00:00Z",
+      settled_at: "2026-04-20T00:00:00Z",
+    },
+    commitments: [],
+    shipment: { status: "in_transit", carrier: null, tracking_number: null, shipped_at: null, delivered_at: null, hub: null },
+    ...over,
+  };
+}
+
+describe("InMotionDrawerBody", () => {
+  it("renders the stage pill from STAGE_META across funds_held / in_transit / at_hub (C10)", () => {
+    // funds_held: settled but no shipment
+    const fundsHeldGroup = makeGroup({
+      shipment: null,
+      commitments: [makeCommit()],
+    });
+    const { rerender } = render(<InMotionDrawerBody group={fundsHeldGroup} />);
+    let pill = screen.getByTestId("in-motion-stage-pill");
+    expect(pill.getAttribute("data-stage")).toBe("funds_held");
+    expect(pill.textContent).toBe("Funds Held");
+
+    // in_transit
+    rerender(
+      <InMotionDrawerBody
+        group={makeGroup({
+          shipment: { status: "in_transit", carrier: null, tracking_number: null, shipped_at: null, delivered_at: null, hub: null },
+          commitments: [makeCommit()],
+        })}
+      />
+    );
+    pill = screen.getByTestId("in-motion-stage-pill");
+    expect(pill.getAttribute("data-stage")).toBe("in_transit");
+    expect(pill.textContent).toBe("In Transit");
+
+    // at_hub
+    rerender(
+      <InMotionDrawerBody
+        group={makeGroup({
+          shipment: { status: "at_hub", carrier: null, tracking_number: null, shipped_at: null, delivered_at: null, hub: null },
+          commitments: [makeCommit()],
+        })}
+      />
+    );
+    pill = screen.getByTestId("in-motion-stage-pill");
+    expect(pill.getAttribute("data-stage")).toBe("at_hub");
+    expect(pill.textContent).toBe("At Hub");
+  });
+
+  it("renders settled / paid / saved values (C11)", () => {
+    // 2 succeeded commitments × 40kg @ $9/kg seller → $9.90 buyer = $396 each = $792 paid
+    // base price $10 → $11/kg buyer × 80kg = $880 baseline
+    // saved = $880 − $792 = $88
+    const group = makeGroup({
+      commitments: [makeCommit({ id: "c-1" }), makeCommit({ id: "c-2" })],
+    });
+    render(<InMotionDrawerBody group={group} />);
+    expect(screen.getByTestId("in-motion-stat-settled").textContent).toContain("80 kg");
+    expect(screen.getByTestId("in-motion-stat-paid").textContent).toContain("$792.00");
+    expect(screen.getByTestId("in-motion-stat-saved").textContent).toContain("$88.00");
+  });
+
+  it("falls back to total_price when charge_amount_cents is null (C11)", () => {
+    const group = makeGroup({
+      commitments: [
+        makeCommit({
+          charge_amount_cents: null,
+          total_price: 100,
+          quantity_kg: 10,
+        }),
+      ],
+    });
+    render(<InMotionDrawerBody group={group} />);
+    expect(screen.getByTestId("in-motion-stat-paid").textContent).toContain("$100.00");
+  });
+
+  it("hides the saved value when no savings exist (C11 edge)", () => {
+    // No tier hit, paid the base price exactly: charge_amount_cents matches base × kg × 1.10
+    const group = makeGroup({
+      commitments: [
+        makeCommit({
+          quantity_kg: 10,
+          // base $10 × 1.10 × 10kg = $110
+          charge_amount_cents: 11000,
+        }),
+      ],
+    });
+    render(<InMotionDrawerBody group={group} />);
+    expect(screen.getByTestId("in-motion-stat-saved").textContent).toContain("—");
+  });
+});

--- a/components/buyer-commitments/commitment-drawer/__tests__/raising-body.test.tsx
+++ b/components/buyer-commitments/commitment-drawer/__tests__/raising-body.test.tsx
@@ -1,0 +1,202 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import type { Commitment, Lot } from "@/lib/types";
+import type { CommitmentGroup } from "@/components/buyer-commitments/bucket-by-lifecycle";
+
+// Mock @merninos/ui to avoid the npm-link symlink / dupe-React issue.
+vi.mock("@merninos/ui", () => {
+  const Pass = ({ children, asChild, ...rest }: any) => <div {...rest}>{children}</div>;
+  return { Button: Pass };
+});
+
+vi.mock("next/link", () => ({
+  default: ({ children, href, ...rest }: any) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+import { RaisingDrawerBody } from "@/components/buyer-commitments/commitment-drawer/raising-body";
+
+function makeCommit(over: Partial<Commitment> = {}): Commitment {
+  return {
+    id: "c-1",
+    lot_id: "lot-1",
+    buyer_id: "b-1",
+    hub_id: null,
+    campaign_id: "camp-1",
+    quantity_kg: 50,
+    price_per_kg: 10,
+    total_price: 550,
+    status: "confirmed",
+    payment_status: "setup_complete",
+    charge_amount_cents: null,
+    charge_currency: "usd",
+    stripe_checkout_session_id: null,
+    stripe_setup_intent_id: null,
+    stripe_payment_method_id: null,
+    stripe_customer_id: null,
+    stripe_payment_intent_id: "pi_x",
+    stripe_charge_id: null,
+    payment_error: null,
+    charged_at: null,
+    notes: null,
+    picked_up_at: null,
+    picked_up_by: null,
+    refund_status: "not_refunded",
+    refunded_amount_cents: 0,
+    refunded_at: null,
+    refunded_by: null,
+    last_refund_id: null,
+    refund_reason: null,
+    created_at: "2026-04-15T12:00:00Z",
+    updated_at: "2026-04-15T12:00:00Z",
+    ...over,
+  };
+}
+
+function makeLot(over: Partial<Lot> = {}): Lot {
+  return {
+    id: "lot-1",
+    seller_id: "s-1",
+    title: "Sample Lot",
+    origin_country: "Ethiopia",
+    region: "Yirgacheffe",
+    farm: null,
+    variety: null,
+    process: null,
+    altitude_min: null,
+    altitude_max: null,
+    crop_year: null,
+    score: null,
+    description: null,
+    total_quantity_kg: 1000,
+    committed_quantity_kg: 700,
+    min_commitment_kg: 600,
+    price_per_kg: 10,
+    currency: "USD",
+    status: "active",
+    commitment_deadline: null,
+    expiry_date: null,
+    settlement_status: "pending",
+    settlement_processed_at: null,
+    images: [],
+    flavor_notes: [],
+    certifications: [],
+    created_at: "2026-04-01T00:00:00Z",
+    updated_at: "2026-04-01T00:00:00Z",
+    ...over,
+  } as Lot;
+}
+
+function makeGroup(over: Partial<CommitmentGroup> = {}): CommitmentGroup {
+  return {
+    groupKey: "g-1",
+    lotId: "lot-1",
+    campaignId: "camp-1",
+    hubId: "hub-1",
+    lot: makeLot(),
+    campaign: {
+      id: "camp-1",
+      status: "active",
+      deadline: new Date(Date.now() + 5 * 86_400_000).toISOString(),
+      settled_at: null,
+    },
+    commitments: [makeCommit({ id: "c-1", quantity_kg: 50 })],
+    shipment: null,
+    ...over,
+  };
+}
+
+describe("RaisingDrawerBody", () => {
+  it("renders all summary fields with formatted values (C6)", () => {
+    render(
+      <RaisingDrawerBody
+        group={makeGroup()}
+        tiers={[
+          { min_quantity_kg: 500, price_per_kg: 10 },
+          { min_quantity_kg: 1000, price_per_kg: 9 },
+          { min_quantity_kg: 2000, price_per_kg: 8 },
+        ]}
+      />
+    );
+    // Each summary stat label appears next to its value — assert by label
+    // co-location rather than raw text scan (other "50 kg" / "700 kg" can
+    // appear elsewhere on the body).
+    expect(screen.getByText("Your commits").nextElementSibling?.textContent).toBe("50 kg");
+    expect(screen.getByText("Your exposure").nextElementSibling?.textContent).toBe("$550.00");
+    expect(screen.getByText("Campaign total").nextElementSibling?.textContent).toBe("700 kg");
+    expect(screen.getByText("Minimum").nextElementSibling?.textContent).toBe("600 kg");
+    expect(screen.getByTestId("raising-deadline").textContent).toMatch(/d left|h left/);
+  });
+
+  it("renders the urgency callout when below minimum and hides it when at/above (C7)", () => {
+    const { rerender } = render(
+      <RaisingDrawerBody
+        group={makeGroup({ lot: makeLot({ committed_quantity_kg: 599 }) })}
+        tiers={[]}
+      />
+    );
+    expect(screen.getByTestId("raising-urgency")).toBeInTheDocument();
+    expect(screen.getByTestId("raising-urgency").textContent).toContain("1 kg");
+
+    rerender(
+      <RaisingDrawerBody
+        group={makeGroup({ lot: makeLot({ committed_quantity_kg: 600 }) })}
+        tiers={[]}
+      />
+    );
+    expect(screen.queryByTestId("raising-urgency")).not.toBeInTheDocument();
+  });
+
+  it("renders every tier with the correct unlock state and projected savings delta (C8)", () => {
+    // Buyer has 50kg, campaign is at 700kg, current tier is the 500kg @ $10 tier ($11/kg with fee).
+    render(
+      <RaisingDrawerBody
+        group={makeGroup({
+          lot: makeLot({ committed_quantity_kg: 700, price_per_kg: 10 }),
+          commitments: [makeCommit({ quantity_kg: 50 })],
+        })}
+        tiers={[
+          { min_quantity_kg: 500, price_per_kg: 10 },
+          { min_quantity_kg: 1000, price_per_kg: 9 },
+          { min_quantity_kg: 2000, price_per_kg: 8 },
+        ]}
+      />
+    );
+
+    // 500kg tier: unlocked
+    const t500 = screen.getByTestId("raising-tier-500");
+    expect(t500.getAttribute("data-unlocked")).toBe("true");
+
+    // 1000kg tier: locked, +$55 if reached ($11 - $9.90) × 50
+    const t1000 = screen.getByTestId("raising-tier-1000");
+    expect(t1000.getAttribute("data-unlocked")).toBe("false");
+    expect(screen.getByTestId("raising-tier-delta-1000").textContent).toContain("$55.00");
+
+    // 2000kg tier: locked, +$150 if reached ($11 - $8.80) × 50
+    const t2000 = screen.getByTestId("raising-tier-2000");
+    expect(t2000.getAttribute("data-unlocked")).toBe("false");
+    expect(screen.getByTestId("raising-tier-delta-2000").textContent).toContain("$110.00");
+  });
+
+  it("does not render a tier list when no tiers exist (C8 edge)", () => {
+    render(<RaisingDrawerBody group={makeGroup()} tiers={[]} />);
+    expect(screen.queryByTestId("raising-tier-list")).not.toBeInTheDocument();
+  });
+
+  it("renders Commit more linking to the campaign page with the buyer's hub (C9)", () => {
+    render(
+      <RaisingDrawerBody
+        group={makeGroup({ lotId: "lot-42", hubId: "hub-9" })}
+        tiers={[]}
+      />
+    );
+    const link = screen.getByTestId("raising-commit-more");
+    expect(link.getAttribute("href")).toBe("/dashboard/buyer/lot/lot-42?hub=hub-9");
+  });
+});

--- a/components/buyer-commitments/commitment-drawer/__tests__/raising-body.test.tsx
+++ b/components/buyer-commitments/commitment-drawer/__tests__/raising-body.test.tsx
@@ -20,6 +20,11 @@ vi.mock("next/link", () => ({
   ),
 }));
 
+// Force kg unit so legacy assertions like "50 kg" / "$9.90/kg" stay stable.
+vi.mock("@/components/unit-provider", () => ({
+  useUnitPreference: () => ({ unit: "kg", setUnit: () => {} }),
+}));
+
 import { RaisingDrawerBody } from "@/components/buyer-commitments/commitment-drawer/raising-body";
 
 function makeCommit(over: Partial<Commitment> = {}): Commitment {

--- a/components/buyer-commitments/commitment-drawer/closed-body.tsx
+++ b/components/buyer-commitments/commitment-drawer/closed-body.tsx
@@ -1,4 +1,5 @@
 import { addPlatformFee } from "@/lib/pricing";
+import { UnitPriceText, UnitWeightText } from "@/components/unit-value";
 import { ContributionsTable } from "./contributions-table";
 import type { CommitmentGroup } from "../bucket-by-lifecycle";
 
@@ -18,9 +19,6 @@ const fmtMoney = (n: number) =>
     currency: "USD",
     maximumFractionDigits: 2,
   }).format(n || 0);
-
-const fmtKg = (n: number) =>
-  new Intl.NumberFormat("en-US", { maximumFractionDigits: 1 }).format(n || 0);
 
 export function ClosedDrawerBody({
   group,
@@ -127,7 +125,7 @@ export function ClosedDrawerBody({
           className="mt-1 font-headline text-3xl font-bold text-espresso tabular-nums"
           data-testid="closed-quantity"
         >
-          {fmtKg(totalKg)} kg
+          <UnitWeightText kg={totalKg} maximumFractionDigits={1} />
         </div>
       </div>
 
@@ -144,11 +142,18 @@ export function ClosedDrawerBody({
             data-testid="closed-tier-threshold"
           >
             <span className="font-bold tabular-nums">
-              {fmtKg(Number(settledTier.min_quantity_kg))} kg
+              <UnitWeightText
+                kg={Number(settledTier.min_quantity_kg)}
+                maximumFractionDigits={0}
+              />
             </span>{" "}
             tier · final price{" "}
             <span className="font-bold tabular-nums">
-              {fmtMoney(finalBuyerPrice)}/kg
+              <UnitPriceText
+                pricePerKg={Number(settledTier.price_per_kg)}
+                currency="USD"
+                includePlatformFee
+              />
             </span>
           </div>
         </div>

--- a/components/buyer-commitments/commitment-drawer/closed-body.tsx
+++ b/components/buyer-commitments/commitment-drawer/closed-body.tsx
@@ -1,0 +1,165 @@
+import { addPlatformFee } from "@/lib/pricing";
+import { ContributionsTable } from "./contributions-table";
+import type { CommitmentGroup } from "../bucket-by-lifecycle";
+
+export interface ClosedDrawerBodyProps {
+  group: CommitmentGroup;
+  /**
+   * "value" — picked_up | done. Lead with savings + qty.
+   * "refund" — minimum_not_met. Lead with refund total, suppress savings/CTA.
+   */
+  mode: "value" | "refund";
+  tiers?: { min_quantity_kg: number; price_per_kg: number }[];
+}
+
+const fmtMoney = (n: number) =>
+  new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 2,
+  }).format(n || 0);
+
+const fmtKg = (n: number) =>
+  new Intl.NumberFormat("en-US", { maximumFractionDigits: 1 }).format(n || 0);
+
+export function ClosedDrawerBody({
+  group,
+  mode,
+  tiers = [],
+}: ClosedDrawerBodyProps) {
+  const lot = group.lot;
+
+  const succeeded = group.commitments.filter(
+    (c) => c.payment_status === "charge_succeeded" && c.status !== "cancelled"
+  );
+  const totalKg = succeeded.reduce((s, c) => s + Number(c.quantity_kg || 0), 0);
+  const paid = succeeded.reduce(
+    (s, c) =>
+      s +
+      (c.charge_amount_cents != null
+        ? c.charge_amount_cents / 100
+        : Number(c.total_price || 0)),
+    0
+  );
+  const totalRefund = group.commitments.reduce(
+    (s, c) => s + Number(c.refunded_amount_cents || 0),
+    0
+  );
+
+  if (mode === "refund") {
+    return (
+      <div className="flex flex-col gap-5" data-testid="closed-drawer-body">
+        <div
+          className="rounded-md border-[3px] border-tomato bg-cream p-5"
+          data-testid="closed-refund-header"
+        >
+          <div className="font-body text-[11px] font-extrabold uppercase tracking-[0.14em] text-tomato">
+            Lot didn't hit minimum
+          </div>
+          <div className="mt-1 font-headline text-3xl font-bold text-espresso tabular-nums">
+            {fmtMoney(totalRefund / 100)} refunded
+          </div>
+          <div className="mt-2 font-body text-sm text-espresso/70">
+            Your card has been credited. No further action needed.
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <div className="font-body text-[11px] font-extrabold uppercase tracking-[0.14em] text-espresso/60">
+            Your contributions
+          </div>
+          <ContributionsTable commitments={group.commitments} />
+        </div>
+      </div>
+    );
+  }
+
+  // Value mode — picked_up | done
+  const basePrice = Number(lot?.price_per_kg || 0);
+  const baseWithFee = basePrice > 0 ? addPlatformFee(basePrice) : 0;
+  const baselinePaid = succeeded.reduce(
+    (s, c) => s + baseWithFee * Number(c.quantity_kg || 0),
+    0
+  );
+  const saved = Math.max(0, baselinePaid - paid);
+
+  // Find which tier the campaign settled at — the highest one whose threshold
+  // was met by the final committed quantity.
+  const finalCommitted = Number(lot?.committed_quantity_kg || 0);
+  const sortedTiers = [...tiers].sort(
+    (a, b) => Number(a.min_quantity_kg) - Number(b.min_quantity_kg)
+  );
+  const unlockedTiers = sortedTiers.filter(
+    (t) => finalCommitted >= Number(t.min_quantity_kg)
+  );
+  const settledTier = unlockedTiers[unlockedTiers.length - 1] ?? null;
+  const finalBuyerPrice = settledTier
+    ? addPlatformFee(Number(settledTier.price_per_kg))
+    : null;
+
+  return (
+    <div className="flex flex-col gap-5" data-testid="closed-drawer-body">
+      <div
+        className="rounded-md border-[3px] border-espresso bg-chalk p-5"
+        data-testid="closed-drawer-header"
+      >
+        {saved > 0 && (
+          <>
+            <div className="font-body text-[11px] font-extrabold uppercase tracking-[0.14em] text-matcha">
+              You saved
+            </div>
+            <div
+              className="mt-1 font-headline text-3xl font-bold text-matcha tabular-nums"
+              data-testid="closed-savings"
+            >
+              {fmtMoney(saved)}
+            </div>
+          </>
+        )}
+        <div
+          className={`font-body text-[11px] font-extrabold uppercase tracking-[0.14em] text-espresso/60 ${
+            saved > 0 ? "mt-3" : ""
+          }`}
+        >
+          You received
+        </div>
+        <div
+          className="mt-1 font-headline text-3xl font-bold text-espresso tabular-nums"
+          data-testid="closed-quantity"
+        >
+          {fmtKg(totalKg)} kg
+        </div>
+      </div>
+
+      {settledTier && finalBuyerPrice != null && (
+        <div
+          className="rounded-md border-2 border-matcha bg-matcha/10 px-4 py-3"
+          data-testid="closed-tier-summary"
+        >
+          <div className="font-body text-[11px] font-extrabold uppercase tracking-[0.14em] text-matcha">
+            Tier unlocked
+          </div>
+          <div
+            className="mt-1 font-body text-sm text-espresso"
+            data-testid="closed-tier-threshold"
+          >
+            <span className="font-bold tabular-nums">
+              {fmtKg(Number(settledTier.min_quantity_kg))} kg
+            </span>{" "}
+            tier · final price{" "}
+            <span className="font-bold tabular-nums">
+              {fmtMoney(finalBuyerPrice)}/kg
+            </span>
+          </div>
+        </div>
+      )}
+
+      <div className="flex flex-col gap-2">
+        <div className="font-body text-[11px] font-extrabold uppercase tracking-[0.14em] text-espresso/60">
+          Your contributions
+        </div>
+        <ContributionsTable commitments={group.commitments} />
+      </div>
+    </div>
+  );
+}

--- a/components/buyer-commitments/commitment-drawer/contributions-table.tsx
+++ b/components/buyer-commitments/commitment-drawer/contributions-table.tsx
@@ -1,12 +1,10 @@
 import { Fragment } from "react";
 import type { Commitment } from "@/lib/types";
+import { UnitWeightText } from "@/components/unit-value";
 
 export interface ContributionsTableProps {
   commitments: Commitment[];
 }
-
-const fmtKg = (n: number) =>
-  new Intl.NumberFormat("en-US", { maximumFractionDigits: 1 }).format(n || 0);
 
 const fmtMoney = (n: number) =>
   new Intl.NumberFormat("en-US", {
@@ -96,7 +94,10 @@ export function ContributionsTable({ commitments }: ContributionsTableProps) {
                 >
                   <td className="px-3 py-2.5 align-top">{fmtDate(c.created_at)}</td>
                   <td className="px-3 py-2.5 text-right align-top tabular-nums">
-                    {fmtKg(Number(c.quantity_kg || 0))} kg
+                    <UnitWeightText
+                      kg={Number(c.quantity_kg || 0)}
+                      maximumFractionDigits={1}
+                    />
                   </td>
                   <td className="px-3 py-2.5 text-right align-top tabular-nums">
                     {fmtMoney(total)}

--- a/components/buyer-commitments/commitment-drawer/contributions-table.tsx
+++ b/components/buyer-commitments/commitment-drawer/contributions-table.tsx
@@ -1,0 +1,135 @@
+import { Fragment } from "react";
+import type { Commitment } from "@/lib/types";
+
+export interface ContributionsTableProps {
+  commitments: Commitment[];
+}
+
+const fmtKg = (n: number) =>
+  new Intl.NumberFormat("en-US", { maximumFractionDigits: 1 }).format(n || 0);
+
+const fmtMoney = (n: number) =>
+  new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 2,
+  }).format(n || 0);
+
+const fmtDate = (iso: string) =>
+  new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(new Date(iso));
+
+const STATUS_LABELS: Record<string, string> = {
+  charge_succeeded: "Paid",
+  pending_setup: "Pending setup",
+  setup_complete: "Authorized",
+  cancelled: "Cancelled",
+  refunded: "Refunded",
+};
+
+const STATUS_TONE: Record<string, string> = {
+  charge_succeeded: "bg-matcha/15 text-matcha border-matcha/40",
+  pending_setup: "bg-honey/15 text-honey border-honey/40",
+  setup_complete: "bg-sky/15 text-espresso border-sky/40",
+  cancelled: "bg-fog text-espresso/60 border-fog",
+  refunded: "bg-tomato/10 text-tomato border-tomato/30",
+};
+
+function statusFor(c: Commitment): string {
+  if (c.status === "cancelled") return "cancelled";
+  if (c.payment_status === "charge_succeeded") return "charge_succeeded";
+  if (c.payment_status === "setup_complete") return "setup_complete";
+  return c.payment_status || "pending_setup";
+}
+
+export function ContributionsTable({ commitments }: ContributionsTableProps) {
+  const rows = commitments.filter((c) => c.payment_status !== "charge_failed");
+
+  if (rows.length === 0) {
+    return (
+      <div className="rounded-md border-2 border-dashed border-espresso/30 bg-cream/50 px-4 py-3 font-body text-sm text-espresso/65">
+        No contributions to show.
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-hidden rounded-md border-[2px] border-espresso bg-chalk">
+      <table className="w-full border-collapse font-body text-sm text-espresso">
+        <thead className="border-b-2 border-espresso bg-cream/60">
+          <tr>
+            <th className="px-3 py-2 text-left text-[10px] font-extrabold uppercase tracking-[0.12em] text-espresso/70">
+              Date
+            </th>
+            <th className="px-3 py-2 text-right text-[10px] font-extrabold uppercase tracking-[0.12em] text-espresso/70">
+              Qty
+            </th>
+            <th className="px-3 py-2 text-right text-[10px] font-extrabold uppercase tracking-[0.12em] text-espresso/70">
+              Total
+            </th>
+            <th className="px-3 py-2 text-right text-[10px] font-extrabold uppercase tracking-[0.12em] text-espresso/70">
+              Status
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((c, idx) => {
+            const status = statusFor(c);
+            const total =
+              c.charge_amount_cents != null
+                ? c.charge_amount_cents / 100
+                : Number(c.total_price || 0);
+            const refundCents = c.refunded_amount_cents ?? 0;
+            const refundedAt = c.refunded_at;
+            const hasRefund = refundCents > 0;
+            const isLast = idx === rows.length - 1;
+            const parentBorder = hasRefund || !isLast ? "border-b border-espresso/15" : "";
+            const refundBorder = !isLast ? "border-b border-espresso/15" : "";
+            return (
+              <Fragment key={c.id}>
+                <tr
+                  data-testid={`commitment-row-${c.id}`}
+                  className={parentBorder}
+                >
+                  <td className="px-3 py-2.5 align-top">{fmtDate(c.created_at)}</td>
+                  <td className="px-3 py-2.5 text-right align-top tabular-nums">
+                    {fmtKg(Number(c.quantity_kg || 0))} kg
+                  </td>
+                  <td className="px-3 py-2.5 text-right align-top tabular-nums">
+                    {fmtMoney(total)}
+                  </td>
+                  <td className="px-3 py-2.5 text-right align-top">
+                    <span
+                      className={`inline-block rounded-pill border-[1.5px] px-2 py-0.5 text-[9px] font-extrabold uppercase tracking-[0.1em] ${
+                        STATUS_TONE[status] ?? STATUS_TONE.pending_setup
+                      }`}
+                    >
+                      {STATUS_LABELS[status] ?? status}
+                    </span>
+                  </td>
+                </tr>
+                {hasRefund && (
+                  <tr
+                    data-testid={`commitment-refund-${c.id}`}
+                    className={refundBorder}
+                  >
+                    <td
+                      colSpan={4}
+                      className="bg-tomato/5 px-3 py-2 text-left font-body text-xs italic text-tomato"
+                    >
+                      Refunded {fmtMoney(refundCents / 100)}
+                      {refundedAt ? ` on ${fmtDate(refundedAt)}` : ""}
+                    </td>
+                  </tr>
+                )}
+              </Fragment>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/components/buyer-commitments/commitment-drawer/in-motion-body.tsx
+++ b/components/buyer-commitments/commitment-drawer/in-motion-body.tsx
@@ -1,4 +1,6 @@
+import * as React from "react";
 import { addPlatformFee } from "@/lib/pricing";
+import { UnitWeightText } from "@/components/unit-value";
 import { ContributionsTable } from "./contributions-table";
 import {
   STAGE_META,
@@ -17,9 +19,6 @@ const fmtMoney = (n: number) =>
     currency: "USD",
     maximumFractionDigits: 2,
   }).format(n || 0);
-
-const fmtKg = (n: number) =>
-  new Intl.NumberFormat("en-US", { maximumFractionDigits: 1 }).format(n || 0);
 
 const STAGE_PILL_BG: Record<StageColor, string> = {
   tomato: "bg-tomato text-cream",
@@ -82,7 +81,7 @@ export function InMotionDrawerBody({ group }: InMotionDrawerBodyProps) {
         <SummaryStat
           testId="in-motion-stat-settled"
           label="Settled"
-          value={`${fmtKg(settledKg)} kg`}
+          value={<UnitWeightText kg={settledKg} maximumFractionDigits={1} />}
         />
         <SummaryStat
           testId="in-motion-stat-paid"
@@ -114,7 +113,7 @@ function SummaryStat({
   testId,
 }: {
   label: string;
-  value: string;
+  value: React.ReactNode;
   tone?: "matcha";
   testId?: string;
 }) {

--- a/components/buyer-commitments/commitment-drawer/in-motion-body.tsx
+++ b/components/buyer-commitments/commitment-drawer/in-motion-body.tsx
@@ -1,0 +1,135 @@
+import { addPlatformFee } from "@/lib/pricing";
+import { ContributionsTable } from "./contributions-table";
+import {
+  STAGE_META,
+  stageOfGroup,
+  type CommitmentGroup,
+  type StageColor,
+} from "../bucket-by-lifecycle";
+
+export interface InMotionDrawerBodyProps {
+  group: CommitmentGroup;
+}
+
+const fmtMoney = (n: number) =>
+  new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 2,
+  }).format(n || 0);
+
+const fmtKg = (n: number) =>
+  new Intl.NumberFormat("en-US", { maximumFractionDigits: 1 }).format(n || 0);
+
+const STAGE_PILL_BG: Record<StageColor, string> = {
+  tomato: "bg-tomato text-cream",
+  honey: "bg-honey text-espresso",
+  sky: "bg-sky text-espresso",
+  sun: "bg-sun text-espresso",
+  matcha: "bg-matcha text-cream",
+  fog: "bg-fog text-espresso",
+  espresso: "bg-espresso text-cream",
+};
+
+export function InMotionDrawerBody({ group }: InMotionDrawerBodyProps) {
+  const lot = group.lot;
+  const stage = stageOfGroup(group);
+  const stageMeta = STAGE_META[stage];
+
+  const succeeded = group.commitments.filter(
+    (c) => c.payment_status === "charge_succeeded" && c.status !== "cancelled"
+  );
+  const settledKg = succeeded.reduce(
+    (s, c) => s + Number(c.quantity_kg || 0),
+    0
+  );
+  const paid = succeeded.reduce(
+    (s, c) =>
+      s +
+      (c.charge_amount_cents != null
+        ? c.charge_amount_cents / 100
+        : Number(c.total_price || 0)),
+    0
+  );
+  // Saved versus base = (base_price_with_fee × kg) − actually paid, summed.
+  const basePrice = Number(lot?.price_per_kg || 0);
+  const baseWithFee = basePrice > 0 ? addPlatformFee(basePrice) : 0;
+  const baselinePaid = succeeded.reduce(
+    (s, c) => s + baseWithFee * Number(c.quantity_kg || 0),
+    0
+  );
+  const saved = Math.max(0, baselinePaid - paid);
+
+  return (
+    <div className="flex flex-col gap-5">
+      <div className="flex items-baseline justify-between gap-3">
+        <div className="font-body text-[11px] font-extrabold uppercase tracking-[0.14em] text-espresso/60">
+          Stage
+        </div>
+        <span
+          data-testid="in-motion-stage-pill"
+          data-stage={stage}
+          className={`rounded-pill border-2 border-espresso px-3 py-0.5 font-body text-[11px] font-extrabold uppercase tracking-[0.1em] ${STAGE_PILL_BG[stageMeta.color]}`}
+        >
+          {stageMeta.label}
+        </span>
+      </div>
+
+      <div
+        className="grid grid-cols-3 gap-3 rounded-md border-2 border-espresso bg-chalk p-4"
+        data-testid="in-motion-summary"
+      >
+        <SummaryStat
+          testId="in-motion-stat-settled"
+          label="Settled"
+          value={`${fmtKg(settledKg)} kg`}
+        />
+        <SummaryStat
+          testId="in-motion-stat-paid"
+          label="Paid"
+          value={fmtMoney(paid)}
+        />
+        <SummaryStat
+          testId="in-motion-stat-saved"
+          label="Saved"
+          value={saved > 0 ? fmtMoney(saved) : "—"}
+          tone={saved > 0 ? "matcha" : undefined}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <div className="font-body text-[11px] font-extrabold uppercase tracking-[0.14em] text-espresso/60">
+          Your contributions
+        </div>
+        <ContributionsTable commitments={group.commitments} />
+      </div>
+    </div>
+  );
+}
+
+function SummaryStat({
+  label,
+  value,
+  tone,
+  testId,
+}: {
+  label: string;
+  value: string;
+  tone?: "matcha";
+  testId?: string;
+}) {
+  return (
+    <div className="flex flex-col" data-testid={testId}>
+      <span className="font-body text-[10px] font-extrabold uppercase tracking-[0.14em] text-espresso/55">
+        {label}
+      </span>
+      <span
+        className={`font-headline text-base font-extrabold tabular-nums ${
+          tone === "matcha" ? "text-matcha" : "text-espresso"
+        }`}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}

--- a/components/buyer-commitments/commitment-drawer/index.tsx
+++ b/components/buyer-commitments/commitment-drawer/index.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerDescription,
+  DrawerBody,
+} from "@merninos/ui";
+import { stageOfGroup, type CommitmentGroup } from "../bucket-by-lifecycle";
+import type { PricingTier } from "@/lib/types";
+
+export interface CommitmentDrawerProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  group: CommitmentGroup | null;
+  tiers: PricingTier[];
+}
+
+/**
+ * Hook: returns the side the drawer should anchor to.
+ * Right above 768px, bottom below.
+ */
+function useDrawerSide(): "right" | "bottom" {
+  const [side, setSide] = useState<"right" | "bottom">("right");
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const mql = window.matchMedia("(min-width: 768px)");
+    const update = () => setSide(mql.matches ? "right" : "bottom");
+    update();
+    mql.addEventListener("change", update);
+    return () => mql.removeEventListener("change", update);
+  }, []);
+  return side;
+}
+
+export function CommitmentDrawer({
+  open,
+  onOpenChange,
+  group,
+  tiers,
+}: CommitmentDrawerProps) {
+  const side = useDrawerSide();
+  const stage = group ? stageOfGroup(group) : null;
+  const dataMode =
+    stage === "raising"
+      ? "raising"
+      : stage === "funds_held" || stage === "in_transit" || stage === "at_hub"
+      ? "in-motion"
+      : stage === "minimum_not_met"
+      ? "min-not-met"
+      : stage === "picked_up" || stage === "done"
+      ? "closed-value"
+      : null;
+
+  return (
+    <Drawer open={open} onOpenChange={onOpenChange}>
+      <DrawerContent side={side} data-mode={dataMode ?? undefined}>
+        {group ? (
+          <>
+            <DrawerHeader>
+              <DrawerTitle>{group.lot?.title || "Lot"}</DrawerTitle>
+              <DrawerDescription>
+                {[group.lot?.region, group.lot?.origin_country]
+                  .filter(Boolean)
+                  .join(" · ")}
+              </DrawerDescription>
+            </DrawerHeader>
+            <DrawerBody>
+              {dataMode === "raising" && (
+                <div data-testid="drawer-body-raising">
+                  Raising body — placeholder (Stage 3)
+                </div>
+              )}
+              {dataMode === "in-motion" && (
+                <div data-testid="drawer-body-in-motion">
+                  In motion body — placeholder (Stage 3)
+                </div>
+              )}
+              {dataMode === "closed-value" && (
+                <div data-testid="drawer-body-closed-value">
+                  Closed (value) body — placeholder (Stage 3)
+                </div>
+              )}
+              {dataMode === "min-not-met" && (
+                <div data-testid="drawer-body-min-not-met">
+                  Closed (refund) body — placeholder (Stage 3)
+                </div>
+              )}
+            </DrawerBody>
+          </>
+        ) : null}
+      </DrawerContent>
+    </Drawer>
+  );
+}

--- a/components/buyer-commitments/commitment-drawer/index.tsx
+++ b/components/buyer-commitments/commitment-drawer/index.tsx
@@ -11,6 +11,9 @@ import {
 } from "@merninos/ui";
 import { stageOfGroup, type CommitmentGroup } from "../bucket-by-lifecycle";
 import type { PricingTier } from "@/lib/types";
+import { RaisingDrawerBody } from "./raising-body";
+import { InMotionDrawerBody } from "./in-motion-body";
+import { ClosedDrawerBody } from "./closed-body";
 
 export interface CommitmentDrawerProps {
   open: boolean;
@@ -71,22 +74,22 @@ export function CommitmentDrawer({
             <DrawerBody>
               {dataMode === "raising" && (
                 <div data-testid="drawer-body-raising">
-                  Raising body — placeholder (Stage 3)
+                  <RaisingDrawerBody group={group} tiers={tiers} />
                 </div>
               )}
               {dataMode === "in-motion" && (
                 <div data-testid="drawer-body-in-motion">
-                  In motion body — placeholder (Stage 3)
+                  <InMotionDrawerBody group={group} />
                 </div>
               )}
               {dataMode === "closed-value" && (
                 <div data-testid="drawer-body-closed-value">
-                  Closed (value) body — placeholder (Stage 3)
+                  <ClosedDrawerBody group={group} mode="value" tiers={tiers} />
                 </div>
               )}
               {dataMode === "min-not-met" && (
                 <div data-testid="drawer-body-min-not-met">
-                  Closed (refund) body — placeholder (Stage 3)
+                  <ClosedDrawerBody group={group} mode="refund" tiers={tiers} />
                 </div>
               )}
             </DrawerBody>

--- a/components/buyer-commitments/commitment-drawer/raising-body.tsx
+++ b/components/buyer-commitments/commitment-drawer/raising-body.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { Button } from "@merninos/ui";
 import { addPlatformFee } from "@/lib/pricing";
+import { UnitPriceText, UnitWeightText } from "@/components/unit-value";
 import { ContributionsTable } from "./contributions-table";
 import type { CommitmentGroup } from "../bucket-by-lifecycle";
 
@@ -18,9 +19,6 @@ const fmtMoney = (n: number) =>
     currency: "USD",
     maximumFractionDigits: 2,
   }).format(n || 0);
-
-const fmtKg = (n: number) =>
-  new Intl.NumberFormat("en-US", { maximumFractionDigits: 1 }).format(n || 0);
 
 function fmtCountdown(deadline: string | null | undefined): string {
   if (!deadline) return "—";
@@ -93,7 +91,9 @@ export function RaisingDrawerBody({ group, tiers }: RaisingDrawerBodyProps) {
             Below minimum
           </div>
           <div className="mt-1">
-            <span className="font-bold tabular-nums">{fmtKg(gapToMin)} kg</span>{" "}
+            <span className="font-bold tabular-nums">
+              <UnitWeightText kg={gapToMin} maximumFractionDigits={0} />
+            </span>{" "}
             still needed. If the lot doesn't hit its minimum, all commits get
             refunded.
           </div>
@@ -101,13 +101,19 @@ export function RaisingDrawerBody({ group, tiers }: RaisingDrawerBodyProps) {
       )}
 
       <div className="grid grid-cols-2 gap-3 rounded-md border-2 border-espresso bg-chalk p-4">
-        <SummaryStat label="Your commits" value={`${fmtKg(myKg)} kg`} />
+        <SummaryStat
+          label="Your commits"
+          value={<UnitWeightText kg={myKg} maximumFractionDigits={1} />}
+        />
         <SummaryStat label="Your exposure" value={fmtMoney(myExposure)} />
         <SummaryStat
           label="Campaign total"
-          value={`${fmtKg(campaignTotal)} kg`}
+          value={<UnitWeightText kg={campaignTotal} maximumFractionDigits={0} />}
         />
-        <SummaryStat label="Minimum" value={`${fmtKg(minKg)} kg`} />
+        <SummaryStat
+          label="Minimum"
+          value={<UnitWeightText kg={minKg} maximumFractionDigits={0} />}
+        />
       </div>
 
       {sortedTiers.length > 0 && (
@@ -119,6 +125,7 @@ export function RaisingDrawerBody({ group, tiers }: RaisingDrawerBodyProps) {
             {sortedTiers.map((t) => {
               const tierThreshold = Number(t.min_quantity_kg);
               const tierBuyerPrice = addPlatformFee(Number(t.price_per_kg));
+              const tierSellerPrice = Number(t.price_per_kg);
               const unlocked = campaignTotal >= tierThreshold;
               const personalDelta = unlocked
                 ? 0
@@ -136,10 +143,14 @@ export function RaisingDrawerBody({ group, tiers }: RaisingDrawerBodyProps) {
                 >
                   <div className="flex items-center gap-3">
                     <span className="font-headline text-sm font-extrabold tabular-nums text-espresso">
-                      {fmtKg(tierThreshold)} kg
+                      <UnitWeightText kg={tierThreshold} maximumFractionDigits={0} />
                     </span>
                     <span className="font-body text-sm text-espresso/70 tabular-nums">
-                      {fmtMoney(tierBuyerPrice)}/kg
+                      <UnitPriceText
+                        pricePerKg={tierSellerPrice}
+                        currency="USD"
+                        includePlatformFee
+                      />
                     </span>
                   </div>
                   <div className="flex items-center gap-2">
@@ -186,7 +197,13 @@ export function RaisingDrawerBody({ group, tiers }: RaisingDrawerBodyProps) {
   );
 }
 
-function SummaryStat({ label, value }: { label: string; value: string }) {
+function SummaryStat({
+  label,
+  value,
+}: {
+  label: string;
+  value: React.ReactNode;
+}) {
   return (
     <div className="flex flex-col">
       <span className="font-body text-[10px] font-extrabold uppercase tracking-[0.14em] text-espresso/55">

--- a/components/buyer-commitments/commitment-drawer/raising-body.tsx
+++ b/components/buyer-commitments/commitment-drawer/raising-body.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+import Link from "next/link";
+import { Button } from "@merninos/ui";
+import { addPlatformFee } from "@/lib/pricing";
+import { ContributionsTable } from "./contributions-table";
+import type { CommitmentGroup } from "../bucket-by-lifecycle";
+
+export interface RaisingDrawerBodyProps {
+  group: CommitmentGroup;
+  /** Sorted ascending by min_quantity_kg from the page query. */
+  tiers: { min_quantity_kg: number; price_per_kg: number }[];
+}
+
+const fmtMoney = (n: number) =>
+  new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 2,
+  }).format(n || 0);
+
+const fmtKg = (n: number) =>
+  new Intl.NumberFormat("en-US", { maximumFractionDigits: 1 }).format(n || 0);
+
+function fmtCountdown(deadline: string | null | undefined): string {
+  if (!deadline) return "—";
+  const ms = Math.max(0, new Date(deadline).getTime() - Date.now());
+  if (ms === 0) return "Ended";
+  const d = Math.floor(ms / 86_400_000);
+  if (d > 0) return `${d}d left`;
+  const h = Math.floor(ms / 3_600_000);
+  if (h > 0) return `${h}h left`;
+  const m = Math.floor(ms / 60_000);
+  return `${m}m left`;
+}
+
+export function RaisingDrawerBody({ group, tiers }: RaisingDrawerBodyProps) {
+  const lot = group.lot;
+  const myCommits = group.commitments.filter(
+    (c) => c.status !== "cancelled" && c.payment_status !== "charge_failed"
+  );
+  const myKg = myCommits.reduce((s, c) => s + Number(c.quantity_kg || 0), 0);
+  const myExposure = myCommits.reduce(
+    (s, c) =>
+      s + Number(c.quantity_kg || 0) * addPlatformFee(Number(c.price_per_kg || 0)),
+    0
+  );
+
+  const campaignTotal = Number(lot?.committed_quantity_kg || 0);
+  const minKg = Number(lot?.min_commitment_kg || 0);
+  const belowMin = minKg > 0 && campaignTotal < minKg;
+  const gapToMin = Math.max(0, minKg - campaignTotal);
+
+  // The current tier is the highest one whose threshold has been met. If
+  // none yet, fall back to the lot's base price (which is what the buyer
+  // is currently committed at).
+  const sortedTiers = [...tiers].sort(
+    (a, b) => Number(a.min_quantity_kg) - Number(b.min_quantity_kg)
+  );
+  const unlockedTiers = sortedTiers.filter(
+    (t) => campaignTotal >= Number(t.min_quantity_kg)
+  );
+  const currentTier = unlockedTiers[unlockedTiers.length - 1] ?? null;
+  const currentBuyerPrice = addPlatformFee(
+    Number(currentTier?.price_per_kg ?? lot?.price_per_kg ?? 0)
+  );
+
+  const deadline = group.campaign?.deadline ?? lot?.commitment_deadline ?? null;
+  const commitMoreHref = `/dashboard/buyer/lot/${group.lotId}${
+    group.hubId ? `?hub=${group.hubId}` : ""
+  }`;
+
+  return (
+    <div className="flex flex-col gap-5">
+      <div className="flex items-baseline justify-between gap-3">
+        <div className="font-body text-[11px] font-extrabold uppercase tracking-[0.14em] text-espresso/60">
+          Closes in
+        </div>
+        <div
+          className="font-headline text-base font-bold text-tomato"
+          data-testid="raising-deadline"
+        >
+          {fmtCountdown(deadline)}
+        </div>
+      </div>
+
+      {belowMin && (
+        <div
+          className="rounded-md border-[3px] border-tomato bg-tomato/10 px-4 py-3 font-body text-sm text-espresso"
+          data-testid="raising-urgency"
+        >
+          <div className="font-headline text-[11px] font-extrabold uppercase tracking-[0.12em] text-tomato">
+            Below minimum
+          </div>
+          <div className="mt-1">
+            <span className="font-bold tabular-nums">{fmtKg(gapToMin)} kg</span>{" "}
+            still needed. If the lot doesn't hit its minimum, all commits get
+            refunded.
+          </div>
+        </div>
+      )}
+
+      <div className="grid grid-cols-2 gap-3 rounded-md border-2 border-espresso bg-chalk p-4">
+        <SummaryStat label="Your commits" value={`${fmtKg(myKg)} kg`} />
+        <SummaryStat label="Your exposure" value={fmtMoney(myExposure)} />
+        <SummaryStat
+          label="Campaign total"
+          value={`${fmtKg(campaignTotal)} kg`}
+        />
+        <SummaryStat label="Minimum" value={`${fmtKg(minKg)} kg`} />
+      </div>
+
+      {sortedTiers.length > 0 && (
+        <div className="flex flex-col gap-2" data-testid="raising-tier-list">
+          <div className="font-body text-[11px] font-extrabold uppercase tracking-[0.14em] text-espresso/60">
+            Pricing tiers
+          </div>
+          <div className="flex flex-col gap-1.5">
+            {sortedTiers.map((t) => {
+              const tierThreshold = Number(t.min_quantity_kg);
+              const tierBuyerPrice = addPlatformFee(Number(t.price_per_kg));
+              const unlocked = campaignTotal >= tierThreshold;
+              const personalDelta = unlocked
+                ? 0
+                : Math.max(0, (currentBuyerPrice - tierBuyerPrice) * myKg);
+              return (
+                <div
+                  key={tierThreshold}
+                  data-testid={`raising-tier-${tierThreshold}`}
+                  data-unlocked={unlocked ? "true" : "false"}
+                  className={`flex items-center justify-between gap-3 rounded-md border-2 px-3 py-2 ${
+                    unlocked
+                      ? "border-matcha bg-matcha/10"
+                      : "border-espresso/30 bg-cream/40"
+                  }`}
+                >
+                  <div className="flex items-center gap-3">
+                    <span className="font-headline text-sm font-extrabold tabular-nums text-espresso">
+                      {fmtKg(tierThreshold)} kg
+                    </span>
+                    <span className="font-body text-sm text-espresso/70 tabular-nums">
+                      {fmtMoney(tierBuyerPrice)}/kg
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    {unlocked ? (
+                      <span className="rounded-pill bg-matcha px-2 py-0.5 font-body text-[10px] font-extrabold uppercase tracking-[0.1em] text-cream">
+                        Unlocked
+                      </span>
+                    ) : (
+                      <>
+                        {personalDelta > 0 && myKg > 0 && (
+                          <span
+                            className="font-body text-xs font-bold text-tomato tabular-nums"
+                            data-testid={`raising-tier-delta-${tierThreshold}`}
+                          >
+                            +{fmtMoney(personalDelta)} if reached
+                          </span>
+                        )}
+                        <span className="rounded-pill border-[1.5px] border-espresso/40 px-2 py-0.5 font-body text-[10px] font-extrabold uppercase tracking-[0.1em] text-espresso/55">
+                          Locked
+                        </span>
+                      </>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      <div className="flex flex-col gap-2">
+        <div className="font-body text-[11px] font-extrabold uppercase tracking-[0.14em] text-espresso/60">
+          Your contributions
+        </div>
+        <ContributionsTable commitments={group.commitments} />
+      </div>
+
+      <Button asChild variant="default" size="default" className="self-start">
+        <Link href={commitMoreHref} data-testid="raising-commit-more">
+          Commit more →
+        </Link>
+      </Button>
+    </div>
+  );
+}
+
+function SummaryStat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex flex-col">
+      <span className="font-body text-[10px] font-extrabold uppercase tracking-[0.14em] text-espresso/55">
+        {label}
+      </span>
+      <span className="font-headline text-base font-extrabold tabular-nums text-espresso">
+        {value}
+      </span>
+    </div>
+  );
+}

--- a/components/buyer-commitments/in-motion-lot-card.tsx
+++ b/components/buyer-commitments/in-motion-lot-card.tsx
@@ -1,3 +1,4 @@
+import { ChevronRight } from "lucide-react";
 import { CommitmentPickupButton } from "@/components/commitment-pickup-button";
 import { UnitWeightText } from "@/components/unit-value";
 import { LifecycleTrack } from "./lifecycle-track";
@@ -5,6 +6,8 @@ import { stageOfGroup, type CommitmentGroup } from "./bucket-by-lifecycle";
 
 export interface InMotionLotCardProps {
   group: CommitmentGroup;
+  onSelect?: () => void;
+  triggerRef?: React.Ref<HTMLButtonElement>;
 }
 
 const fmtMoney = (n: number) =>
@@ -19,7 +22,7 @@ function fmtRelDays(iso: string | null | undefined): string | null {
   return `${-d}d ago`;
 }
 
-export function InMotionLotCard({ group }: InMotionLotCardProps) {
+export function InMotionLotCard({ group, onSelect, triggerRef }: InMotionLotCardProps) {
   const lot = group.lot;
   const stage = stageOfGroup(group);
   const succeeded = group.commitments.filter((c) => c.payment_status === "charge_succeeded");
@@ -52,9 +55,22 @@ export function InMotionLotCard({ group }: InMotionLotCardProps) {
             {(lot?.region || lot?.origin_country || "").toString().toUpperCase()}
             {lot?.region && lot?.origin_country ? ` · ${lot.origin_country.toUpperCase()}` : ""}
           </div>
-          <div className="mt-1 font-headline text-[20px] font-bold leading-tight text-espresso">
-            {lot?.title || "Unknown lot"}
-          </div>
+          {onSelect ? (
+            <button
+              ref={triggerRef}
+              type="button"
+              onClick={onSelect}
+              data-testid={`in-motion-card-trigger-${group.groupKey}`}
+              className="mt-1 inline-flex items-center gap-1.5 text-left font-headline text-[20px] font-bold leading-tight text-espresso transition-colors hover:text-tomato focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-tomato focus-visible:ring-offset-2 focus-visible:ring-offset-chalk rounded-sm"
+            >
+              {lot?.title || "Unknown lot"}
+              <ChevronRight className="h-4 w-4 shrink-0 text-espresso/55" strokeWidth={2.5} />
+            </button>
+          ) : (
+            <div className="mt-1 font-headline text-[20px] font-bold leading-tight text-espresso">
+              {lot?.title || "Unknown lot"}
+            </div>
+          )}
           <div className="mt-1 font-headline text-xs text-espresso/60">
             <UnitWeightText kg={myKg} maximumFractionDigits={0} /> · {fmtMoney(paid)} settled
             {refunded > 0 && (

--- a/components/buyer-commitments/portfolio-strip.tsx
+++ b/components/buyer-commitments/portfolio-strip.tsx
@@ -1,4 +1,5 @@
 import { StatCard } from "@merninos/ui";
+import { UnitWeightText } from "@/components/unit-value";
 import type { PortfolioStats } from "./bucket-by-lifecycle";
 
 export interface PortfolioStripProps {
@@ -11,11 +12,6 @@ const fmtMoney = (n: number) =>
     currency: "USD",
     maximumFractionDigits: 0,
   }).format(n || 0);
-
-const fmtKg = (kg: number) =>
-  kg >= 1000
-    ? `${(kg / 1000).toFixed(2).replace(/\.?0+$/, "")} t`
-    : `${(kg || 0).toLocaleString()} lb`;
 
 /**
  * 4-card portfolio strip for the buyer commitments page.
@@ -49,7 +45,11 @@ export function PortfolioStrip({ stats }: PortfolioStripProps) {
         className={cardClass}
         variant="sky"
         label="Landing Soon"
-        value={<Val>{fmtKg(stats.landingKg)}</Val>}
+        value={
+          <Val>
+            <UnitWeightText kg={stats.landingKg} maximumFractionDigits={0} />
+          </Val>
+        }
         sub={`${stats.inMotionCount} in motion`}
       />
       <StatCard

--- a/components/buyer-commitments/raising-lot-card.tsx
+++ b/components/buyer-commitments/raising-lot-card.tsx
@@ -2,7 +2,8 @@
 
 import Link from "next/link";
 import Image from "next/image";
-import { useEffect, useState } from "react";
+import { forwardRef, useEffect, useState } from "react";
+import { ChevronRight } from "lucide-react";
 import { Button, TierBar, type TierBarTick } from "@merninos/ui";
 import { addPlatformFee } from "@/lib/pricing";
 import { UnitPriceText, UnitWeightText } from "@/components/unit-value";
@@ -12,6 +13,10 @@ export interface RaisingLotCardProps {
   group: CommitmentGroup;
   /** Sorted ascending by min_quantity_kg from the page query. */
   pricingTiers: { min_quantity_kg: number; price_per_kg: number }[];
+  /** Fired when the buyer wants to open the per-lot drawer. */
+  onSelect?: () => void;
+  /** Forwarded to the chevron button so the parent can return focus on close. */
+  triggerRef?: React.Ref<HTMLButtonElement>;
 }
 
 const fmtMoney = (n: number) =>
@@ -32,7 +37,7 @@ function fmtCountdown(deadline: string | null | undefined, nowMs: number): { lab
   return { label: `${s}s`, goingFast };
 }
 
-export function RaisingLotCard({ group, pricingTiers }: RaisingLotCardProps) {
+export function RaisingLotCard({ group, pricingTiers, onSelect, triggerRef }: RaisingLotCardProps) {
   const [now, setNow] = useState(() => Date.now());
   useEffect(() => {
     const t = setInterval(() => setNow(Date.now()), 1000);
@@ -65,7 +70,7 @@ export function RaisingLotCard({ group, pricingTiers }: RaisingLotCardProps) {
 
   return (
     <div
-      className={`relative grid grid-cols-1 overflow-hidden rounded-[14px] border-[3px] bg-chalk shadow-flat-md md:grid-cols-[180px_1fr_220px] ${
+      className={`grid grid-cols-1 overflow-hidden rounded-[14px] border-[3px] bg-chalk shadow-flat-md md:grid-cols-[180px_1fr_220px] ${
         goingFast ? "border-tomato" : "border-espresso"
       }`}
     >
@@ -100,12 +105,25 @@ export function RaisingLotCard({ group, pricingTiers }: RaisingLotCardProps) {
           {(lot?.region || lot?.origin_country || "").toString().toUpperCase()}
           {lot?.region && lot?.origin_country ? ` · ${lot.origin_country.toUpperCase()}` : ""}
         </div>
-        <Link
-          href={`/dashboard/buyer/lot/${group.lotId}${group.hubId ? `?hub=${group.hubId}` : ""}`}
-          className="mt-1 font-headline text-[20px] font-bold leading-tight text-espresso transition-colors hover:text-tomato"
-        >
-          {lot?.title || "Unknown lot"}
-        </Link>
+        {onSelect ? (
+          <button
+            ref={triggerRef}
+            type="button"
+            onClick={onSelect}
+            data-testid={`raising-card-trigger-${group.groupKey}`}
+            className="mt-1 inline-flex items-center gap-1.5 text-left font-headline text-[20px] font-bold leading-tight text-espresso transition-colors hover:text-tomato focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-tomato focus-visible:ring-offset-2 focus-visible:ring-offset-chalk rounded-sm"
+          >
+            {lot?.title || "Unknown lot"}
+            <ChevronRight className="h-4 w-4 shrink-0 text-espresso/55" strokeWidth={2.5} />
+          </button>
+        ) : (
+          <Link
+            href={`/dashboard/buyer/lot/${group.lotId}${group.hubId ? `?hub=${group.hubId}` : ""}`}
+            className="mt-1 font-headline text-[20px] font-bold leading-tight text-espresso transition-colors hover:text-tomato"
+          >
+            {lot?.title || "Unknown lot"}
+          </Link>
+        )}
         {(lot?.farm || lot?.process) && (
           <div className="mb-3.5 mt-1 font-headline text-xs italic text-espresso/60">
             {[lot?.farm, lot?.process].filter(Boolean).join(" · ")}

--- a/components/dashboard-shell.tsx
+++ b/components/dashboard-shell.tsx
@@ -215,9 +215,11 @@ export function DashboardShell({
 
           <div className="flex-1 lg:hidden" />
 
-          {/* Right rail — unit toggle + user chip */}
+          {/* Unit toggle — visible on every breakpoint */}
+          <UnitToggle />
+
+          {/* Right rail — user chip + sign out (desktop only) */}
           <div className="hidden items-center gap-2.5 lg:flex">
-            <UnitToggle />
             <div className="text-right leading-tight whitespace-nowrap">
               <div className="font-headline text-[14px] font-bold tracking-[-0.01em] text-espresso">
                 {displayName}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -149,6 +149,12 @@ export interface Commitment {
   notes: string | null;
   picked_up_at: string | null;
   picked_up_by: string | null;
+  refund_status: string;
+  refunded_amount_cents: number;
+  refunded_at: string | null;
+  refunded_by: string | null;
+  last_refund_id: string | null;
+  refund_reason: string | null;
   created_at: string;
   updated_at: string;
   // Joined fields

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,3 +1,8 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   typescript: {
@@ -7,6 +12,16 @@ const nextConfig = {
     unoptimized: true,
   },
   transpilePackages: ["@merninos/ui"],
-}
+  // When @merninos/ui is `npm link`-ed during dev, its dist lives outside
+  // crowdroast/. Default turbopack uses the closest lockfile as the workspace
+  // root and panics with "leaves the filesystem root" when Tailwind tries to
+  // scan ../mernin-ui/dist/. Pointing the root at the parent meta repo keeps
+  // both crowdroast/ and mernin-ui/ inside bounds. Production builds on Vercel
+  // resolve @merninos/ui from the registry — no symlink, no upward traversal —
+  // so this override is harmless there.
+  turbopack: {
+    root: path.join(__dirname, ".."),
+  },
+};
 
-export default nextConfig
+export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@hookform/resolvers": "^3.9.1",
-        "@merninos/ui": "^0.2.1",
+        "@merninos/ui": "^0.2.2",
         "@radix-ui/react-accordion": "1.2.2",
         "@radix-ui/react-alert-dialog": "1.1.4",
         "@radix-ui/react-aspect-ratio": "1.1.1",
@@ -1420,10 +1420,11 @@
       }
     },
     "node_modules/@merninos/ui": {
-      "version": "0.2.1",
-      "resolved": "https://npm.pkg.github.com/download/@merninos/ui/0.2.1/6bf8eca342b5ed6eb579b011b8cc8d0eedd1506a",
-      "integrity": "sha512-A4LHoQ4ZIqaiZouSSuyyUYAG9Ll8kX+dEz5TqBCbUbMwKJiZ8cE6n9UGB2YWVNjjNvS8UXk1SRMAvxwiLEH1JQ==",
+      "version": "0.2.2",
+      "resolved": "https://npm.pkg.github.com/download/@merninos/ui/0.2.2/f2def10f1df714429bb5a6ca6a63d62c426cc8ed",
+      "integrity": "sha512-3ovPL1k93Ghpse5Y8947iRlegQHIqtpgFLi51Zdqy6Em+V/NS+orp3uIuIv9iT7tR6YmjqUHVg21mFL2BVlB4g==",
       "dependencies": {
+        "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-slot": "^1",
         "class-variance-authority": "^0.7",
         "clsx": "^2",
@@ -1434,6 +1435,319 @@
         "react": "^18 || ^19",
         "react-dom": "^18 || ^19",
         "tailwindcss": "^3 || ^4"
+      }
+    },
+    "node_modules/@merninos/ui/node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@merninos/ui/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@merninos/ui/node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@merninos/ui/node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
+      "integrity": "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@merninos/ui/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
+      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-escape-keydown": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@merninos/ui/node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
+      "integrity": "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@merninos/ui/node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
+      "integrity": "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@merninos/ui/node_modules/@radix-ui/react-id": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@merninos/ui/node_modules/@radix-ui/react-portal": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
+      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@merninos/ui/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@merninos/ui/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@merninos/ui/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@merninos/ui/node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
+      "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@merninos/ui/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@merninos/ui/node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
+      "integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@merninos/ui/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@merninos/ui/node_modules/lucide-react": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",
-    "@merninos/ui": "^0.2.1",
+    "@merninos/ui": "^0.2.2",
     "@radix-ui/react-accordion": "1.2.2",
     "@radix-ui/react-alert-dialog": "1.1.4",
     "@radix-ui/react-aspect-ratio": "1.1.1",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   test: {
     globals: true,
     include: ["**/*.test.{ts,tsx}"],
+    exclude: ["**/node_modules/**", "**/.claude/**", "**/.next/**"],
     environmentMatchGlobs: [
       // Component tests run in jsdom
       ["app/browse/**/*.test.tsx", "jsdom"],

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,1 +1,17 @@
 import "@testing-library/jest-dom";
+
+// jsdom doesn't implement matchMedia. Stub it so components that read media
+// queries (e.g. CommitmentDrawer's useDrawerSide hook) don't throw at mount.
+if (typeof window !== "undefined" && !window.matchMedia) {
+  window.matchMedia = (query: string) =>
+    ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    } as MediaQueryList);
+}


### PR DESCRIPTION
## Summary

Adds per-lot drawers to the Buyer Commitments page so buyers can drill into a per-lot breakdown of their participation in each campaign. Clicking the lot title (with the inline chevron) on any card opens a drawer, with the body content shaped by lifecycle stage:

- **Still Raising** — drives commits. Tier list with locked / unlocked state, projected savings if each locked tier is reached, urgency callout below minimum, deadline countdown, "Commit more" CTA linking to the campaign page.
- **In Motion** — confirms what's coming. Stage pill from `STAGE_META`, settled qty / paid / saved, contributions breakdown.
- **Closed (picked_up | done)** — celebrates value received. Leads with savings + qty (or just qty if savings = $0), surfaces which tier was unlocked.
- **Closed (minimum_not_met)** — reassures. Leads with refund total, no tier UI, no Commit more CTA.

Mobile responsive (bottom sheet < 768px, side drawer ≥ 768px). Slide-in / slide-out animations honor `prefers-reduced-motion`.

## Other fixes bundled in

- Unit toggle (kg ↔ lb) is now visible on every breakpoint, not just desktop
- `Landing Soon` portfolio stat and the "X landing soon" section header now respect the unit toggle
- Refund fields (`refund_status`, `refunded_amount_cents`, etc.) added to the `Commitment` TypeScript type — they were already in the schema
- `next.config.mjs` extends turbopack root to the meta workspace so dev builds tolerate `npm link`-ed `@merninos/ui` (no-op in production)

## Blocked by

This PR depends on `@merninos/ui` exposing the new `Drawer` primitive. Sequence:

1. Merge https://github.com/MerninOS/mernin-ui/pull/1
2. Run `npm run release` in `mernin-ui` to publish the new version
3. In this PR, bump `@merninos/ui` in `package.json` from `^0.2.1` to whatever was published, run `npm install`, commit
4. Mark this PR as ready for review

## Closes

Closes #57

## Test plan

- [ ] CI builds pass
- [ ] `npm test` — 53 buyer-commitments tests + full suite green (185 total)
- [ ] Buyer commitments page renders all three section types
- [ ] Click any lot title in Still Raising → drawer slides in from right (desktop) or bottom (mobile), shows tier list with projected savings
- [ ] Click any lot title in In Motion → drawer shows stage pill + breakdown; pickup button still works
- [ ] Click any closed lot row → drawer leads with savings + qty
- [ ] Min-not-met closed lot → drawer leads with refund total, no tier UI, no Commit more CTA
- [ ] Press Esc → drawer closes, focus returns to the originating title button
- [ ] Toggle kg ↔ lb in nav — Landing Soon stat, In Motion "landing soon" copy, and all drawer quantities flip
- [ ] On mobile, the unit toggle is visible in the top bar
- [ ] `prefers-reduced-motion: reduce` → drawer renders instantly, no slide

🤖 Generated with [Claude Code](https://claude.com/claude-code)