### PR TITLE
test(seed): add a min-not-met fixture for buyer-1

### DIFF
--- a/components/buyer-commitments/commitment-drawer/__tests__/closed-body.test.tsx
+++ b/components/buyer-commitments/commitment-drawer/__tests__/closed-body.test.tsx
@@ -169,7 +169,7 @@ describe("ClosedDrawerBody — value mode", () => {
 });
 
 describe("ClosedDrawerBody — refund mode", () => {
-  it("leads with the refund total and suppresses tier UI / savings / Commit more (C14)", () => {
+  it("leads with the refund total via the admin-tracked refunded_amount_cents column (C14)", () => {
     const group = makeGroup({
       commitments: [
         makeCommit({
@@ -194,5 +194,63 @@ describe("ClosedDrawerBody — refund mode", () => {
     expect(screen.queryByTestId("closed-savings")).not.toBeInTheDocument();
     expect(screen.queryByTestId("closed-tier-summary")).not.toBeInTheDocument();
     expect(screen.queryByText(/Commit more/i)).not.toBeInTheDocument();
+  });
+
+  it("uses total_price as the refund when the cron has flipped a charged commitment to cancelled", () => {
+    // The settle-deadlines cron issues a Stripe refund and updates the
+    // commitment to status=cancelled / payment_status=cancelled, but does
+    // NOT touch refunded_amount_cents. The drawer should fall back to
+    // total_price as the refund amount in that case (the buyer got back
+    // exactly what they were originally going to be charged).
+    const group = makeGroup({
+      commitments: [
+        makeCommit({
+          id: "c-cron-1",
+          status: "cancelled",
+          payment_status: "cancelled",
+          stripe_payment_intent_id: "pi_charged_then_refunded",
+          total_price: 132,
+          charge_amount_cents: 13200,
+          refunded_amount_cents: 0, // never touched by cron
+          refunded_at: null,
+          payment_error: "Refunded: lot minimum not met by deadline",
+        }),
+        makeCommit({
+          id: "c-cron-2",
+          status: "cancelled",
+          payment_status: "cancelled",
+          stripe_payment_intent_id: "pi_charged_then_refunded_2",
+          total_price: 264,
+          charge_amount_cents: 26400,
+          refunded_amount_cents: 0,
+          refunded_at: null,
+          payment_error: "Refunded: lot minimum not met by deadline",
+        }),
+      ],
+    });
+    render(<ClosedDrawerBody group={group} mode="refund" />);
+    const header = screen.getByTestId("closed-refund-header");
+    // 132 + 264 = 396
+    expect(header.textContent).toContain("$396.00");
+  });
+
+  it("shows $0 when the campaign failed before any commitment was charged", () => {
+    // Setup-Intent-only commitments that got cancelled before settlement
+    // ever processed a charge — no money moved, so no refund.
+    const group = makeGroup({
+      commitments: [
+        makeCommit({
+          status: "cancelled",
+          payment_status: "cancelled",
+          stripe_payment_intent_id: null,
+          total_price: 132,
+          charge_amount_cents: null,
+          refunded_amount_cents: 0,
+        }),
+      ],
+    });
+    render(<ClosedDrawerBody group={group} mode="refund" />);
+    const header = screen.getByTestId("closed-refund-header");
+    expect(header.textContent).toContain("$0.00");
   });
 });

--- a/components/buyer-commitments/commitment-drawer/closed-body.tsx
+++ b/components/buyer-commitments/commitment-drawer/closed-body.tsx
@@ -1,6 +1,7 @@
 import { addPlatformFee } from "@/lib/pricing";
 import { UnitPriceText, UnitWeightText } from "@/components/unit-value";
 import { ContributionsTable } from "./contributions-table";
+import { refundDollarsFor } from "./refund-amount";
 import type { CommitmentGroup } from "../bucket-by-lifecycle";
 
 export interface ClosedDrawerBodyProps {
@@ -40,7 +41,7 @@ export function ClosedDrawerBody({
     0
   );
   const totalRefund = group.commitments.reduce(
-    (s, c) => s + Number(c.refunded_amount_cents || 0),
+    (s, c) => s + refundDollarsFor(c),
     0
   );
 
@@ -55,7 +56,7 @@ export function ClosedDrawerBody({
             Lot didn't hit minimum
           </div>
           <div className="mt-1 font-headline text-3xl font-bold text-espresso tabular-nums">
-            {fmtMoney(totalRefund / 100)} refunded
+            {fmtMoney(totalRefund)} refunded
           </div>
           <div className="mt-2 font-body text-sm text-espresso/70">
             Your card has been credited. No further action needed.

--- a/components/buyer-commitments/commitment-drawer/contributions-table.tsx
+++ b/components/buyer-commitments/commitment-drawer/contributions-table.tsx
@@ -1,6 +1,7 @@
 import { Fragment } from "react";
 import type { Commitment } from "@/lib/types";
 import { UnitWeightText } from "@/components/unit-value";
+import { refundDollarsFor } from "./refund-amount";
 
 export interface ContributionsTableProps {
   commitments: Commitment[];
@@ -80,9 +81,9 @@ export function ContributionsTable({ commitments }: ContributionsTableProps) {
               c.charge_amount_cents != null
                 ? c.charge_amount_cents / 100
                 : Number(c.total_price || 0);
-            const refundCents = c.refunded_amount_cents ?? 0;
+            const refundDollars = refundDollarsFor(c);
             const refundedAt = c.refunded_at;
-            const hasRefund = refundCents > 0;
+            const hasRefund = refundDollars > 0;
             const isLast = idx === rows.length - 1;
             const parentBorder = hasRefund || !isLast ? "border-b border-espresso/15" : "";
             const refundBorder = !isLast ? "border-b border-espresso/15" : "";
@@ -121,7 +122,7 @@ export function ContributionsTable({ commitments }: ContributionsTableProps) {
                       colSpan={4}
                       className="bg-tomato/5 px-3 py-2 text-left font-body text-xs italic text-tomato"
                     >
-                      Refunded {fmtMoney(refundCents / 100)}
+                      Refunded {fmtMoney(refundDollars)}
                       {refundedAt ? ` on ${fmtDate(refundedAt)}` : ""}
                     </td>
                   </tr>

--- a/components/buyer-commitments/commitment-drawer/refund-amount.ts
+++ b/components/buyer-commitments/commitment-drawer/refund-amount.ts
@@ -1,0 +1,43 @@
+import type { Commitment } from "@/lib/types";
+
+/**
+ * Returns the refund amount in dollars for a single commitment, handling the
+ * three ways a refund can be reflected in the data:
+ *
+ * 1. **Cron-triggered min-not-met refund** — `app/api/payments/settle-deadlines`
+ *    flips `payment_status` to `cancelled` and writes a `payment_error` that
+ *    starts with `"Refunded:"`, but does NOT touch `refunded_amount_cents`.
+ *    Use `total_price` as the refund amount in this case (the buyer got back
+ *    exactly what they were going to be charged).
+ *
+ * 2. **Stripe-managed refund on a still-succeeded commitment** —
+ *    `charge_amount_cents` is already net of refunds (per the Stripe webhook
+ *    that updates it). Refund = `total_price − charge_amount_cents`.
+ *
+ * 3. **Admin manual refund** — `app/api/admin/refunds/route.ts` writes
+ *    `refunded_amount_cents` directly. Use it when present.
+ *
+ * Pick the largest of the candidates so we never double-count when paths
+ * overlap (e.g. an admin refund tracked AND charge_amount_cents already
+ * reduced by Stripe).
+ */
+export function refundDollarsFor(c: Commitment): number {
+  const billed = Number(c.total_price || 0);
+
+  // Path 1: cron-triggered cancellation after a successful charge
+  const cronRefund =
+    c.payment_status === "cancelled" && c.stripe_payment_intent_id
+      ? billed
+      : 0;
+
+  // Path 2: Stripe netted charge_amount_cents on partial/full refund
+  const stripeRefund =
+    c.payment_status === "charge_succeeded" && c.charge_amount_cents != null
+      ? Math.max(0, billed - c.charge_amount_cents / 100)
+      : 0;
+
+  // Path 3: admin manual-refund column
+  const trackedRefund = Number(c.refunded_amount_cents || 0) / 100;
+
+  return Math.max(cronRefund, stripeRefund, trackedRefund);
+}

--- a/scripts/seed-test-env.ts
+++ b/scripts/seed-test-env.ts
@@ -195,6 +195,47 @@ const PAST_DAYS = 5;
 const COMMITMENT_QUANTITY_KG = 50;
 const COMMITMENT_PRICE_PER_KG = 17.0; // matches PRICING_TIERS[1]
 
+// A min-not-met lot for buyer-1: realistic post-refund state so the
+// commitments page renders a Closed Lots card / drawer in "refund" mode
+// without having to step through the full charge → cron flow.
+//
+// Mirrors what app/api/payments/settle-deadlines/route.ts leaves behind:
+// the cron issues a Stripe refund and writes status=cancelled /
+// payment_status=cancelled on the commitment but does NOT touch
+// refunded_amount_cents — so the drawer's refundDollarsFor() helper has
+// to fall back to total_price for the displayed refund amount.
+const MIN_NOT_MET_LOT = {
+  title: "Sidamo Heirloom — Below Minimum Test",
+  origin_country: "Ethiopia",
+  region: "Sidamo",
+  farm: "Tabe Burka Cooperative",
+  variety: "Heirloom",
+  process: "Washed",
+  altitude_min: 1850,
+  altitude_max: 2050,
+  crop_year: "2025/26",
+  score: 86.0,
+  description:
+    "Test fixture: charged buyer-1 then refunded after the campaign failed to hit minimum.",
+  total_quantity_kg: 200,
+  min_commitment_kg: 100, // intentionally above what buyer-1 will commit
+  price_per_kg: 19.0,
+  currency: "USD",
+  status: "active",
+  flavor_notes: ["bergamot", "stone fruit"],
+  certifications: ["organic"],
+};
+
+const MIN_NOT_MET_PRICING_TIERS = [
+  { min_quantity_kg: 100, price_per_kg: 19.0 },
+  { min_quantity_kg: 150, price_per_kg: 17.5 },
+];
+
+// Buyer-1's commitment on the failed campaign. Below the 100kg minimum
+// so the campaign couldn't have hit it.
+const MIN_NOT_MET_QUANTITY_KG = 30;
+const MIN_NOT_MET_PRICE_PER_KG = 19.0;
+
 // A second lot that has NO campaign and a past expiry_date, so the
 // lot-expiry cron has work to do (the main lot above has an active
 // campaign, which lot-expiry intentionally skips).
@@ -392,6 +433,110 @@ async function createPaidCommitment(
   return data.id;
 }
 
+async function createMinNotMetLot(
+  supabase: SupabaseClient,
+  sellerId: string,
+  hubId: string,
+): Promise<string> {
+  const past = new Date();
+  past.setDate(past.getDate() - PAST_DAYS - 2);
+  const { data, error } = await supabase
+    .from("lots")
+    .insert({
+      seller_id: sellerId,
+      hub_id: hubId,
+      ...MIN_NOT_MET_LOT,
+      committed_quantity_kg: MIN_NOT_MET_QUANTITY_KG,
+      commitment_deadline: past.toISOString(),
+      settlement_status: "minimum_not_met",
+      settlement_processed_at: new Date().toISOString(),
+    })
+    .select("id")
+    .single();
+  if (error) throw error;
+  return data.id;
+}
+
+async function createMinNotMetPricingTiers(
+  supabase: SupabaseClient,
+  lotId: string,
+): Promise<void> {
+  const rows = MIN_NOT_MET_PRICING_TIERS.map((t) => ({ lot_id: lotId, ...t }));
+  const { error } = await supabase.from("pricing_tiers").insert(rows);
+  if (error) throw error;
+}
+
+async function createFailedCampaign(
+  supabase: SupabaseClient,
+  lotId: string,
+  hubId: string,
+): Promise<string> {
+  const past = new Date();
+  past.setDate(past.getDate() - PAST_DAYS - 2);
+  const { data, error } = await supabase
+    .from("campaigns")
+    .insert({
+      lot_id: lotId,
+      hub_id: hubId,
+      deadline: past.toISOString(),
+      status: "failed",
+      settled_at: new Date().toISOString(),
+    })
+    .select("id")
+    .single();
+  if (error) throw error;
+  return data.id;
+}
+
+/**
+ * Mirrors the post-cron state from app/api/payments/settle-deadlines after
+ * it issues a Stripe refund on a min-not-met campaign:
+ * - status: cancelled
+ * - payment_status: cancelled
+ * - stripe_payment_intent_id: present (charge happened)
+ * - charge_amount_cents: still the original charged amount
+ * - refunded_amount_cents: 0 (the cron does NOT update this — only the
+ *   admin manual-refund route does)
+ * - payment_error: "Refunded: ..."
+ *
+ * The drawer's refundDollarsFor() helper detects this shape via
+ * payment_status=cancelled + a present payment_intent_id and falls back
+ * to total_price as the displayed refund amount.
+ */
+async function createRefundedMinNotMetCommitment(
+  supabase: SupabaseClient,
+  lotId: string,
+  buyerId: string,
+  hubId: string,
+  campaignId: string,
+): Promise<string> {
+  const total_price = MIN_NOT_MET_QUANTITY_KG * MIN_NOT_MET_PRICE_PER_KG;
+  const chargedAt = new Date();
+  chargedAt.setDate(chargedAt.getDate() - PAST_DAYS - 1);
+  const { data, error } = await supabase
+    .from("commitments")
+    .insert({
+      lot_id: lotId,
+      buyer_id: buyerId,
+      hub_id: hubId,
+      campaign_id: campaignId,
+      quantity_kg: MIN_NOT_MET_QUANTITY_KG,
+      price_per_kg: MIN_NOT_MET_PRICE_PER_KG,
+      total_price,
+      status: "cancelled",
+      payment_status: "cancelled",
+      charge_amount_cents: Math.round(total_price * 100),
+      charge_currency: "USD",
+      charged_at: chargedAt.toISOString(),
+      stripe_payment_intent_id: `pi_seed_minnotmet_${Date.now()}`,
+      payment_error: "Refunded: lot minimum not met by deadline",
+    })
+    .select("id")
+    .single();
+  if (error) throw error;
+  return data.id;
+}
+
 // ---- main -------------------------------------------------------------
 
 async function main() {
@@ -470,6 +615,30 @@ async function main() {
 
     const expiredLotId = await createExpiredOnlyLot(supabase, sellerId, hubId);
     console.log(`✓ Expired-only lot created (for lot-expiry cron): ${expiredLotId}`);
+
+    const minNotMetLotId = await createMinNotMetLot(supabase, sellerId, hubId);
+    console.log(`✓ Min-not-met lot created: ${minNotMetLotId}`);
+
+    await createMinNotMetPricingTiers(supabase, minNotMetLotId);
+    console.log(`✓ ${MIN_NOT_MET_PRICING_TIERS.length} pricing tiers created for min-not-met lot`);
+
+    const failedCampaignId = await createFailedCampaign(
+      supabase,
+      minNotMetLotId,
+      hubId,
+    );
+    console.log(`✓ Failed campaign created: ${failedCampaignId}`);
+
+    const refundedCommitmentId = await createRefundedMinNotMetCommitment(
+      supabase,
+      minNotMetLotId,
+      buyerIds[0],
+      hubId,
+      failedCampaignId,
+    );
+    console.log(
+      `✓ Refunded commitment for buyer-1 on failed campaign: ${refundedCommitmentId}`,
+    );
 
     console.log("\nSeed completed.");
   } catch (err) {


### PR DESCRIPTION
## Summary

Two related changes for the Closed Lots min-not-met drawer:

### 1. Fix the displayed refund amount

The drawer's refund header was reading `commitment.refunded_amount_cents` and showing `$0.00`, because the cron at `app/api/payments/settle-deadlines/route.ts` that processes min-not-met refunds **does not touch that column** — it issues the Stripe refund, then writes `status: cancelled / payment_status: cancelled` and a `payment_error` string. Only the admin manual-refund route writes `refunded_amount_cents`.

Adds `refund-amount.ts` with a `refundDollarsFor(c)` helper that derives the refund amount from whichever path actually moved the money:

- **Cron-triggered min-not-met cancellation** — `payment_status === "cancelled"` with a `stripe_payment_intent_id` present means a charge happened then got refunded for the full `total_price`.
- **Stripe-managed refund on a still-succeeded commitment** — `total_price − charge_amount_cents / 100` (Stripe nets the latter on partial/full refund).
- **Admin manual refund** — `refunded_amount_cents / 100`.

Takes `Math.max()` across all three so we never double-count when paths overlap. Used in both the closed drawer's refund header AND the contributions table's per-row refund line so the table footer matches the per-commitment lines.

### 2. Add a min-not-met seed fixture

Seeds a second test lot whose campaign is in the `failed` state, with a single buyer-1 commitment shaped like the post-cron refund flow (the exact shape that broke the original drawer):

- `status: "cancelled"`, `payment_status: "cancelled"`
- `stripe_payment_intent_id`: present
- `charge_amount_cents`: original charged amount, preserved
- `refunded_amount_cents`: `0` (cron never touches it)
- `payment_error`: `"Refunded: lot minimum not met by deadline"`

## Run it

```bash
npm run db:seed:refresh
```

Log in as `buyer-1@crowdroast.local` (password: `test-password-123`) → `/dashboard/buyer/commitments` → "Sidamo Heirloom — Below Minimum Test" appears in Closed Lots. Open the drawer — refund header reads `$570.00 refunded` (30 kg × $19.00).

## Test plan

- [ ] CI build passes
- [ ] `npm test` — all buyer-commitments tests green (55 in this area)
- [ ] After `npm run db:seed:refresh`, buyer-1's Closed Lots section shows the new lot
- [ ] Drawer renders the actual refund amount, not `$0.00`
- [ ] Contributions table inside the drawer shows the per-commitment refund line

🤖 Generated with [Claude Code](https://claude.com/claude-code)