### PR TITLE
Buyer referral invites with credit-ledger payouts

### DIFF
--- a/app/api/admin/credits/grant/__tests__/route.test.ts
+++ b/app/api/admin/credits/grant/__tests__/route.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextResponse } from "next/server";
+
+type Result = { data: unknown; error: unknown };
+
+let nextProfileLookup: Result = { data: null, error: null };
+let nextInsertResult: Result = { data: null, error: null };
+let nextLedgerSum: Result = { data: [], error: null };
+const insertCalls: Array<Record<string, unknown>> = [];
+
+let mockCtx:
+  | { user: { id: string }; admin: unknown }
+  | { error: NextResponse } = { error: NextResponse.json({ error: "no" }, { status: 401 }) };
+
+vi.mock("@/lib/auth/admin-route", () => ({
+  requireAdminContext: vi.fn(async () => mockCtx),
+}));
+
+function adminClient() {
+  return {
+    from: vi.fn((table: string) => {
+      if (table === "profiles") {
+        return {
+          select: () => ({
+            eq: () => ({
+              maybeSingle: async () => nextProfileLookup,
+            }),
+          }),
+        };
+      }
+      if (table === "credit_ledger") {
+        return {
+          insert: (payload: Record<string, unknown>) => {
+            insertCalls.push(payload);
+            return {
+              select: () => ({
+                single: async () => nextInsertResult,
+              }),
+            };
+          },
+          select: () => ({
+            eq: () => Promise.resolve(nextLedgerSum),
+          }),
+        };
+      }
+      throw new Error(`Unexpected table ${table}`);
+    }),
+  };
+}
+
+import { POST } from "../route";
+
+function makeRequest(body: unknown): Request {
+  return new Request("http://localhost/api/admin/credits/grant", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json" },
+  });
+}
+
+beforeEach(() => {
+  nextProfileLookup = { data: null, error: null };
+  nextInsertResult = { data: null, error: null };
+  nextLedgerSum = { data: [], error: null };
+  insertCalls.length = 0;
+  mockCtx = { user: { id: "admin-1" }, admin: adminClient() };
+});
+
+describe("POST /api/admin/credits/grant", () => {
+  it("403 when caller is not admin (delegated to requireAdminContext)", async () => {
+    mockCtx = { error: NextResponse.json({ error: "Forbidden" }, { status: 403 }) };
+    const res = await POST(makeRequest({ user_id: "u-1", amount_cents: 1000 }));
+    expect(res.status).toBe(403);
+  });
+
+  it("400 when user_id missing", async () => {
+    const res = await POST(makeRequest({ amount_cents: 1000 }));
+    const body = await res.json();
+    expect(res.status).toBe(400);
+    expect(body.error).toBe("user_id_required");
+  });
+
+  it("400 when amount is zero", async () => {
+    const res = await POST(makeRequest({ user_id: "u-1", amount_cents: 0 }));
+    const body = await res.json();
+    expect(res.status).toBe(400);
+    expect(body.error).toBe("amount_cents_must_be_nonzero_integer");
+  });
+
+  it("400 when amount is non-integer", async () => {
+    const res = await POST(makeRequest({ user_id: "u-1", amount_cents: 12.5 }));
+    expect(res.status).toBe(400);
+  });
+
+  it("404 when target user does not exist", async () => {
+    nextProfileLookup = { data: null, error: null };
+    const res = await POST(makeRequest({ user_id: "ghost", amount_cents: 1000 }));
+    const body = await res.json();
+    expect(res.status).toBe(404);
+    expect(body.error).toBe("user_not_found");
+  });
+
+  it("happy positive grant: inserts admin_adjust row stamped with granting admin", async () => {
+    nextProfileLookup = { data: { id: "u-1" }, error: null };
+    nextInsertResult = {
+      data: {
+        id: "ledger-1",
+        amount_cents: 5000,
+        reason: "admin_adjust",
+        granted_by_admin_id: "admin-1",
+        note: "make-good",
+        created_at: "2026-05-06",
+      },
+      error: null,
+    };
+    nextLedgerSum = { data: [{ amount_cents: 5000 }], error: null };
+
+    const res = await POST(
+      makeRequest({ user_id: "u-1", amount_cents: 5000, note: "make-good" })
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(body.balance_cents).toBe(5000);
+    expect(body.ledger_row.reason).toBe("admin_adjust");
+    expect(body.ledger_row.granted_by_admin_id).toBe("admin-1");
+
+    expect(insertCalls).toHaveLength(1);
+    expect(insertCalls[0]).toMatchObject({
+      user_id: "u-1",
+      amount_cents: 5000,
+      reason: "admin_adjust",
+      granted_by_admin_id: "admin-1",
+      note: "make-good",
+    });
+  });
+
+  it("happy negative grant: admin can deduct", async () => {
+    nextProfileLookup = { data: { id: "u-1" }, error: null };
+    nextInsertResult = {
+      data: {
+        id: "ledger-2",
+        amount_cents: -1500,
+        reason: "admin_adjust",
+        granted_by_admin_id: "admin-1",
+        note: null,
+        created_at: "2026-05-06",
+      },
+      error: null,
+    };
+    nextLedgerSum = {
+      data: [{ amount_cents: 5000 }, { amount_cents: -1500 }],
+      error: null,
+    };
+
+    const res = await POST(makeRequest({ user_id: "u-1", amount_cents: -1500 }));
+    const body = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(body.balance_cents).toBe(3500);
+    expect(insertCalls[0].amount_cents).toBe(-1500);
+  });
+});

--- a/app/api/admin/credits/grant/route.ts
+++ b/app/api/admin/credits/grant/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from "next/server";
+import { requireAdminContext } from "@/lib/auth/admin-route";
+
+// POST /api/admin/credits/grant — admin-only credit ledger insert with reason
+// 'admin_adjust'. Negative amounts are accepted (admins can deduct). The
+// granted_by_admin_id and note are required for the audit trail — every
+// admin_adjust row carries the admin who created it.
+export async function POST(request: Request) {
+  const ctx = await requireAdminContext();
+  if (ctx.error) return ctx.error;
+
+  const body = await request.json().catch(() => null);
+  if (!body || typeof body !== "object") {
+    return NextResponse.json({ error: "invalid_body" }, { status: 400 });
+  }
+
+  const userId = typeof body.user_id === "string" ? body.user_id : "";
+  const amountCents = typeof body.amount_cents === "number" ? body.amount_cents : NaN;
+  const note = typeof body.note === "string" ? body.note : null;
+
+  if (!userId) {
+    return NextResponse.json({ error: "user_id_required" }, { status: 400 });
+  }
+  if (!Number.isInteger(amountCents) || amountCents === 0) {
+    return NextResponse.json({ error: "amount_cents_must_be_nonzero_integer" }, { status: 400 });
+  }
+
+  // Confirm the target profile exists. The admin client doesn't need this
+  // for the FK to fire, but a friendly 404 beats a Postgres error string.
+  const { data: target } = await ctx.admin
+    .from("profiles")
+    .select("id")
+    .eq("id", userId)
+    .maybeSingle();
+
+  if (!target) {
+    return NextResponse.json({ error: "user_not_found" }, { status: 404 });
+  }
+
+  const { data: row, error } = await ctx.admin
+    .from("credit_ledger")
+    .insert({
+      user_id: userId,
+      amount_cents: amountCents,
+      reason: "admin_adjust",
+      granted_by_admin_id: ctx.user.id,
+      note,
+    })
+    .select("id, amount_cents, reason, granted_by_admin_id, note, created_at")
+    .single();
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  // Compute the new balance for the success-toast.
+  const { data: ledger } = await ctx.admin
+    .from("credit_ledger")
+    .select("amount_cents")
+    .eq("user_id", userId);
+
+  const balance_cents = (ledger ?? []).reduce(
+    (sum: number, r: { amount_cents: number }) => sum + r.amount_cents,
+    0
+  );
+
+  return NextResponse.json({ ledger_row: row, balance_cents }, { status: 201 });
+}

--- a/app/api/credits/me/__tests__/route.test.ts
+++ b/app/api/credits/me/__tests__/route.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+type Result = { data: unknown; error: unknown };
+
+let currentUser: { id: string } | null = null;
+let nextResult: Result = { data: [], error: null };
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({
+    auth: { getUser: vi.fn(async () => ({ data: { user: currentUser } })) },
+    from: vi.fn(() => ({
+      select: () => ({
+        order: () => Promise.resolve(nextResult),
+      }),
+    })),
+  })),
+}));
+
+import { GET } from "../route";
+
+beforeEach(() => {
+  currentUser = null;
+  nextResult = { data: [], error: null };
+});
+
+describe("GET /api/credits/me", () => {
+  it("401 unauthenticated", async () => {
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+
+  it("balance 0 and empty ledger for fresh user", async () => {
+    currentUser = { id: "buyer-1" };
+    nextResult = { data: [], error: null };
+    const res = await GET();
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ balance_cents: 0, ledger: [] });
+  });
+
+  it("computes balance as sum of amount_cents and returns ledger rows", async () => {
+    currentUser = { id: "buyer-1" };
+    nextResult = {
+      data: [
+        {
+          id: "l-3",
+          amount_cents: -800,
+          reason: "commit_applied",
+          source_attribution_id: null,
+          source_commitment_id: "commit-1",
+          granted_by_admin_id: null,
+          note: null,
+          created_at: "2026-05-01",
+        },
+        {
+          id: "l-2",
+          amount_cents: 1000,
+          reason: "referral_earned",
+          source_attribution_id: "attr-2",
+          source_commitment_id: null,
+          granted_by_admin_id: null,
+          note: null,
+          created_at: "2026-04-15",
+        },
+        {
+          id: "l-1",
+          amount_cents: 1000,
+          reason: "referral_earned",
+          source_attribution_id: "attr-1",
+          source_commitment_id: null,
+          granted_by_admin_id: null,
+          note: null,
+          created_at: "2026-04-01",
+        },
+      ],
+      error: null,
+    };
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    // 1000 + 1000 - 800 = 1200
+    expect(body.balance_cents).toBe(1200);
+    expect(body.ledger).toHaveLength(3);
+    expect(body.ledger[0].id).toBe("l-3"); // newest first preserved
+  });
+
+  it("balance handles admin_adjust with positive and negative amounts", async () => {
+    currentUser = { id: "buyer-1" };
+    nextResult = {
+      data: [
+        {
+          id: "l-1",
+          amount_cents: 5000,
+          reason: "admin_adjust",
+          source_attribution_id: null,
+          source_commitment_id: null,
+          granted_by_admin_id: "admin-1",
+          note: "make-good for late lot",
+          created_at: "2026-05-01",
+        },
+        {
+          id: "l-2",
+          amount_cents: -2000,
+          reason: "admin_adjust",
+          source_attribution_id: null,
+          source_commitment_id: null,
+          granted_by_admin_id: "admin-1",
+          note: "correction",
+          created_at: "2026-05-02",
+        },
+      ],
+      error: null,
+    };
+    const res = await GET();
+    const body = await res.json();
+    expect(body.balance_cents).toBe(3000);
+  });
+
+  it("500 on db error", async () => {
+    currentUser = { id: "buyer-1" };
+    nextResult = { data: null, error: { message: "boom" } };
+    const res = await GET();
+    expect(res.status).toBe(500);
+  });
+});

--- a/app/api/credits/me/route.ts
+++ b/app/api/credits/me/route.ts
@@ -1,0 +1,46 @@
+import { createClient } from "@/lib/supabase/server";
+import { NextResponse } from "next/server";
+
+// GET /api/credits/me — caller's credit balance plus ledger history.
+//
+// Balance is the running SUM of amount_cents in credit_ledger for this user.
+// We also return the ledger rows themselves (newest first) so the dashboard
+// disclosure can render history without a second round-trip. RLS limits the
+// rows to the caller's own user_id.
+export async function GET() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { data, error } = await supabase
+    .from("credit_ledger")
+    .select(
+      "id, amount_cents, reason, source_attribution_id, source_commitment_id, granted_by_admin_id, note, created_at"
+    )
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  type Row = {
+    id: string;
+    amount_cents: number;
+    reason: "referral_earned" | "commit_applied" | "admin_adjust";
+    source_attribution_id: string | null;
+    source_commitment_id: string | null;
+    granted_by_admin_id: string | null;
+    note: string | null;
+    created_at: string;
+  };
+
+  const rows = (data ?? []) as Row[];
+  const balance_cents = rows.reduce((sum, r) => sum + r.amount_cents, 0);
+
+  return NextResponse.json({ balance_cents, ledger: rows });
+}

--- a/app/api/invite-codes/[code]/__tests__/route.test.ts
+++ b/app/api/invite-codes/[code]/__tests__/route.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+type SelectResult = { data: unknown; error: unknown };
+
+let nextResult: SelectResult = { data: null, error: null };
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({
+    from: vi.fn(() => ({
+      select: () => ({
+        eq: () => ({
+          maybeSingle: async () => nextResult,
+        }),
+      }),
+    })),
+  })),
+}));
+
+import { GET } from "../route";
+
+function callGet(code: string) {
+  return GET(new Request(`http://localhost/api/invite-codes/${code}`), {
+    params: Promise.resolve({ code }),
+  });
+}
+
+beforeEach(() => {
+  nextResult = { data: null, error: null };
+});
+
+describe("GET /api/invite-codes/[code]", () => {
+  it("404 when code does not exist", async () => {
+    nextResult = { data: null, error: null };
+    const res = await callGet("missing12");
+    const body = await res.json();
+    expect(res.status).toBe(404);
+    expect(body.error).toBe("invalid_or_revoked");
+  });
+
+  it("404 when code is revoked", async () => {
+    nextResult = {
+      data: {
+        code: "revoked001",
+        revoked_at: "2026-01-01T00:00:00Z",
+        hub: { id: "hub-1", name: "Test Hub", city: "Austin" },
+        inviter: { contact_name: "Alice" },
+      },
+      error: null,
+    };
+    const res = await callGet("revoked001");
+    const body = await res.json();
+    expect(res.status).toBe(404);
+    expect(body.error).toBe("invalid_or_revoked");
+  });
+
+  it("returns landing-page payload for a valid code", async () => {
+    nextResult = {
+      data: {
+        code: "validabc01",
+        revoked_at: null,
+        hub: { id: "hub-1", name: "Test Hub", city: "Austin" },
+        inviter: { contact_name: "Alice" },
+      },
+      error: null,
+    };
+    const res = await callGet("validabc01");
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body).toEqual({
+      code: "validabc01",
+      inviterName: "Alice",
+      hubId: "hub-1",
+      hubName: "Test Hub",
+      hubCity: "Austin",
+    });
+  });
+
+  it("404 when hub has been hard-deleted (defensive)", async () => {
+    nextResult = {
+      data: {
+        code: "orphancode",
+        revoked_at: null,
+        hub: null,
+        inviter: { contact_name: "Alice" },
+      },
+      error: null,
+    };
+    const res = await callGet("orphancode");
+    expect(res.status).toBe(404);
+  });
+
+  it("500 on database error", async () => {
+    nextResult = { data: null, error: { message: "boom" } };
+    const res = await callGet("anycode001");
+    expect(res.status).toBe(500);
+  });
+});

--- a/app/api/invite-codes/[code]/accept/__tests__/route.test.ts
+++ b/app/api/invite-codes/[code]/accept/__tests__/route.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+type Result = { data: unknown; error: unknown };
+
+let currentUser: { id: string } | null = null;
+let serverFromQueue: Array<{ table: string; result: Result }> = [];
+let adminFromQueue: Array<{ table: string; result: Result }> = [];
+const adminInsertCalls: Array<{ table: string; payload: Record<string, unknown> }> = [];
+const adminUpdateCalls: Array<{ table: string; payload: Record<string, unknown> }> = [];
+
+function makeChain(table: string, result: Result, sink: "server" | "admin") {
+  let pendingPayload: Record<string, unknown> | null = null;
+  let pendingOp: "select" | "insert" | "update" | null = null;
+  const chain: Record<string, unknown> = {
+    select: () => {
+      pendingOp = "select";
+      return chain;
+    },
+    insert: (payload: Record<string, unknown>) => {
+      pendingOp = "insert";
+      pendingPayload = payload;
+      if (sink === "admin") adminInsertCalls.push({ table, payload });
+      return chain;
+    },
+    update: (payload: Record<string, unknown>) => {
+      pendingOp = "update";
+      pendingPayload = payload;
+      if (sink === "admin") adminUpdateCalls.push({ table, payload });
+      return chain;
+    },
+    eq: () => chain,
+    is: () => chain,
+    maybeSingle: async () => result,
+    then: (resolve: (v: Result) => unknown) => Promise.resolve(result).then(resolve),
+  };
+  void pendingOp;
+  void pendingPayload;
+  return chain;
+}
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({
+    auth: { getUser: vi.fn(async () => ({ data: { user: currentUser } })) },
+    from: vi.fn((table: string) => {
+      const next = serverFromQueue.shift();
+      if (!next) throw new Error(`Unexpected server.from(${table})`);
+      return makeChain(table, next.result, "server");
+    }),
+  })),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({
+    from: vi.fn((table: string) => {
+      const next = adminFromQueue.shift();
+      if (!next) throw new Error(`Unexpected admin.from(${table})`);
+      return makeChain(table, next.result, "admin");
+    }),
+  })),
+}));
+
+import { POST } from "../route";
+
+function callAccept(code: string) {
+  return POST(new Request(`http://localhost/api/invite-codes/${code}/accept`, { method: "POST" }), {
+    params: Promise.resolve({ code }),
+  });
+}
+
+beforeEach(() => {
+  currentUser = null;
+  serverFromQueue = [];
+  adminFromQueue = [];
+  adminInsertCalls.length = 0;
+  adminUpdateCalls.length = 0;
+});
+
+describe("POST /api/invite-codes/[code]/accept", () => {
+  it("401 unauthenticated", async () => {
+    const res = await callAccept("anycode001");
+    expect(res.status).toBe(401);
+  });
+
+  it("404 when invite is missing", async () => {
+    currentUser = { id: "buyer-1" };
+    adminFromQueue.push({ table: "invite_codes", result: { data: null, error: null } });
+    const res = await callAccept("missing001");
+    const body = await res.json();
+    expect(res.status).toBe(404);
+    expect(body.error).toBe("invalid_or_revoked");
+  });
+
+  it("404 when invite is revoked", async () => {
+    currentUser = { id: "buyer-1" };
+    adminFromQueue.push({
+      table: "invite_codes",
+      result: {
+        data: {
+          inviter_user_id: "inviter-1",
+          hub_id: "hub-1",
+          revoked_at: "2026-01-01T00:00:00Z",
+          hub: { name: "Test Hub" },
+        },
+        error: null,
+      },
+    });
+    const res = await callAccept("revoked001");
+    expect(res.status).toBe(404);
+  });
+
+  it("400 self-invite when caller is the inviter", async () => {
+    currentUser = { id: "inviter-1" };
+    adminFromQueue.push({
+      table: "invite_codes",
+      result: {
+        data: {
+          inviter_user_id: "inviter-1",
+          hub_id: "hub-1",
+          revoked_at: null,
+          hub: { name: "Test Hub" },
+        },
+        error: null,
+      },
+    });
+    const res = await callAccept("selfcode01");
+    const body = await res.json();
+    expect(res.status).toBe(400);
+    expect(body.error).toBe("self_invite_not_allowed");
+    expect(adminInsertCalls.length).toBe(0);
+  });
+
+  it("200 already_member when caller is active in this hub", async () => {
+    currentUser = { id: "buyer-1" };
+    adminFromQueue.push({
+      table: "invite_codes",
+      result: {
+        data: {
+          inviter_user_id: "inviter-1",
+          hub_id: "hub-1",
+          revoked_at: null,
+          hub: { name: "Test Hub" },
+        },
+        error: null,
+      },
+    });
+    adminFromQueue.push({
+      table: "hub_members",
+      result: {
+        data: { hub_id: "hub-1", hub: { name: "Test Hub" } },
+        error: null,
+      },
+    });
+    const res = await callAccept("samehubcd1");
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.already_member).toBe(true);
+    expect(adminInsertCalls.length).toBe(0);
+  });
+
+  it("409 different_hub_active when caller is in another hub", async () => {
+    currentUser = { id: "buyer-1" };
+    adminFromQueue.push({
+      table: "invite_codes",
+      result: {
+        data: {
+          inviter_user_id: "inviter-1",
+          hub_id: "hub-1",
+          revoked_at: null,
+          hub: { name: "Test Hub" },
+        },
+        error: null,
+      },
+    });
+    adminFromQueue.push({
+      table: "hub_members",
+      result: {
+        data: { hub_id: "hub-2", hub: { name: "Other Hub" } },
+        error: null,
+      },
+    });
+    const res = await callAccept("diffhubcd1");
+    const body = await res.json();
+    expect(res.status).toBe(409);
+    expect(body.error).toBe("different_hub_active");
+    expect(body.currentHubName).toBe("Other Hub");
+    expect(adminInsertCalls.length).toBe(0);
+  });
+
+  it("inserts membership and stamps profile attribution when hubless", async () => {
+    currentUser = { id: "buyer-1" };
+    adminFromQueue.push({
+      table: "invite_codes",
+      result: {
+        data: {
+          inviter_user_id: "inviter-1",
+          hub_id: "hub-1",
+          revoked_at: null,
+          hub: { name: "Test Hub" },
+        },
+        error: null,
+      },
+    });
+    adminFromQueue.push({ table: "hub_members", result: { data: null, error: null } });
+    adminFromQueue.push({ table: "hub_members", result: { data: null, error: null } }); // insert
+    adminFromQueue.push({ table: "profiles", result: { data: null, error: null } }); // update
+
+    const res = await callAccept("happycode1");
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.joined).toBe(true);
+    expect(body.hubId).toBe("hub-1");
+    expect(body.hubName).toBe("Test Hub");
+
+    expect(adminInsertCalls).toHaveLength(1);
+    expect(adminInsertCalls[0].table).toBe("hub_members");
+    expect(adminInsertCalls[0].payload).toMatchObject({
+      hub_id: "hub-1",
+      user_id: "buyer-1",
+      status: "active",
+      role: "buyer",
+      invited_by_user_id: "inviter-1",
+    });
+
+    expect(adminUpdateCalls).toHaveLength(1);
+    expect(adminUpdateCalls[0].table).toBe("profiles");
+    expect(adminUpdateCalls[0].payload).toMatchObject({
+      invited_by_user_id: "inviter-1",
+      invite_code_used: "happycode1",
+    });
+  });
+});

--- a/app/api/invite-codes/[code]/accept/route.ts
+++ b/app/api/invite-codes/[code]/accept/route.ts
@@ -1,0 +1,101 @@
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { NextResponse } from "next/server";
+
+// POST /api/invite-codes/[code]/accept — logged-in user joins the snapshotted
+// hub on an invite_code. Branches per spec criteria 4 + 5:
+//
+//   already-member-of-this-hub  → 200 { already_member: true }
+//   already-active-other-hub    → 409 { error: 'different_hub_active' }
+//   self-invite                 → 400 { error: 'self_invite_not_allowed' }
+//   hubless                     → insert hub_members row, 200
+//
+// The hub_members insert goes through the service-role client because the
+// repo's hub_members RLS only lets hub owners insert; a buyer joining via a
+// link is a buyer-initiated insert that owner-RLS doesn't cover.
+export async function POST(
+  _request: Request,
+  { params }: { params: Promise<{ code: string }> }
+) {
+  const { code } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const admin = createAdminClient();
+
+  // Look up the invite. Service-role so revoked/missing codes 404 cleanly.
+  const { data: invite } = await admin
+    .from("invite_codes")
+    .select("inviter_user_id, hub_id, revoked_at, hub:hubs!invite_codes_hub_id_fkey(name)")
+    .eq("code", code)
+    .maybeSingle();
+
+  if (!invite || invite.revoked_at) {
+    return NextResponse.json({ error: "invalid_or_revoked" }, { status: 404 });
+  }
+
+  // Self-invite (logged-in inviter clicks their own link).
+  if (invite.inviter_user_id === user.id) {
+    return NextResponse.json({ error: "self_invite_not_allowed" }, { status: 400 });
+  }
+
+  // Caller's existing active membership, if any.
+  const { data: activeMembership } = await admin
+    .from("hub_members")
+    .select("hub_id, hub:hubs!hub_members_hub_id_fkey(name)")
+    .eq("user_id", user.id)
+    .eq("status", "active")
+    .maybeSingle();
+
+  if (activeMembership) {
+    if (activeMembership.hub_id === invite.hub_id) {
+      return NextResponse.json({ already_member: true });
+    }
+    const currentHub = activeMembership.hub as unknown as { name: string } | null;
+    return NextResponse.json(
+      {
+        error: "different_hub_active",
+        currentHubName: currentHub?.name ?? null,
+      },
+      { status: 409 }
+    );
+  }
+
+  // Hubless caller — insert active membership attributed to the inviter.
+  const { error: insertError } = await admin.from("hub_members").insert({
+    hub_id: invite.hub_id,
+    user_id: user.id,
+    status: "active",
+    role: "buyer",
+    joined_at: new Date().toISOString(),
+    invited_by_user_id: invite.inviter_user_id,
+  });
+
+  if (insertError) {
+    return NextResponse.json({ error: insertError.message }, { status: 500 });
+  }
+
+  // Best-effort lock-once write of profile attribution. The trigger on
+  // profiles.invited_by_user_id rejects overwrites, so wrapping this in a
+  // catch-and-ignore handler keeps the accept-route succeeding even if the
+  // user already had an inviter stamped from a prior signup-time path.
+  await admin
+    .from("profiles")
+    .update({ invited_by_user_id: invite.inviter_user_id, invite_code_used: code })
+    .eq("id", user.id)
+    .is("invited_by_user_id", null)
+    .then(() => undefined);
+
+  const inviteHub = invite.hub as unknown as { name: string } | null;
+  return NextResponse.json({
+    joined: true,
+    hubId: invite.hub_id,
+    hubName: inviteHub?.name ?? null,
+  });
+}

--- a/app/api/invite-codes/[code]/route.ts
+++ b/app/api/invite-codes/[code]/route.ts
@@ -1,0 +1,53 @@
+import { createAdminClient } from "@/lib/supabase/admin";
+import { NextResponse } from "next/server";
+
+// GET /api/invite-codes/[code] — public lookup powering the landing page.
+//
+// Logged-out visitors must be able to load the landing page, so this route
+// uses the service-role client. We return only the small set of fields the
+// landing page actually renders: inviter contact_name, hub name + city, and
+// the code itself for echo-back. Nothing PII-sensitive.
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ code: string }> }
+) {
+  const { code } = await params;
+  const admin = createAdminClient();
+
+  const { data, error } = await admin
+    .from("invite_codes")
+    .select(
+      `
+      code,
+      revoked_at,
+      hub:hubs!invite_codes_hub_id_fkey(id, name, city),
+      inviter:profiles!invite_codes_inviter_user_id_fkey(contact_name)
+      `
+    )
+    .eq("code", code)
+    .maybeSingle();
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  if (!data || data.revoked_at) {
+    return NextResponse.json({ error: "invalid_or_revoked" }, { status: 404 });
+  }
+
+  const hub = data.hub as unknown as { id: string; name: string; city: string | null } | null;
+  const inviter = data.inviter as unknown as { contact_name: string | null } | null;
+
+  if (!hub) {
+    // FK is non-null on insert, but the hub could have been hard-deleted.
+    return NextResponse.json({ error: "invalid_or_revoked" }, { status: 404 });
+  }
+
+  return NextResponse.json({
+    code: data.code,
+    inviterName: inviter?.contact_name ?? null,
+    hubId: hub.id,
+    hubName: hub.name,
+    hubCity: hub.city,
+  });
+}

--- a/app/api/invite-codes/__tests__/route.test.ts
+++ b/app/api/invite-codes/__tests__/route.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+type SelectResult = { data: unknown; error: unknown };
+
+// We model the supabase client as a tiny chain that records calls and
+// returns canned data. Each test sets up a sequence of from() responses;
+// the chain records the table+filters used for the assertion phase.
+type Chain = {
+  select: (cols?: string) => Chain;
+  insert: (payload: Record<string, unknown>) => Chain;
+  eq: (col: string, val: unknown) => Chain;
+  is: (col: string, val: unknown) => Chain;
+  maybeSingle: () => Promise<SelectResult>;
+  then: (resolve: (v: SelectResult) => unknown) => Promise<unknown>;
+  _table: string;
+  _payload?: Record<string, unknown>;
+  _eq: Record<string, unknown>;
+};
+
+let fromQueue: Array<{ table: string; result: SelectResult }> = [];
+const insertCalls: Array<{ table: string; payload: Record<string, unknown> }> = [];
+let currentUser: { id: string } | null = null;
+
+function makeChain(table: string, result: SelectResult): Chain {
+  const chain: Chain = {
+    _table: table,
+    _eq: {},
+    select() {
+      return chain;
+    },
+    insert(payload) {
+      chain._payload = payload;
+      insertCalls.push({ table, payload });
+      return chain;
+    },
+    eq(col, val) {
+      chain._eq[col] = val;
+      return chain;
+    },
+    is(col, val) {
+      chain._eq[col] = val;
+      return chain;
+    },
+    async maybeSingle() {
+      return result;
+    },
+    then(resolve) {
+      // Supabase's insert() returns a thenable. The route awaits it directly
+      // (no .single() / .maybeSingle()) so we resolve with the canned result.
+      return Promise.resolve(result).then(resolve);
+    },
+  };
+  return chain;
+}
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({
+    auth: {
+      getUser: vi.fn(async () => ({ data: { user: currentUser } })),
+    },
+    from: vi.fn((table: string) => {
+      const next = fromQueue.shift();
+      if (!next) throw new Error(`Unexpected from(${table}) — queue empty`);
+      if (next.table !== table) {
+        throw new Error(`Expected from(${next.table}) but got from(${table})`);
+      }
+      return makeChain(table, next.result);
+    }),
+  })),
+}));
+
+vi.mock("@/lib/referrals/code", () => ({
+  generateInviteCode: vi.fn(() => "fixedcode1"),
+}));
+
+import { POST } from "../route";
+
+function makeRequest(): Request {
+  return new Request("http://localhost/api/invite-codes", {
+    method: "POST",
+    headers: { origin: "https://crowdroast.test" },
+  });
+}
+
+beforeEach(() => {
+  fromQueue = [];
+  insertCalls.length = 0;
+  currentUser = null;
+});
+
+describe("POST /api/invite-codes", () => {
+  it("401 when unauthenticated", async () => {
+    currentUser = null;
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it("403 when caller has no active hub membership", async () => {
+    currentUser = { id: "buyer-1" };
+    fromQueue.push({ table: "hub_members", result: { data: null, error: null } });
+    const res = await POST(makeRequest());
+    const body = await res.json();
+    expect(res.status).toBe(403);
+    expect(body.error).toBe("active_hub_membership_required");
+  });
+
+  it("returns the existing code when one already exists (idempotency)", async () => {
+    currentUser = { id: "buyer-1" };
+    fromQueue.push({
+      table: "hub_members",
+      result: {
+        data: {
+          hub_id: "hub-1",
+          hub: { id: "hub-1", name: "Test Hub", city: "Austin" },
+        },
+        error: null,
+      },
+    });
+    fromQueue.push({
+      table: "invite_codes",
+      result: { data: { code: "existing01" }, error: null },
+    });
+
+    const res = await POST(makeRequest());
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.code).toBe("existing01");
+    expect(body.url).toBe("https://crowdroast.test/i/existing01");
+    expect(body.hubId).toBe("hub-1");
+    expect(body.hubName).toBe("Test Hub");
+    expect(insertCalls.length).toBe(0); // idempotent — no insert
+  });
+
+  it("inserts a new code when none exists", async () => {
+    currentUser = { id: "buyer-1" };
+    fromQueue.push({
+      table: "hub_members",
+      result: {
+        data: {
+          hub_id: "hub-1",
+          hub: { id: "hub-1", name: "Test Hub", city: "Austin" },
+        },
+        error: null,
+      },
+    });
+    fromQueue.push({
+      table: "invite_codes",
+      result: { data: null, error: null }, // no existing
+    });
+    fromQueue.push({
+      table: "invite_codes",
+      result: { data: null, error: null }, // insert succeeds (no error)
+    });
+
+    const res = await POST(makeRequest());
+    const body = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(body.code).toBe("fixedcode1");
+    expect(body.url).toBe("https://crowdroast.test/i/fixedcode1");
+    expect(insertCalls.length).toBe(1);
+    expect(insertCalls[0].table).toBe("invite_codes");
+    expect(insertCalls[0].payload).toMatchObject({
+      code: "fixedcode1",
+      inviter_user_id: "buyer-1",
+      hub_id: "hub-1",
+    });
+  });
+
+  it("re-reads on unique-violation race and returns the winning code", async () => {
+    currentUser = { id: "buyer-1" };
+    fromQueue.push({
+      table: "hub_members",
+      result: {
+        data: {
+          hub_id: "hub-1",
+          hub: { id: "hub-1", name: "Test Hub", city: "Austin" },
+        },
+        error: null,
+      },
+    });
+    fromQueue.push({
+      table: "invite_codes",
+      result: { data: null, error: null }, // no existing on first read
+    });
+    fromQueue.push({
+      table: "invite_codes",
+      result: { data: null, error: { code: "23505", message: "duplicate" } }, // race
+    });
+    fromQueue.push({
+      table: "invite_codes",
+      result: { data: { code: "winnerrace" }, error: null }, // re-read finds winner
+    });
+
+    const res = await POST(makeRequest());
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.code).toBe("winnerrace");
+  });
+});

--- a/app/api/invite-codes/route.ts
+++ b/app/api/invite-codes/route.ts
@@ -1,0 +1,106 @@
+import { createClient } from "@/lib/supabase/server";
+import { NextResponse } from "next/server";
+import { generateInviteCode } from "@/lib/referrals/code";
+
+// POST /api/invite-codes — get-or-create the caller's invite code.
+//
+// Idempotent: calling twice as the same authenticated buyer returns the same
+// code. The hub on the returned code is the inviter's hub at the moment the
+// code was first generated; if they later switch hubs, the snapshot stays
+// (per spec criterion 4 false-positive — invitees still go to the snapshotted
+// hub even if the inviter has moved on).
+export async function POST(request: Request) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // Caller must be an active member of some hub. The share UI is gated on
+  // this in the dashboard, but enforce server-side too.
+  const { data: membership } = await supabase
+    .from("hub_members")
+    .select("hub_id, hub:hubs!hub_members_hub_id_fkey(id, name, city)")
+    .eq("user_id", user.id)
+    .eq("status", "active")
+    .maybeSingle();
+
+  if (!membership) {
+    return NextResponse.json(
+      { error: "active_hub_membership_required" },
+      { status: 403 }
+    );
+  }
+
+  // Type assertion: the join always returns a single hub object since hub_id
+  // is a non-null FK.
+  const hub = membership.hub as unknown as { id: string; name: string; city: string | null };
+
+  const origin = request.headers.get("origin") || process.env.NEXT_PUBLIC_APP_URL || "";
+
+  // Existing active code? Return it (idempotency).
+  const { data: existing } = await supabase
+    .from("invite_codes")
+    .select("code")
+    .eq("inviter_user_id", user.id)
+    .is("revoked_at", null)
+    .maybeSingle();
+
+  if (existing) {
+    return NextResponse.json({
+      code: existing.code,
+      url: `${origin}/i/${existing.code}`,
+      hubId: hub.id,
+      hubName: hub.name,
+      hubCity: hub.city,
+    });
+  }
+
+  // Create a new one. The partial unique index on
+  // (inviter_user_id WHERE revoked_at IS NULL) guards against duplicates if
+  // two requests race; on collision, re-select and return the winner.
+  const code = generateInviteCode();
+  const { error: insertError } = await supabase.from("invite_codes").insert({
+    code,
+    inviter_user_id: user.id,
+    hub_id: hub.id,
+  });
+
+  if (insertError) {
+    // 23505 is unique_violation. Either our generated code collided (~51 bits
+    // makes this astronomically unlikely) or another request beat us to the
+    // partial unique on inviter_user_id. Either way, re-read.
+    if (insertError.code === "23505") {
+      const { data: winner } = await supabase
+        .from("invite_codes")
+        .select("code")
+        .eq("inviter_user_id", user.id)
+        .is("revoked_at", null)
+        .maybeSingle();
+      if (winner) {
+        return NextResponse.json({
+          code: winner.code,
+          url: `${origin}/i/${winner.code}`,
+          hubId: hub.id,
+          hubName: hub.name,
+          hubCity: hub.city,
+        });
+      }
+    }
+    return NextResponse.json({ error: insertError.message }, { status: 500 });
+  }
+
+  return NextResponse.json(
+    {
+      code,
+      url: `${origin}/i/${code}`,
+      hubId: hub.id,
+      hubName: hub.name,
+      hubCity: hub.city,
+    },
+    { status: 201 }
+  );
+}

--- a/app/api/payments/settle-deadlines/__tests__/orphan-cancellation.test.ts
+++ b/app/api/payments/settle-deadlines/__tests__/orphan-cancellation.test.ts
@@ -70,11 +70,23 @@ function enqueue(table: string, response: { data: unknown; error: unknown }) {
 type RpcCall = { fn: string; args: unknown };
 const rpcCalls: RpcCall[] = [];
 
+// Tables this test does not exercise (e.g., referral_attributions added by
+// the buyer-referral feature) fall back to a benign empty-data chain so we
+// don't have to enqueue a response for every cross-cutting helper that
+// happens to call from() during the cron run.
+const PASSIVE_TABLES = new Set(["referral_attributions"]);
+
 vi.mock("@/lib/supabase/admin", () => ({
   createAdminClient: vi.fn(() => ({
     from: vi.fn((table: string) => {
       const next = fromQueue.shift();
-      if (!next) throw new Error(`Unexpected from(${table}) — queue empty`);
+      if (!next) {
+        if (PASSIVE_TABLES.has(table)) {
+          pendingTable = table;
+          return makeChain({ data: [], error: null });
+        }
+        throw new Error(`Unexpected from(${table}) — queue empty`);
+      }
       return next();
     }),
     rpc: vi.fn((fn: string, args: unknown) => {

--- a/app/api/payments/settle-deadlines/route.ts
+++ b/app/api/payments/settle-deadlines/route.ts
@@ -22,6 +22,7 @@ import {
   getFinalPricePerKg,
 } from "@/lib/payments/settlement-logic";
 import { insertReferralAttributionIfEligible } from "@/lib/referrals/insert-attribution";
+import { settleAttributionIfPending } from "@/lib/referrals/settle-attribution";
 import { NextResponse } from "next/server";
 
 function isMissingPlatformSettingsTable(error: { message?: string } | null) {
@@ -944,6 +945,14 @@ async function settleDeadlines(request: Request) {
             payment_error: null,
           })
           .eq("id", commitment.id);
+
+        // Buyer-referral: lot settled successfully for this commit. If the
+        // invitee's first-charged commitment was this one, flip the pending
+        // attribution to earned and emit the +$10 credit_ledger row for the
+        // inviter. Idempotent — partial unique index handles cron retries.
+        if (!debug) {
+          await settleAttributionIfPending(admin, commitment.id);
+        }
 
         succeededCount += 1;
       } catch (transferError) {

--- a/app/api/payments/settle-deadlines/route.ts
+++ b/app/api/payments/settle-deadlines/route.ts
@@ -4,6 +4,7 @@ import { authorizeCronRequest } from "@/lib/auth/cron-route";
 import {
   sendLotClosedEmailsBatch,
   sendLotFailedEmail,
+  sendReferralCreditEarnedEmail,
 } from "@/lib/email";
 import { finalizeCampaign } from "@/lib/lots/finalize-campaign";
 import { createShipmentForLot } from "@/lib/shipments";
@@ -973,8 +974,37 @@ async function settleDeadlines(request: Request) {
         // invitee's first-charged commitment was this one, flip the pending
         // attribution to earned and emit the +$10 credit_ledger row for the
         // inviter. Idempotent — partial unique index handles cron retries.
+        // When the helper signals a fresh ledger insert (earned=true), fire
+        // ReferralCreditEarned to the inviter as a background task so a
+        // delivery hiccup never fails the cron loop.
         if (!debug) {
-          await settleAttributionIfPending(admin, commitment.id);
+          const settleResult = await settleAttributionIfPending(admin, commitment.id);
+          if (settleResult.earned && settleResult.inviterUserId) {
+            const inviterUserId = settleResult.inviterUserId;
+            backgroundTasks.push(
+              (async () => {
+                const { data: inviterProfile } = await admin
+                  .from("profiles")
+                  .select("email, contact_name")
+                  .eq("id", inviterUserId)
+                  .maybeSingle();
+                const { data: inviteeProfile } = await admin
+                  .from("profiles")
+                  .select("contact_name")
+                  .eq("id", commitment.buyer_id)
+                  .maybeSingle();
+                if (!inviterProfile?.email) return;
+                await sendReferralCreditEarnedEmail({
+                  inviter: {
+                    email: inviterProfile.email,
+                    contact_name: inviterProfile.contact_name,
+                  },
+                  inviteeName: inviteeProfile?.contact_name || "A new roaster",
+                  lotTitle: lot?.title ?? null,
+                });
+              })().catch(() => undefined)
+            );
+          }
         }
 
         succeededCount += 1;

--- a/app/api/payments/settle-deadlines/route.ts
+++ b/app/api/payments/settle-deadlines/route.ts
@@ -23,6 +23,7 @@ import {
 } from "@/lib/payments/settlement-logic";
 import { insertReferralAttributionIfEligible } from "@/lib/referrals/insert-attribution";
 import { settleAttributionIfPending } from "@/lib/referrals/settle-attribution";
+import { voidAttributionsForCampaign } from "@/lib/referrals/void-attribution";
 import { NextResponse } from "next/server";
 
 function isMissingPlatformSettingsTable(error: { message?: string } | null) {
@@ -523,6 +524,12 @@ async function settleDeadlines(request: Request) {
 
       // AC-7: notify all parties that the campaign failed
       if (!debug) backgroundTasks.push(sendLotFailedNotifications(admin, lot.id, campaign.hub_id));
+
+      // Buyer-referral: lot failed → void any pending attributions tied to
+      // this campaign. Earned attributions are untouched (criterion 8).
+      // No credit_ledger writes — voiding never moves money.
+      if (!debug) await voidAttributionsForCampaign(admin, campaign.id);
+
       continue;
     }
 

--- a/app/api/payments/settle-deadlines/route.ts
+++ b/app/api/payments/settle-deadlines/route.ts
@@ -24,6 +24,7 @@ import {
 import { insertReferralAttributionIfEligible } from "@/lib/referrals/insert-attribution";
 import { settleAttributionIfPending } from "@/lib/referrals/settle-attribution";
 import { voidAttributionsForCampaign } from "@/lib/referrals/void-attribution";
+import { applyInviterCreditOnSettle } from "@/lib/referrals/apply-credit";
 import { NextResponse } from "next/server";
 
 function isMissingPlatformSettingsTable(error: { message?: string } | null) {
@@ -881,7 +882,22 @@ async function settleDeadlines(request: Request) {
           "crowdroast",
           crowdroastDestinationAccount
         );
-        const missingPlatformAmount = Math.max(0, split.platformAmount - existingPlatformAmount);
+
+        // Buyer-referral: apply the buyer's credit balance against Mernin's
+        // share on this commit (criteria 9, 10). Inserts a single negative
+        // credit_ledger row and reduces Mernin's effective platform target
+        // by that amount. Idempotent across cron retries via the partial
+        // unique index on (source_commitment_id) WHERE reason='commit_applied'.
+        const creditApplication = debug
+          ? { applied: 0, adjustedPlatformAmountCents: split.platformAmount, ledgerRowInserted: false }
+          : await applyInviterCreditOnSettle(admin, {
+              commitmentId: commitment.id,
+              buyerId: commitment.buyer_id,
+              platformAmountCents: split.platformAmount,
+            });
+
+        const adjustedPlatformAmount = creditApplication.adjustedPlatformAmountCents;
+        const missingPlatformAmount = Math.max(0, adjustedPlatformAmount - existingPlatformAmount);
         if (debug) {
           debugCommitments.push({
             commitment_id: commitment.id,

--- a/app/api/payments/settle-deadlines/route.ts
+++ b/app/api/payments/settle-deadlines/route.ts
@@ -21,6 +21,7 @@ import {
   computeSplit,
   getFinalPricePerKg,
 } from "@/lib/payments/settlement-logic";
+import { insertReferralAttributionIfEligible } from "@/lib/referrals/insert-attribution";
 import { NextResponse } from "next/server";
 
 function isMissingPlatformSettingsTable(error: { message?: string } | null) {
@@ -734,6 +735,12 @@ async function settleDeadlines(request: Request) {
                 payment_status: "charge_succeeded",
               })
               .eq("id", commitment.id);
+
+            // Buyer-referral: settlement just self-corrected this commitment
+            // to charge_succeeded after a missed webhook. Helper is
+            // idempotent so calling it here is safe even if the webhook
+            // ever lands later.
+            await insertReferralAttributionIfEligible(admin, commitment.id);
           }
         } catch {
           // Keep original flow below; commitment will be marked failed with details.

--- a/app/api/referrals/me/__tests__/route.test.ts
+++ b/app/api/referrals/me/__tests__/route.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+type Result = { data: unknown; error: unknown };
+
+let currentUser: { id: string } | null = null;
+let nextResult: Result = { data: [], error: null };
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({
+    auth: { getUser: vi.fn(async () => ({ data: { user: currentUser } })) },
+    from: vi.fn(() => ({
+      select: () => ({
+        order: () => Promise.resolve(nextResult),
+      }),
+    })),
+  })),
+}));
+
+import { GET } from "../route";
+
+beforeEach(() => {
+  currentUser = null;
+  nextResult = { data: [], error: null };
+});
+
+describe("GET /api/referrals/me", () => {
+  it("401 unauthenticated", async () => {
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+
+  it("returns empty groups for a buyer with no referrals", async () => {
+    currentUser = { id: "buyer-1" };
+    nextResult = { data: [], error: null };
+    const res = await GET();
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ pending: [], earned: [], voided: [] });
+  });
+
+  it("groups attributions by status", async () => {
+    currentUser = { id: "buyer-1" };
+    nextResult = {
+      data: [
+        {
+          id: "a-1",
+          status: "pending",
+          earned_at: null,
+          created_at: "2026-04-01",
+          invitee: { contact_name: "Alice", company_name: "Alice Roasters" },
+        },
+        {
+          id: "a-2",
+          status: "earned",
+          earned_at: "2026-04-15",
+          created_at: "2026-04-10",
+          invitee: { contact_name: "Bob", company_name: null },
+        },
+        {
+          id: "a-3",
+          status: "voided",
+          earned_at: null,
+          created_at: "2026-04-20",
+          invitee: { contact_name: "Carol", company_name: null },
+        },
+        {
+          id: "a-4",
+          status: "earned",
+          earned_at: "2026-05-01",
+          created_at: "2026-04-25",
+          invitee: { contact_name: "Dave", company_name: null },
+        },
+      ],
+      error: null,
+    };
+
+    const res = await GET();
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.pending).toHaveLength(1);
+    expect(body.earned).toHaveLength(2);
+    expect(body.voided).toHaveLength(1);
+    expect(body.earned.map((r: { id: string }) => r.id)).toEqual(["a-2", "a-4"]);
+  });
+
+  it("500 on db error", async () => {
+    currentUser = { id: "buyer-1" };
+    nextResult = { data: null, error: { message: "boom" } };
+    const res = await GET();
+    expect(res.status).toBe(500);
+  });
+});

--- a/app/api/referrals/me/__tests__/route.test.ts
+++ b/app/api/referrals/me/__tests__/route.test.ts
@@ -3,14 +3,25 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 type Result = { data: unknown; error: unknown };
 
 let currentUser: { id: string } | null = null;
-let nextResult: Result = { data: [], error: null };
+let attributionsResult: Result = { data: [], error: null };
+let invitedProfilesResult: Result = { data: [], error: null };
 
 vi.mock("@/lib/supabase/server", () => ({
   createClient: vi.fn(async () => ({
     auth: { getUser: vi.fn(async () => ({ data: { user: currentUser } })) },
     from: vi.fn(() => ({
       select: () => ({
-        order: () => Promise.resolve(nextResult),
+        order: () => Promise.resolve(attributionsResult),
+      }),
+    })),
+  })),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({
+    from: vi.fn(() => ({
+      select: () => ({
+        eq: () => Promise.resolve(invitedProfilesResult),
       }),
     })),
   })),
@@ -20,7 +31,8 @@ import { GET } from "../route";
 
 beforeEach(() => {
   currentUser = null;
-  nextResult = { data: [], error: null };
+  attributionsResult = { data: [], error: null };
+  invitedProfilesResult = { data: [], error: null };
 });
 
 describe("GET /api/referrals/me", () => {
@@ -29,46 +41,26 @@ describe("GET /api/referrals/me", () => {
     expect(res.status).toBe(401);
   });
 
-  it("returns empty groups for a buyer with no referrals", async () => {
+  it("returns empty groups for a buyer with no invitees of any kind", async () => {
     currentUser = { id: "buyer-1" };
-    nextResult = { data: [], error: null };
+    attributionsResult = { data: [], error: null };
+    invitedProfilesResult = { data: [], error: null };
     const res = await GET();
     const body = await res.json();
     expect(res.status).toBe(200);
-    expect(body).toEqual({ pending: [], earned: [], voided: [] });
+    expect(body).toEqual({ joined: [], pending: [], earned: [], voided: [] });
   });
 
-  it("groups attributions by status", async () => {
+  it("includes signup-only invitees in the joined group when no attribution exists", async () => {
     currentUser = { id: "buyer-1" };
-    nextResult = {
+    attributionsResult = { data: [], error: null };
+    invitedProfilesResult = {
       data: [
         {
-          id: "a-1",
-          status: "pending",
-          earned_at: null,
+          id: "invitee-1",
+          contact_name: "Alice",
+          company_name: "Alice Roasters",
           created_at: "2026-04-01",
-          invitee: { contact_name: "Alice", company_name: "Alice Roasters" },
-        },
-        {
-          id: "a-2",
-          status: "earned",
-          earned_at: "2026-04-15",
-          created_at: "2026-04-10",
-          invitee: { contact_name: "Bob", company_name: null },
-        },
-        {
-          id: "a-3",
-          status: "voided",
-          earned_at: null,
-          created_at: "2026-04-20",
-          invitee: { contact_name: "Carol", company_name: null },
-        },
-        {
-          id: "a-4",
-          status: "earned",
-          earned_at: "2026-05-01",
-          created_at: "2026-04-25",
-          invitee: { contact_name: "Dave", company_name: null },
         },
       ],
       error: null,
@@ -77,15 +69,104 @@ describe("GET /api/referrals/me", () => {
     const res = await GET();
     const body = await res.json();
     expect(res.status).toBe(200);
-    expect(body.pending).toHaveLength(1);
-    expect(body.earned).toHaveLength(2);
-    expect(body.voided).toHaveLength(1);
-    expect(body.earned.map((r: { id: string }) => r.id)).toEqual(["a-2", "a-4"]);
+    expect(body.joined).toHaveLength(1);
+    expect(body.joined[0]).toMatchObject({
+      id: "invitee-1",
+      status: "joined",
+      invitee: { contact_name: "Alice", company_name: "Alice Roasters" },
+    });
+    expect(body.pending).toHaveLength(0);
   });
 
-  it("500 on db error", async () => {
+  it("dedupes: an invitee with an attribution row does NOT also show in joined", async () => {
     currentUser = { id: "buyer-1" };
-    nextResult = { data: null, error: { message: "boom" } };
+    attributionsResult = {
+      data: [
+        {
+          id: "attr-1",
+          status: "pending",
+          earned_at: null,
+          created_at: "2026-04-15",
+          invitee_user_id: "invitee-1",
+          invitee: { contact_name: "Alice", company_name: null },
+        },
+      ],
+      error: null,
+    };
+    invitedProfilesResult = {
+      data: [
+        // Same invitee — should NOT appear in joined since they have an attribution.
+        {
+          id: "invitee-1",
+          contact_name: "Alice",
+          company_name: null,
+          created_at: "2026-04-01",
+        },
+        // A different invitee with no attribution yet.
+        {
+          id: "invitee-2",
+          contact_name: "Bob",
+          company_name: null,
+          created_at: "2026-04-20",
+        },
+      ],
+      error: null,
+    };
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(body.pending).toHaveLength(1);
+    expect(body.pending[0].invitee.contact_name).toBe("Alice");
+    expect(body.joined).toHaveLength(1);
+    expect(body.joined[0].invitee.contact_name).toBe("Bob");
+  });
+
+  it("groups attribution rows by status (pending / earned / voided)", async () => {
+    currentUser = { id: "buyer-1" };
+    attributionsResult = {
+      data: [
+        {
+          id: "a-1",
+          status: "pending",
+          earned_at: null,
+          created_at: "2026-04-01",
+          invitee_user_id: "i-1",
+          invitee: { contact_name: "Alice", company_name: null },
+        },
+        {
+          id: "a-2",
+          status: "earned",
+          earned_at: "2026-04-15",
+          created_at: "2026-04-10",
+          invitee_user_id: "i-2",
+          invitee: { contact_name: "Bob", company_name: null },
+        },
+        {
+          id: "a-3",
+          status: "voided",
+          earned_at: null,
+          created_at: "2026-04-20",
+          invitee_user_id: "i-3",
+          invitee: { contact_name: "Carol", company_name: null },
+        },
+      ],
+      error: null,
+    };
+    invitedProfilesResult = { data: [], error: null };
+
+    const res = await GET();
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.pending).toHaveLength(1);
+    expect(body.earned).toHaveLength(1);
+    expect(body.voided).toHaveLength(1);
+    expect(body.joined).toHaveLength(0);
+  });
+
+  it("500 on attributions query error", async () => {
+    currentUser = { id: "buyer-1" };
+    attributionsResult = { data: null, error: { message: "boom" } };
     const res = await GET();
     expect(res.status).toBe(500);
   });

--- a/app/api/referrals/me/route.ts
+++ b/app/api/referrals/me/route.ts
@@ -1,10 +1,24 @@
 import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
 import { NextResponse } from "next/server";
 
-// GET /api/referrals/me — inviter-facing list of attributions, grouped by
-// status. RLS on referral_attributions only lets the inviter read rows where
-// inviter_user_id = auth.uid(), so the cookie-bound client returns exactly
-// the right scope without an extra filter here.
+// GET /api/referrals/me — inviter-facing list, grouped by status.
+//
+//   joined   — invitee signed up but hasn't reached charge_succeeded yet
+//              (no referral_attributions row exists yet). Sourced from
+//              profiles.invited_by_user_id directly so the inviter sees
+//              their friend immediately on signup, not just after first
+//              charge.
+//   pending  — first charge succeeded, awaiting lot settle.
+//   earned   — lot settled successfully, $10 credit landed.
+//   voided   — lot failed; never paying out for this attribution.
+//
+// referral_attributions is RLS-scoped to inviter_user_id = auth.uid() so the
+// cookie-bound client handles that. The joined-only query reads profiles
+// scoped by invited_by_user_id; we use the service-role client there because
+// the standard profile RLS doesn't grant a user read access to other users'
+// profile rows. We constrain the read to invited_by_user_id = caller and
+// only return contact_name / company_name — no PII like email.
 export async function GET() {
   const supabase = await createClient();
   const {
@@ -15,33 +29,70 @@ export async function GET() {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const { data, error } = await supabase
+  const { data: attributions, error: attrErr } = await supabase
     .from("referral_attributions")
     .select(
       `
-      id, status, earned_at, created_at,
+      id, status, earned_at, created_at, invitee_user_id,
       invitee:profiles!referral_attributions_invitee_user_id_fkey(contact_name, company_name)
       `
     )
     .order("created_at", { ascending: false });
 
-  if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
+  if (attrErr) {
+    return NextResponse.json({ error: attrErr.message }, { status: 500 });
   }
 
-  type Row = {
+  type AttrRow = {
     id: string;
     status: "pending" | "earned" | "voided";
     earned_at: string | null;
     created_at: string;
+    invitee_user_id: string;
     invitee: { contact_name: string | null; company_name: string | null } | null;
   };
 
-  const rows = (data ?? []) as unknown as Row[];
+  const attrRows = (attributions ?? []) as unknown as AttrRow[];
+  const attributedInviteeIds = new Set(attrRows.map((r) => r.invitee_user_id));
+
+  // Joined-but-not-yet-attributed: profiles where invited_by_user_id = me
+  // AND no attribution row exists yet. Service-role read scoped to the
+  // calling user's id at the WHERE clause.
+  const admin = createAdminClient();
+  const { data: invitedProfiles } = await admin
+    .from("profiles")
+    .select("id, contact_name, company_name, created_at")
+    .eq("invited_by_user_id", user.id);
+
+  type InvitedProfile = {
+    id: string;
+    contact_name: string | null;
+    company_name: string | null;
+    created_at: string;
+  };
+
+  type JoinedRow = {
+    id: string;
+    status: "joined";
+    earned_at: null;
+    created_at: string;
+    invitee: { contact_name: string | null; company_name: string | null };
+  };
+
+  const joined: JoinedRow[] = ((invitedProfiles ?? []) as InvitedProfile[])
+    .filter((p) => !attributedInviteeIds.has(p.id))
+    .map((p) => ({
+      id: p.id,
+      status: "joined" as const,
+      earned_at: null,
+      created_at: p.created_at,
+      invitee: { contact_name: p.contact_name, company_name: p.company_name },
+    }));
 
   return NextResponse.json({
-    pending: rows.filter((r) => r.status === "pending"),
-    earned: rows.filter((r) => r.status === "earned"),
-    voided: rows.filter((r) => r.status === "voided"),
+    joined,
+    pending: attrRows.filter((r) => r.status === "pending"),
+    earned: attrRows.filter((r) => r.status === "earned"),
+    voided: attrRows.filter((r) => r.status === "voided"),
   });
 }

--- a/app/api/referrals/me/route.ts
+++ b/app/api/referrals/me/route.ts
@@ -1,0 +1,47 @@
+import { createClient } from "@/lib/supabase/server";
+import { NextResponse } from "next/server";
+
+// GET /api/referrals/me — inviter-facing list of attributions, grouped by
+// status. RLS on referral_attributions only lets the inviter read rows where
+// inviter_user_id = auth.uid(), so the cookie-bound client returns exactly
+// the right scope without an extra filter here.
+export async function GET() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { data, error } = await supabase
+    .from("referral_attributions")
+    .select(
+      `
+      id, status, earned_at, created_at,
+      invitee:profiles!referral_attributions_invitee_user_id_fkey(contact_name, company_name)
+      `
+    )
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  type Row = {
+    id: string;
+    status: "pending" | "earned" | "voided";
+    earned_at: string | null;
+    created_at: string;
+    invitee: { contact_name: string | null; company_name: string | null } | null;
+  };
+
+  const rows = (data ?? []) as unknown as Row[];
+
+  return NextResponse.json({
+    pending: rows.filter((r) => r.status === "pending"),
+    earned: rows.filter((r) => r.status === "earned"),
+    voided: rows.filter((r) => r.status === "voided"),
+  });
+}

--- a/app/api/referrals/signup-notify/route.ts
+++ b/app/api/referrals/signup-notify/route.ts
@@ -1,0 +1,75 @@
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { sendReferralSignupEmail } from "@/lib/email";
+import { NextResponse } from "next/server";
+
+// POST /api/referrals/signup-notify — best-effort, idempotent helper that
+// sends ReferralSignup to the inviter once per attributed user. The dashboard
+// layout fires this on first load for any user who has invited_by_user_id
+// set AND referral_signup_email_sent_at null.
+//
+// PG triggers can't emit email, so this is the v1 mechanism. The
+// referral_signup_email_sent_at stamp on profiles makes it idempotent
+// regardless of how many times the dashboard re-mounts.
+export async function POST() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const admin = createAdminClient();
+
+  // Load the invitee's profile + the inviter we'd notify.
+  const { data: invitee } = await admin
+    .from("profiles")
+    .select("contact_name, company_name, invited_by_user_id, referral_signup_email_sent_at")
+    .eq("id", user.id)
+    .maybeSingle();
+
+  if (!invitee) {
+    return NextResponse.json({ error: "profile_not_found" }, { status: 404 });
+  }
+
+  if (!invitee.invited_by_user_id || invitee.referral_signup_email_sent_at) {
+    return NextResponse.json({ skipped: true });
+  }
+
+  const { data: inviter } = await admin
+    .from("profiles")
+    .select("email, contact_name")
+    .eq("id", invitee.invited_by_user_id)
+    .maybeSingle();
+
+  // Best-effort: load the snapshotted hub on the invite_code so the email
+  // names the right hub even if the inviter has since switched.
+  const { data: membership } = await admin
+    .from("hub_members")
+    .select("hub:hubs!hub_members_hub_id_fkey(name)")
+    .eq("user_id", user.id)
+    .eq("status", "active")
+    .maybeSingle();
+
+  const hub = (membership?.hub as unknown as { name: string } | null) ?? null;
+
+  if (inviter?.email && hub?.name) {
+    await sendReferralSignupEmail({
+      inviter: { email: inviter.email, contact_name: inviter.contact_name },
+      invitee: { contact_name: invitee.contact_name, company_name: invitee.company_name },
+      hubName: hub.name,
+    }).catch(() => undefined);
+  }
+
+  // Stamp regardless — we don't want to retry on transient send failures
+  // forever on every dashboard load. Manual admin re-send is the escape
+  // hatch if delivery actually fails.
+  await admin
+    .from("profiles")
+    .update({ referral_signup_email_sent_at: new Date().toISOString() })
+    .eq("id", user.id);
+
+  return NextResponse.json({ sent: true });
+}

--- a/app/api/stripe/webhook/__tests__/webhook-failure-events.test.ts
+++ b/app/api/stripe/webhook/__tests__/webhook-failure-events.test.ts
@@ -39,6 +39,11 @@ function makeChain(table: string) {
       filters.push({ op: "is", col, val });
       return chain;
     }),
+    // Post-update commitment lookup added by buyer-referral wiring uses
+    // .maybeSingle(); resolving to null means the helper short-circuits
+    // (no commitment row to look up an inviter for) which is fine for these
+    // failure-path tests that don't need attribution behavior.
+    maybeSingle: vi.fn(async () => ({ data: null, error: null })),
     then: (resolve: (v: unknown) => void) => {
       if (pendingPayload) {
         updateCalls.push({ table, payload: pendingPayload, filters: [...filters] });

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -1,5 +1,6 @@
 import { createAdminClient } from "@/lib/supabase/admin";
 import { getPaymentIntent, verifyStripeWebhookSignature } from "@/lib/stripe";
+import { insertReferralAttributionIfEligible } from "@/lib/referrals/insert-attribution";
 import { NextResponse } from "next/server";
 
 interface StripeEvent {
@@ -71,6 +72,21 @@ export async function POST(request: Request) {
           .from("commitments")
           .update(updatePayload)
           .eq("stripe_checkout_session_id", session.id);
+
+        // Buyer-referral: when this update flipped payment_status to
+        // charge_succeeded, attempt to create the (pending) attribution row.
+        // Helper is idempotent — safe to call alongside the payment_intent
+        // .succeeded handler below which may also fire for the same commit.
+        if (updatePayload.payment_status === "charge_succeeded") {
+          const { data: commitmentRow } = await admin
+            .from("commitments")
+            .select("id")
+            .eq("stripe_checkout_session_id", session.id)
+            .maybeSingle();
+          if (commitmentRow?.id) {
+            await insertReferralAttributionIfEligible(admin, commitmentRow.id);
+          }
+        }
       } else if (session.mode === "setup") {
         const admin = createAdminClient();
 
@@ -111,6 +127,9 @@ export async function POST(request: Request) {
             payment_error: null,
           })
           .eq("id", paymentIntent.metadata.commitment_id);
+
+        // Buyer-referral: first charge_succeeded creates the attribution row.
+        await insertReferralAttributionIfEligible(admin, paymentIntent.metadata.commitment_id);
       }
     }
 

--- a/app/auth/sign-up/page.tsx
+++ b/app/auth/sign-up/page.tsx
@@ -36,6 +36,11 @@ function SignUpForm() {
   const [isLoading, setIsLoading] = useState(false);
   const router = useRouter();
 
+  // Buyer referral invites: any ?invite=[code] query param is threaded through
+  // raw_user_meta_data so the handle_new_user trigger (migration 32) writes
+  // profile + hub_members attribution at signup time.
+  const inviteCode = searchParams.get("invite") ?? "";
+
   const handleSignUp = async (e: React.FormEvent) => {
     e.preventDefault();
     const supabase = createClient();
@@ -49,6 +54,13 @@ function SignUpForm() {
     }
 
     try {
+      const signUpData: Record<string, unknown> = {
+        role: "buyer",
+        company_name: companyName,
+        contact_name: contactName,
+      };
+      if (inviteCode) signUpData.invite_code = inviteCode;
+
       const { error } = await supabase.auth.signUp({
         email,
         password,
@@ -56,11 +68,7 @@ function SignUpForm() {
           emailRedirectTo:
             process.env.NEXT_PUBLIC_DEV_SUPABASE_REDIRECT_URL ||
             `${window.location.origin}/dashboard`,
-          data: {
-            role: "buyer",
-            company_name: companyName,
-            contact_name: contactName,
-          },
+          data: signUpData,
         },
       });
       if (error) throw error;

--- a/app/dashboard/admin/credits/CreditGrantForm.tsx
+++ b/app/dashboard/admin/credits/CreditGrantForm.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { useState } from "react";
+
+type GrantResponse = {
+  ledger_row: {
+    id: string;
+    amount_cents: number;
+    reason: string;
+    granted_by_admin_id: string;
+    note: string | null;
+    created_at: string;
+  };
+  balance_cents: number;
+};
+
+export function CreditGrantForm() {
+  const [userId, setUserId] = useState("");
+  const [amountDollars, setAmountDollars] = useState("");
+  const [note, setNote] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [result, setResult] = useState<GrantResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    setResult(null);
+
+    const amountCents = Math.round(parseFloat(amountDollars) * 100);
+    if (!Number.isInteger(amountCents) || amountCents === 0) {
+      setError("Enter a non-zero dollar amount.");
+      setSubmitting(false);
+      return;
+    }
+
+    try {
+      const res = await fetch("/api/admin/credits/grant", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          user_id: userId.trim(),
+          amount_cents: amountCents,
+          note: note.trim() || null,
+        }),
+      });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setError(body?.error || "Couldn't grant credits.");
+        setSubmitting(false);
+        return;
+      }
+      setResult(body as GrantResponse);
+      setAmountDollars("");
+      setNote("");
+    } catch {
+      setError("Network error. Try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="rounded-xl border-3 p-6 flex flex-col gap-4"
+      style={{
+        background: "#FDFAF0",
+        borderColor: "#1C0F05",
+        boxShadow: "5px 5px 0 #1C0F05",
+      }}
+    >
+      <div>
+        <label
+          htmlFor="user_id"
+          className="block text-xs font-bold uppercase tracking-[0.08em] mb-1"
+          style={{ color: "#1C0F05" }}
+        >
+          User ID
+        </label>
+        <input
+          id="user_id"
+          type="text"
+          required
+          placeholder="uuid"
+          value={userId}
+          onChange={(e) => setUserId(e.target.value)}
+          className="w-full rounded-md border-2 px-3 py-2 text-sm font-mono"
+          style={{ borderColor: "#1C0F05", background: "#F5F0D8", color: "#1C0F05" }}
+        />
+      </div>
+
+      <div>
+        <label
+          htmlFor="amount"
+          className="block text-xs font-bold uppercase tracking-[0.08em] mb-1"
+          style={{ color: "#1C0F05" }}
+        >
+          Amount (dollars; negative deducts)
+        </label>
+        <input
+          id="amount"
+          type="number"
+          step="0.01"
+          required
+          placeholder="10.00"
+          value={amountDollars}
+          onChange={(e) => setAmountDollars(e.target.value)}
+          className="w-full rounded-md border-2 px-3 py-2 text-sm"
+          style={{ borderColor: "#1C0F05", background: "#F5F0D8", color: "#1C0F05" }}
+        />
+      </div>
+
+      <div>
+        <label
+          htmlFor="note"
+          className="block text-xs font-bold uppercase tracking-[0.08em] mb-1"
+          style={{ color: "#1C0F05" }}
+        >
+          Note (audit trail)
+        </label>
+        <textarea
+          id="note"
+          rows={2}
+          placeholder="why this adjustment was made"
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+          className="w-full rounded-md border-2 px-3 py-2 text-sm"
+          style={{ borderColor: "#1C0F05", background: "#F5F0D8", color: "#1C0F05" }}
+        />
+      </div>
+
+      <div className="flex items-center justify-between">
+        <button
+          type="submit"
+          disabled={submitting}
+          className="rounded-pill border-3 px-6 py-2 text-xs font-bold uppercase tracking-[0.1em] transition disabled:opacity-60"
+          style={{
+            borderColor: "#1C0F05",
+            background: "#E8442A",
+            color: "#F5F0D8",
+            boxShadow: "3px 3px 0 #1C0F05",
+          }}
+        >
+          {submitting ? "Granting…" : "Grant credits"}
+        </button>
+
+        {result && (
+          <p className="text-xs font-bold" style={{ color: "#5A7A3A" }}>
+            ✓ Done. New balance: ${(result.balance_cents / 100).toFixed(2)}
+          </p>
+        )}
+        {error && (
+          <p className="text-xs font-bold" style={{ color: "#1C0F05" }}>
+            {error}
+          </p>
+        )}
+      </div>
+    </form>
+  );
+}

--- a/app/dashboard/admin/credits/__tests__/CreditGrantForm.test.tsx
+++ b/app/dashboard/admin/credits/__tests__/CreditGrantForm.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { CreditGrantForm } from "../CreditGrantForm";
+
+const ORIGINAL_FETCH = global.fetch;
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  fetchMock = vi.fn();
+  global.fetch = fetchMock as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  global.fetch = ORIGINAL_FETCH;
+});
+
+describe("<CreditGrantForm />", () => {
+  it("posts a positive grant in cents (dollars × 100) and shows new balance", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          ledger_row: {
+            id: "l-1",
+            amount_cents: 5000,
+            reason: "admin_adjust",
+            granted_by_admin_id: "admin-1",
+            note: "make-good",
+            created_at: "2026-05-06",
+          },
+          balance_cents: 5000,
+        }),
+        { status: 201 }
+      )
+    );
+
+    render(<CreditGrantForm />);
+    fireEvent.change(screen.getByLabelText(/User ID/i), { target: { value: "u-1" } });
+    fireEvent.change(screen.getByLabelText(/Amount/i), { target: { value: "50.00" } });
+    fireEvent.change(screen.getByLabelText(/Note/i), { target: { value: "make-good" } });
+    fireEvent.click(screen.getByRole("button", { name: /Grant credits/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/New balance: \$50\.00/)).toBeInTheDocument();
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/admin/credits/grant",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ user_id: "u-1", amount_cents: 5000, note: "make-good" }),
+      })
+    );
+  });
+
+  it("negative grants are accepted (admin can deduct)", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          ledger_row: {
+            id: "l-2",
+            amount_cents: -1500,
+            reason: "admin_adjust",
+            granted_by_admin_id: "admin-1",
+            note: null,
+            created_at: "2026-05-06",
+          },
+          balance_cents: 3500,
+        }),
+        { status: 201 }
+      )
+    );
+
+    render(<CreditGrantForm />);
+    fireEvent.change(screen.getByLabelText(/User ID/i), { target: { value: "u-1" } });
+    fireEvent.change(screen.getByLabelText(/Amount/i), { target: { value: "-15" } });
+    fireEvent.click(screen.getByRole("button", { name: /Grant credits/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/New balance: \$35\.00/)).toBeInTheDocument();
+    });
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toMatchObject({
+      amount_cents: -1500,
+    });
+  });
+
+  it("rejects zero amount client-side without hitting the endpoint", async () => {
+    render(<CreditGrantForm />);
+    fireEvent.change(screen.getByLabelText(/User ID/i), { target: { value: "u-1" } });
+    fireEvent.change(screen.getByLabelText(/Amount/i), { target: { value: "0" } });
+    fireEvent.click(screen.getByRole("button", { name: /Grant credits/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/non-zero/i)).toBeInTheDocument();
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("renders endpoint error inline", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: "user_not_found" }), { status: 404 })
+    );
+    render(<CreditGrantForm />);
+    fireEvent.change(screen.getByLabelText(/User ID/i), { target: { value: "ghost" } });
+    fireEvent.change(screen.getByLabelText(/Amount/i), { target: { value: "10" } });
+    fireEvent.click(screen.getByRole("button", { name: /Grant credits/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/user_not_found/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/app/dashboard/admin/credits/page.tsx
+++ b/app/dashboard/admin/credits/page.tsx
@@ -1,0 +1,22 @@
+import { CreditGrantForm } from "./CreditGrantForm";
+
+// Server component — admin-gating happens at the layout level
+// (app/dashboard/admin/layout.tsx). Mounts the client form.
+export default function AdminCreditsPage() {
+  return (
+    <div className="max-w-2xl">
+      <h1
+        className="text-2xl font-semibold tracking-tight mb-2"
+        style={{ fontFamily: "'Cal Sans', system-ui, sans-serif", color: "#1C0F05" }}
+      >
+        Grant credits
+      </h1>
+      <p className="text-sm font-medium mb-6" style={{ color: "#7A6A50" }}>
+        Insert an admin_adjust ledger row for a user. Positive amounts credit;
+        negative amounts deduct. Every grant carries your user id and an
+        optional note for audit.
+      </p>
+      <CreditGrantForm />
+    </div>
+  );
+}

--- a/app/dashboard/buyer/page.tsx
+++ b/app/dashboard/buyer/page.tsx
@@ -7,6 +7,7 @@ import { UnitPriceText, UnitWeightText } from "@/components/unit-value";
 import { LeaveHubButton } from "@/components/leave-hub-button";
 import { FeaturedRoastHero } from "@/components/featured-roast-hero";
 import { InviteShareCard } from "@/components/referrals/InviteShareCard";
+import { MyReferralsList } from "@/components/referrals/MyReferralsList";
 
 function getHubName(memberships: any[], hubId: string) {
   const membership = memberships.find((m: any) => m.hub_id === hubId);
@@ -266,12 +267,11 @@ export default async function BuyerOverview({
       )}
 
       {/* Referral surfaces — render only when buyer has at least one
-          membership (the InviteShareCard returns null on its own when the
-          POST /api/invite-codes endpoint 403s). Future cards
-          (CreditBalanceCard, MyReferralsList) slot here too. */}
+          membership. CreditBalanceCard slots here next. */}
       {(memberships?.length ?? 0) > 0 && (
-        <div className="mb-8">
+        <div className="mb-8 grid grid-cols-1 md:grid-cols-2 gap-4">
           <InviteShareCard />
+          <MyReferralsList />
         </div>
       )}
 

--- a/app/dashboard/buyer/page.tsx
+++ b/app/dashboard/buyer/page.tsx
@@ -6,6 +6,7 @@ import { Button } from "@merninos/ui";
 import { UnitPriceText, UnitWeightText } from "@/components/unit-value";
 import { LeaveHubButton } from "@/components/leave-hub-button";
 import { FeaturedRoastHero } from "@/components/featured-roast-hero";
+import { InviteShareCard } from "@/components/referrals/InviteShareCard";
 
 function getHubName(memberships: any[], hubId: string) {
   const membership = memberships.find((m: any) => m.hub_id === hubId);
@@ -261,6 +262,16 @@ export default async function BuyerOverview({
             hubId={featuredCampaign?.hub_id ?? null}
             tiers={featuredCampaign ? tiersMap[featuredCampaign.lot_id] : undefined}
           />
+        </div>
+      )}
+
+      {/* Referral surfaces — render only when buyer has at least one
+          membership (the InviteShareCard returns null on its own when the
+          POST /api/invite-codes endpoint 403s). Future cards
+          (CreditBalanceCard, MyReferralsList) slot here too. */}
+      {(memberships?.length ?? 0) > 0 && (
+        <div className="mb-8">
+          <InviteShareCard />
         </div>
       )}
 

--- a/app/dashboard/buyer/page.tsx
+++ b/app/dashboard/buyer/page.tsx
@@ -8,6 +8,7 @@ import { LeaveHubButton } from "@/components/leave-hub-button";
 import { FeaturedRoastHero } from "@/components/featured-roast-hero";
 import { InviteShareCard } from "@/components/referrals/InviteShareCard";
 import { MyReferralsList } from "@/components/referrals/MyReferralsList";
+import { CreditBalanceCard } from "@/components/referrals/CreditBalanceCard";
 
 function getHubName(memberships: any[], hubId: string) {
   const membership = memberships.find((m: any) => m.hub_id === hubId);
@@ -267,11 +268,14 @@ export default async function BuyerOverview({
       )}
 
       {/* Referral surfaces — render only when buyer has at least one
-          membership. CreditBalanceCard slots here next. */}
+          membership. */}
       {(memberships?.length ?? 0) > 0 && (
         <div className="mb-8 grid grid-cols-1 md:grid-cols-2 gap-4">
           <InviteShareCard />
-          <MyReferralsList />
+          <CreditBalanceCard />
+          <div className="md:col-span-2">
+            <MyReferralsList />
+          </div>
         </div>
       )}
 

--- a/app/dashboard/hub/members/page.tsx
+++ b/app/dashboard/hub/members/page.tsx
@@ -80,7 +80,9 @@ export default function HubMembersPage() {
       const [membersResult, requestsResult] = await Promise.all([
         supabase
           .from("hub_members")
-          .select("*, profile:profiles!hub_members_user_id_fkey(company_name, contact_name, email)")
+          .select(
+            "*, profile:profiles!hub_members_user_id_fkey(company_name, contact_name, email), inviter:profiles!hub_members_invited_by_user_id_fkey(contact_name)"
+          )
           .eq("hub_id", selectedHubId)
           .order("joined_at", { ascending: false }),
         supabase
@@ -356,7 +358,16 @@ export default function HubMembersPage() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {members.map((m) => (
+                {members.map((m) => {
+                  const inviterRel = (m as any).inviter as
+                    | { contact_name: string | null }
+                    | { contact_name: string | null }[]
+                    | null
+                    | undefined;
+                  const inviterName = Array.isArray(inviterRel)
+                    ? inviterRel[0]?.contact_name
+                    : inviterRel?.contact_name;
+                  return (
                   <TableRow key={m.id}>
                     <TableCell>
                       <p className="font-medium">
@@ -367,6 +378,18 @@ export default function HubMembersPage() {
                       )}
                       {!m.profile?.email && m.invited_email && (
                         <p className="text-xs text-muted-foreground">{m.invited_email}</p>
+                      )}
+                      {inviterName && (
+                        <p
+                          className="mt-1 inline-block rounded-pill border-2 px-2 py-0.5 text-[10px] font-bold uppercase tracking-[0.08em]"
+                          style={{
+                            borderColor: "#1C0F05",
+                            background: "#D8D0B8",
+                            color: "#1C0F05",
+                          }}
+                        >
+                          Invited by {inviterName}
+                        </p>
                       )}
                     </TableCell>
                     <TableCell className="text-muted-foreground">
@@ -391,7 +414,8 @@ export default function HubMembersPage() {
                       </Button>
                     </TableCell>
                   </TableRow>
-                ))}
+                  );
+                })}
               </TableBody>
             </Table>
           </CardContent>

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -3,6 +3,7 @@ import { createClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
 import { DashboardShell } from "@/components/dashboard-shell";
 import { isAdminAccount } from "@/lib/auth/admin";
+import { SignupNotifyTrigger } from "@/components/referrals/SignupNotifyTrigger";
 
 export default async function DashboardLayout({
   children,
@@ -32,12 +33,20 @@ export default async function DashboardLayout({
     "buyer";
   const role = isAdminAccount({ email: user.email, role: baseRole }) ? "admin" : baseRole;
 
+  // Buyer-referral: best-effort notify of inviter when an attributed user
+  // first lands on the dashboard. Idempotent server-side via the timestamp
+  // stamp on profiles. Skipped for users with no inviter (component itself
+  // also short-circuits for them server-side).
+  const shouldFireNotify =
+    profile?.invited_by_user_id && !profile?.referral_signup_email_sent_at;
+
   return (
     <DashboardShell
       user={user}
       profile={profile}
       role={role}
     >
+      {shouldFireNotify && <SignupNotifyTrigger />}
       {children}
     </DashboardShell>
   );

--- a/app/i/[code]/InviteAcceptButton.tsx
+++ b/app/i/[code]/InviteAcceptButton.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+export function InviteAcceptButton({ code, hubName }: { code: string; hubName: string }) {
+  const router = useRouter();
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleAccept() {
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/invite-codes/${encodeURIComponent(code)}/accept`, {
+        method: "POST",
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        if (body?.error === "different_hub_active") {
+          setError(
+            `You're already in ${body.currentHubName ?? "another hub"}. Switching hubs isn't supported yet.`
+          );
+        } else if (body?.error === "self_invite_not_allowed") {
+          setError("That's your own invite link.");
+        } else {
+          setError(body?.error || "Couldn't join. Try again in a moment.");
+        }
+        setSubmitting(false);
+        return;
+      }
+      router.push("/dashboard");
+    } catch {
+      setError("Couldn't join. Try again in a moment.");
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-3">
+      <button
+        onClick={handleAccept}
+        disabled={submitting}
+        className="inline-flex items-center gap-2 bg-cream text-espresso border-3 border-espresso rounded-pill px-8 py-3 text-sm font-bold uppercase tracking-[0.1em] shadow-[5px_5px_0_#1C0F05] hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-[7px_7px_0_#1C0F05] active:translate-x-1 active:translate-y-1 active:shadow-none transition disabled:opacity-60"
+      >
+        {submitting ? "Joining..." : `Join ${hubName}`}
+      </button>
+      {error && (
+        <p className="text-cream bg-espresso/80 border-2 border-cream rounded-md px-3 py-2 text-xs font-medium">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/app/i/[code]/__tests__/InviteAcceptButton.test.tsx
+++ b/app/i/[code]/__tests__/InviteAcceptButton.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+// Stub next/navigation's useRouter — the button calls router.push() on success.
+const pushMock = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock }),
+}));
+
+import { InviteAcceptButton } from "../InviteAcceptButton";
+
+const ORIGINAL_FETCH = global.fetch;
+
+beforeEach(() => {
+  pushMock.mockReset();
+});
+
+afterEach(() => {
+  global.fetch = ORIGINAL_FETCH;
+});
+
+describe("<InviteAcceptButton />", () => {
+  it("renders 'Join [HubName]' button using the passed hub name", () => {
+    render(<InviteAcceptButton code="abc1234567" hubName="East Side Roasters" />);
+    expect(screen.getByRole("button", { name: /Join East Side Roasters/i })).toBeInTheDocument();
+  });
+
+  it("on success: routes the user to /dashboard", async () => {
+    global.fetch = vi.fn(async () => new Response(JSON.stringify({ joined: true }), { status: 200 })) as unknown as typeof fetch;
+    render(<InviteAcceptButton code="abc1234567" hubName="East Side" />);
+    fireEvent.click(screen.getByRole("button"));
+    await waitFor(() => {
+      expect(pushMock).toHaveBeenCalledWith("/dashboard");
+    });
+  });
+
+  it("on different_hub_active: shows the friendly switching-not-supported message", async () => {
+    global.fetch = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({ error: "different_hub_active", currentHubName: "Other Hub" }),
+          { status: 409 }
+        )
+    ) as unknown as typeof fetch;
+    render(<InviteAcceptButton code="abc1234567" hubName="East Side" />);
+    fireEvent.click(screen.getByRole("button"));
+    await waitFor(() => {
+      expect(screen.getByText(/already in Other Hub/i)).toBeInTheDocument();
+      expect(screen.getByText(/Switching hubs isn't supported/i)).toBeInTheDocument();
+    });
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+
+  it("on self_invite_not_allowed: shows 'your own invite link'", async () => {
+    global.fetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ error: "self_invite_not_allowed" }), { status: 400 })
+    ) as unknown as typeof fetch;
+    render(<InviteAcceptButton code="abc1234567" hubName="East Side" />);
+    fireEvent.click(screen.getByRole("button"));
+    await waitFor(() => {
+      expect(screen.getByText(/your own invite link/i)).toBeInTheDocument();
+    });
+  });
+
+  it("on network failure: shows the generic try-again copy and remains clickable", async () => {
+    global.fetch = vi.fn(async () => {
+      throw new Error("offline");
+    }) as unknown as typeof fetch;
+    render(<InviteAcceptButton code="abc1234567" hubName="East Side" />);
+    fireEvent.click(screen.getByRole("button"));
+    await waitFor(() => {
+      expect(screen.getByText(/Try again in a moment/i)).toBeInTheDocument();
+    });
+    // Submitting state should reset so the button is re-enabled.
+    expect((screen.getByRole("button") as HTMLButtonElement).disabled).toBe(false);
+  });
+});

--- a/app/i/[code]/page.tsx
+++ b/app/i/[code]/page.tsx
@@ -1,0 +1,203 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { SiteHeader } from "@/components/site-header";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { InviteAcceptButton } from "./InviteAcceptButton";
+
+// Bold Mernin' mode landing page. Public — must work for logged-out visitors,
+// so we use the service-role client for the invite lookup. Branches by auth
+// state to render the right CTA per spec criteria 2, 4, 5.
+
+type InviteData = {
+  code: string;
+  inviterName: string | null;
+  hubId: string;
+  hubName: string;
+  hubCity: string | null;
+};
+
+async function loadInvite(code: string): Promise<InviteData | null> {
+  const admin = createAdminClient();
+  const { data } = await admin
+    .from("invite_codes")
+    .select(
+      `
+      code, revoked_at,
+      hub:hubs!invite_codes_hub_id_fkey(id, name, city),
+      inviter:profiles!invite_codes_inviter_user_id_fkey(contact_name)
+      `
+    )
+    .eq("code", code)
+    .maybeSingle();
+
+  if (!data || data.revoked_at) return null;
+  const hub = data.hub as unknown as { id: string; name: string; city: string | null } | null;
+  if (!hub) return null;
+  const inviter = data.inviter as unknown as { contact_name: string | null } | null;
+
+  return {
+    code: data.code,
+    inviterName: inviter?.contact_name ?? null,
+    hubId: hub.id,
+    hubName: hub.name,
+    hubCity: hub.city,
+  };
+}
+
+async function loadActiveHubMembership(userId: string) {
+  const admin = createAdminClient();
+  const { data } = await admin
+    .from("hub_members")
+    .select("hub_id, hub:hubs!hub_members_hub_id_fkey(name)")
+    .eq("user_id", userId)
+    .eq("status", "active")
+    .maybeSingle();
+  if (!data) return null;
+  const hub = data.hub as unknown as { name: string } | null;
+  return { hubId: data.hub_id, hubName: hub?.name ?? "" };
+}
+
+export default async function InviteLandingPage({
+  params,
+}: {
+  params: Promise<{ code: string }>;
+}) {
+  const { code } = await params;
+  const invite = await loadInvite(code);
+
+  if (!invite) {
+    return (
+      <div className="flex min-h-svh flex-col">
+        <SiteHeader />
+        <section className="bg-cream flex-1 flex items-center justify-center px-4 py-20 border-t-5 border-espresso">
+          <div className="text-center max-w-lg">
+            <h1
+              className="font-display text-7xl text-cream mb-6"
+              style={{
+                WebkitTextStroke: "5px #1C0F05",
+                paintOrder: "stroke fill",
+              }}
+            >
+              Link's no good
+            </h1>
+            <p className="text-lg text-espresso/80 font-medium">
+              This invite link isn't valid anymore. Ask the friend who sent it for
+              a fresh one.
+            </p>
+          </div>
+        </section>
+      </div>
+    );
+  }
+
+  // Determine auth state.
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  let cta: "logged_out" | "hubless" | "same_hub" | "different_hub";
+  let currentHubName: string | null = null;
+
+  if (!user) {
+    cta = "logged_out";
+  } else {
+    const membership = await loadActiveHubMembership(user.id);
+    if (!membership) {
+      cta = "hubless";
+    } else if (membership.hubId === invite.hubId) {
+      // Already in this hub — bounce to dashboard.
+      redirect("/dashboard");
+    } else {
+      cta = "different_hub";
+      currentHubName = membership.hubName;
+    }
+  }
+
+  const inviterDisplay = invite.inviterName || "A friend";
+  const cityDisplay = invite.hubCity || invite.hubName;
+
+  return (
+    <div className="flex min-h-svh flex-col">
+      <SiteHeader />
+
+      {/* ─── HERO ───────────────────────────────────────────────────────── */}
+      <section className="bg-tomato px-4 pt-20 pb-16 md:pt-28 md:pb-20 border-b-5 border-espresso">
+        <div className="mx-auto max-w-3xl text-center">
+          {/* Inviter callout (Mernin' voice) */}
+          <div className="inline-block bg-sun border-3 border-espresso rounded-pill px-5 py-1.5 text-xs font-bold uppercase tracking-[0.1em] text-espresso mb-8 shadow-[3px_3px_0_#1C0F05]">
+            ✦ {inviterDisplay} sent you here
+          </div>
+
+          {/* Sticker hero */}
+          <h1
+            className="font-display text-cream text-6xl md:text-8xl leading-none mb-2"
+            style={{
+              WebkitTextStroke: "6px #1C0F05",
+              paintOrder: "stroke fill",
+            }}
+          >
+            Join
+          </h1>
+          <h1
+            className="font-display text-cream text-6xl md:text-8xl leading-none mb-10"
+            style={{
+              WebkitTextStroke: "6px #1C0F05",
+              paintOrder: "stroke fill",
+            }}
+          >
+            {invite.hubName}
+          </h1>
+
+          {/* In-person pickup notice — required by criterion 2 */}
+          <div className="inline-block bg-cream border-3 border-espresso rounded-lg px-6 py-3 mb-10 shadow-[5px_5px_0_#1C0F05] max-w-md">
+            <p className="text-espresso text-sm font-bold uppercase tracking-[0.08em]">
+              Pickup is in person at {cityDisplay}
+            </p>
+            <p className="text-espresso/80 text-sm font-medium mt-1">
+              Make sure you can grab your coffee at the hub.
+            </p>
+          </div>
+
+          {/* Branch CTA */}
+          <div className="flex flex-col items-center gap-4">
+            {cta === "logged_out" && (
+              <>
+                <Link
+                  href={`/auth/sign-up?invite=${encodeURIComponent(invite.code)}`}
+                  className="inline-flex items-center gap-2 bg-cream text-espresso border-3 border-espresso rounded-pill px-8 py-3 text-sm font-bold uppercase tracking-[0.1em] shadow-[5px_5px_0_#1C0F05] hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-[7px_7px_0_#1C0F05] active:translate-x-1 active:translate-y-1 active:shadow-none transition"
+                >
+                  Sign up to join
+                </Link>
+                <p className="text-cream/85 text-xs font-medium">
+                  Already have an account?{" "}
+                  <Link
+                    href={`/auth/login?next=${encodeURIComponent(`/i/${invite.code}`)}`}
+                    className="underline underline-offset-4 font-bold"
+                  >
+                    Log in
+                  </Link>
+                </p>
+              </>
+            )}
+
+            {cta === "hubless" && (
+              <InviteAcceptButton code={invite.code} hubName={invite.hubName} />
+            )}
+
+            {cta === "different_hub" && (
+              <div className="bg-espresso border-3 border-cream rounded-lg px-6 py-5 max-w-md text-cream text-sm font-medium">
+                <p className="font-bold uppercase tracking-[0.08em] mb-2">
+                  You're already in {currentHubName ?? "another hub"}
+                </p>
+                <p>Switching hubs isn't supported yet. Reach out to the team if you
+                need to move.</p>
+              </div>
+            )}
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/components/dashboard-shell.tsx
+++ b/components/dashboard-shell.tsx
@@ -62,6 +62,7 @@ const navByRole = {
     { href: "/dashboard/admin/claims", label: "Claims", icon: FileWarning },
     { href: "/dashboard/admin/refunds", label: "Refunds", icon: CreditCard },
     { href: "/dashboard/admin/payouts", label: "Payouts", icon: CreditCard },
+    { href: "/dashboard/admin/credits", label: "Credits", icon: CreditCard },
   ],
 };
 

--- a/components/referrals/CreditBalanceCard.tsx
+++ b/components/referrals/CreditBalanceCard.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+type LedgerRow = {
+  id: string;
+  amount_cents: number;
+  reason: "referral_earned" | "commit_applied" | "admin_adjust";
+  source_attribution_id: string | null;
+  source_commitment_id: string | null;
+  granted_by_admin_id: string | null;
+  note: string | null;
+  created_at: string;
+};
+
+type CreditsData = {
+  balance_cents: number;
+  ledger: LedgerRow[];
+};
+
+function formatDollars(cents: number): string {
+  const sign = cents < 0 ? "-" : "";
+  const abs = Math.abs(cents);
+  return `${sign}$${(abs / 100).toFixed(2)}`;
+}
+
+function describeRow(row: LedgerRow): string {
+  if (row.reason === "referral_earned") return "Earned: friend joined and committed";
+  if (row.reason === "commit_applied") return "Applied to a recent commitment";
+  if (row.reason === "admin_adjust") {
+    return row.note ? `CrowdRoast adjustment: ${row.note}` : "CrowdRoast adjustment";
+  }
+  return "Adjustment";
+}
+
+export function CreditBalanceCard() {
+  const [data, setData] = useState<CreditsData | null>(null);
+  const [error, setError] = useState(false);
+  const [showHistory, setShowHistory] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch("/api/credits/me");
+        if (cancelled) return;
+        if (!res.ok) {
+          setError(true);
+          return;
+        }
+        setData(await res.json());
+      } catch {
+        if (!cancelled) setError(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <div
+      className="rounded-xl border-3 p-5"
+      style={{
+        background: "#FDFAF0",
+        borderColor: "#1C0F05",
+        boxShadow: "5px 5px 0 #1C0F05",
+      }}
+    >
+      <h3 className="text-base font-bold uppercase tracking-[0.08em]" style={{ color: "#1C0F05" }}>
+        Credit balance
+      </h3>
+
+      {error || !data ? (
+        <p className="text-xs mt-2 font-medium" style={{ color: "#7A6A50" }}>
+          {error ? "Couldn't load — try refreshing." : "Loading…"}
+        </p>
+      ) : (
+        <>
+          <div className="mt-2 mb-1 flex items-baseline gap-2">
+            <span
+              className="text-4xl font-bold"
+              style={{ color: "#1C0F05", fontFamily: "'Cal Sans', system-ui, sans-serif" }}
+            >
+              {formatDollars(data.balance_cents)}
+            </span>
+            <span className="text-[11px] font-bold uppercase tracking-[0.08em]" style={{ color: "#7A6A50" }}>
+              auto-applies on settle
+            </span>
+          </div>
+
+          {data.ledger.length === 0 ? (
+            <p className="text-sm mt-2 font-medium" style={{ color: "#7A6A50" }}>
+              No credits yet. Invite a friend — when their first commitment closes, you'll see $10 land here.
+            </p>
+          ) : (
+            <>
+              <button
+                type="button"
+                onClick={() => setShowHistory((v) => !v)}
+                className="text-[11px] font-bold uppercase tracking-[0.08em] mt-2 underline underline-offset-4"
+                style={{ color: "#1C0F05" }}
+              >
+                {showHistory ? "Hide history" : `Show history (${data.ledger.length})`}
+              </button>
+
+              {showHistory && (
+                <ul className="flex flex-col gap-1 mt-3">
+                  {data.ledger.map((row) => (
+                    <li
+                      key={row.id}
+                      className="flex items-center justify-between rounded-md border-2 px-3 py-2 text-sm"
+                      style={{ borderColor: "#1C0F05", background: "#F5F0D8" }}
+                    >
+                      <span className="font-medium" style={{ color: "#1C0F05" }}>
+                        {describeRow(row)}
+                      </span>
+                      <span
+                        className="font-bold"
+                        style={{
+                          color: row.amount_cents > 0 ? "#5A7A3A" : "#1C0F05",
+                          fontFamily: "'JetBrains Mono', monospace",
+                        }}
+                      >
+                        {row.amount_cents > 0 ? "+" : ""}
+                        {formatDollars(row.amount_cents)}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/components/referrals/InviteShareCard.tsx
+++ b/components/referrals/InviteShareCard.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+type InviteData = {
+  code: string;
+  url: string;
+  hubName: string;
+  hubCity: string | null;
+};
+
+// Subdued dashboard mode card. Calls POST /api/invite-codes (idempotent) on
+// mount to get-or-create the buyer's invite link, then exposes a copy-link
+// action. Hidden on the server side when the buyer has no active hub
+// membership (the route returns 403 in that case so this component renders
+// a no-op fallback).
+export function InviteShareCard() {
+  const [data, setData] = useState<InviteData | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch("/api/invite-codes", { method: "POST" });
+        if (cancelled) return;
+        if (!res.ok) {
+          setError(res.status === 403 ? "join_a_hub_first" : "load_failed");
+          setLoading(false);
+          return;
+        }
+        const body = (await res.json()) as InviteData;
+        setData(body);
+        setLoading(false);
+      } catch {
+        if (!cancelled) {
+          setError("load_failed");
+          setLoading(false);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  async function handleCopy() {
+    if (!data) return;
+    try {
+      await navigator.clipboard.writeText(data.url);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Some browsers / iframe contexts block clipboard writes silently.
+      setCopied(false);
+    }
+  }
+
+  // Hide for users not in a hub — the dashboard's other surfaces nudge them
+  // toward joining one. No empty-state needed here.
+  if (error === "join_a_hub_first") return null;
+
+  return (
+    <div
+      className="rounded-xl border-3 p-5"
+      style={{
+        background: "var(--color-chalk, #FDFAF0)",
+        borderColor: "var(--color-espresso, #1C0F05)",
+        boxShadow: "5px 5px 0 #1C0F05",
+      }}
+    >
+      <div className="mb-3">
+        <h3
+          className="text-base font-bold uppercase tracking-[0.08em]"
+          style={{ color: "#1C0F05" }}
+        >
+          Bring a friend
+        </h3>
+        <p className="text-xs mt-1 font-medium" style={{ color: "#7A6A50" }}>
+          {data
+            ? `Share your link. When a friend joins ${data.hubName} and commits, you earn $10 in credits.`
+            : "Loading your invite link…"}
+        </p>
+      </div>
+
+      {loading && (
+        <p className="text-xs font-medium" style={{ color: "#7A6A50" }}>
+          Brewing your link…
+        </p>
+      )}
+
+      {error === "load_failed" && (
+        <p className="text-sm font-medium" style={{ color: "#1C0F05" }}>
+          Something went sideways. Refresh and try again.
+        </p>
+      )}
+
+      {data && (
+        <div className="flex flex-col sm:flex-row gap-2">
+          <input
+            readOnly
+            value={data.url}
+            className="flex-1 rounded-md border-2 px-3 py-2 text-sm font-mono"
+            style={{
+              borderColor: "#1C0F05",
+              background: "#F5F0D8",
+              color: "#1C0F05",
+            }}
+            onFocus={(e) => e.currentTarget.select()}
+          />
+          <button
+            type="button"
+            onClick={handleCopy}
+            className="rounded-pill border-3 px-5 py-2 text-xs font-bold uppercase tracking-[0.1em] transition"
+            style={{
+              borderColor: "#1C0F05",
+              background: copied ? "#5A7A3A" : "#E8442A",
+              color: "#F5F0D8",
+              boxShadow: "3px 3px 0 #1C0F05",
+            }}
+          >
+            {copied ? "Copied!" : "Copy link"}
+          </button>
+        </div>
+      )}
+
+      {data?.hubCity && data && (
+        <p className="text-[10px] mt-3 font-medium uppercase tracking-[0.08em]" style={{ color: "#7A6A50" }}>
+          ✦ Pickup happens at {data.hubCity}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/components/referrals/MyReferralsList.tsx
+++ b/components/referrals/MyReferralsList.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+type Row = {
+  id: string;
+  status: "pending" | "earned" | "voided";
+  earned_at: string | null;
+  created_at: string;
+  invitee: { contact_name: string | null; company_name: string | null } | null;
+};
+
+type Groups = {
+  pending: Row[];
+  earned: Row[];
+  voided: Row[];
+};
+
+const STATUS_LABEL: Record<Row["status"], string> = {
+  pending: "Brewing",
+  earned: "Earned",
+  voided: "Lot fell through",
+};
+
+const STATUS_BG: Record<Row["status"], string> = {
+  pending: "#D8D0B8", // fog
+  earned: "#5A7A3A", // matcha
+  voided: "#7A6A50", // muted brown
+};
+
+const STATUS_TEXT: Record<Row["status"], string> = {
+  pending: "#1C0F05",
+  earned: "#F5F0D8",
+  voided: "#F5F0D8",
+};
+
+export function MyReferralsList() {
+  const [groups, setGroups] = useState<Groups | null>(null);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch("/api/referrals/me");
+        if (cancelled) return;
+        if (!res.ok) {
+          setError(true);
+          return;
+        }
+        setGroups(await res.json());
+      } catch {
+        if (!cancelled) setError(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (error || !groups) {
+    return (
+      <div
+        className="rounded-xl border-3 p-5"
+        style={{
+          background: "#FDFAF0",
+          borderColor: "#1C0F05",
+          boxShadow: "5px 5px 0 #1C0F05",
+        }}
+      >
+        <h3 className="text-base font-bold uppercase tracking-[0.08em]" style={{ color: "#1C0F05" }}>
+          Your invites
+        </h3>
+        <p className="text-xs mt-2 font-medium" style={{ color: "#7A6A50" }}>
+          {error ? "Couldn't load — try refreshing." : "Loading…"}
+        </p>
+      </div>
+    );
+  }
+
+  const all = [...groups.pending, ...groups.earned, ...groups.voided];
+  const total = all.length;
+
+  return (
+    <div
+      className="rounded-xl border-3 p-5"
+      style={{
+        background: "#FDFAF0",
+        borderColor: "#1C0F05",
+        boxShadow: "5px 5px 0 #1C0F05",
+      }}
+    >
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-base font-bold uppercase tracking-[0.08em]" style={{ color: "#1C0F05" }}>
+          Your invites
+        </h3>
+        <div className="flex gap-2 text-[11px] font-bold uppercase tracking-[0.08em]">
+          <span style={{ color: "#7A6A50" }}>
+            {groups.pending.length} brewing
+          </span>
+          <span style={{ color: "#5A7A3A" }}>
+            {groups.earned.length} earned
+          </span>
+        </div>
+      </div>
+
+      {total === 0 ? (
+        <p className="text-sm font-medium" style={{ color: "#7A6A50" }}>
+          No invites sent yet. Share your link above and earn $10 per friend who commits.
+        </p>
+      ) : (
+        <ul className="flex flex-col gap-2">
+          {all.map((row) => {
+            const name =
+              row.invitee?.contact_name ||
+              row.invitee?.company_name ||
+              "A new roaster";
+            return (
+              <li
+                key={row.id}
+                className="flex items-center justify-between rounded-md border-2 px-3 py-2 text-sm"
+                style={{ borderColor: "#1C0F05", background: "#F5F0D8" }}
+              >
+                <span className="font-medium" style={{ color: "#1C0F05" }}>
+                  {name}
+                </span>
+                <span
+                  className="rounded-pill border-2 px-2.5 py-0.5 text-[10px] font-bold uppercase tracking-[0.08em]"
+                  style={{
+                    borderColor: "#1C0F05",
+                    background: STATUS_BG[row.status],
+                    color: STATUS_TEXT[row.status],
+                  }}
+                >
+                  {STATUS_LABEL[row.status]}
+                </span>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/components/referrals/MyReferralsList.tsx
+++ b/components/referrals/MyReferralsList.tsx
@@ -2,33 +2,39 @@
 
 import { useEffect, useState } from "react";
 
+type Status = "joined" | "pending" | "earned" | "voided";
+
 type Row = {
   id: string;
-  status: "pending" | "earned" | "voided";
+  status: Status;
   earned_at: string | null;
   created_at: string;
   invitee: { contact_name: string | null; company_name: string | null } | null;
 };
 
 type Groups = {
+  joined: Row[];
   pending: Row[];
   earned: Row[];
   voided: Row[];
 };
 
-const STATUS_LABEL: Record<Row["status"], string> = {
+const STATUS_LABEL: Record<Status, string> = {
+  joined: "No commit yet",
   pending: "Brewing",
   earned: "Earned",
   voided: "Lot fell through",
 };
 
-const STATUS_BG: Record<Row["status"], string> = {
+const STATUS_BG: Record<Status, string> = {
+  joined: "#FDFAF0", // chalk — quiet, neutral, signals "waiting"
   pending: "#D8D0B8", // fog
   earned: "#5A7A3A", // matcha
   voided: "#7A6A50", // muted brown
 };
 
-const STATUS_TEXT: Record<Row["status"], string> = {
+const STATUS_TEXT: Record<Status, string> = {
+  joined: "#7A6A50",
   pending: "#1C0F05",
   earned: "#F5F0D8",
   voided: "#F5F0D8",
@@ -78,8 +84,15 @@ export function MyReferralsList() {
     );
   }
 
-  const all = [...groups.pending, ...groups.earned, ...groups.voided];
+  // Order matters: earned (good news) → pending → joined (waiting) → voided.
+  const all = [
+    ...groups.earned,
+    ...groups.pending,
+    ...groups.joined,
+    ...groups.voided,
+  ];
   const total = all.length;
+  const waitingCount = groups.joined.length + groups.pending.length;
 
   return (
     <div
@@ -95,9 +108,9 @@ export function MyReferralsList() {
           Your invites
         </h3>
         <div className="flex gap-2 text-[11px] font-bold uppercase tracking-[0.08em]">
-          <span style={{ color: "#7A6A50" }}>
-            {groups.pending.length} brewing
-          </span>
+          {waitingCount > 0 && (
+            <span style={{ color: "#7A6A50" }}>{waitingCount} waiting</span>
+          )}
           <span style={{ color: "#5A7A3A" }}>
             {groups.earned.length} earned
           </span>
@@ -106,7 +119,7 @@ export function MyReferralsList() {
 
       {total === 0 ? (
         <p className="text-sm font-medium" style={{ color: "#7A6A50" }}>
-          No invites sent yet. Share your link above and earn $10 per friend who commits.
+          No invites yet. Share your link above and earn $10 per friend who commits.
         </p>
       ) : (
         <ul className="flex flex-col gap-2">

--- a/components/referrals/SignupNotifyTrigger.tsx
+++ b/components/referrals/SignupNotifyTrigger.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { useEffect } from "react";
+
+// Fires POST /api/referrals/signup-notify exactly once per dashboard mount.
+// The route itself is idempotent (stamps profiles.referral_signup_email_sent_at
+// after first run) so even if multiple dashboard sub-routes mount this
+// component, the second call short-circuits server-side. No UI.
+export function SignupNotifyTrigger() {
+  useEffect(() => {
+    fetch("/api/referrals/signup-notify", { method: "POST" }).catch(() => undefined);
+  }, []);
+  return null;
+}

--- a/components/referrals/__tests__/CreditBalanceCard.test.tsx
+++ b/components/referrals/__tests__/CreditBalanceCard.test.tsx
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { CreditBalanceCard } from "../CreditBalanceCard";
+
+const ORIGINAL_FETCH = global.fetch;
+
+beforeEach(() => {});
+
+afterEach(() => {
+  global.fetch = ORIGINAL_FETCH;
+});
+
+describe("<CreditBalanceCard />", () => {
+  it("zero-balance empty state", async () => {
+    global.fetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ balance_cents: 0, ledger: [] }), { status: 200 })
+    ) as unknown as typeof fetch;
+
+    render(<CreditBalanceCard />);
+    await waitFor(() => {
+      expect(screen.getByText("$0.00")).toBeInTheDocument();
+      expect(screen.getByText(/Invite a friend/i)).toBeInTheDocument();
+    });
+  });
+
+  it("positive balance shown in dollars; history hidden by default", async () => {
+    global.fetch = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            balance_cents: 1500,
+            ledger: [
+              {
+                id: "l-1",
+                amount_cents: 1000,
+                reason: "referral_earned",
+                source_attribution_id: "a-1",
+                source_commitment_id: null,
+                granted_by_admin_id: null,
+                note: null,
+                created_at: "2026-04-01",
+              },
+              {
+                id: "l-2",
+                amount_cents: 500,
+                reason: "admin_adjust",
+                source_attribution_id: null,
+                source_commitment_id: null,
+                granted_by_admin_id: "admin-1",
+                note: "thanks for early adopting",
+                created_at: "2026-04-15",
+              },
+            ],
+          }),
+          { status: 200 }
+        )
+    ) as unknown as typeof fetch;
+
+    render(<CreditBalanceCard />);
+    await waitFor(() => {
+      expect(screen.getByText("$15.00")).toBeInTheDocument();
+    });
+    // History collapsed by default.
+    expect(screen.queryByText(/Earned: friend joined/i)).not.toBeInTheDocument();
+    // Toggle reveals rows.
+    fireEvent.click(screen.getByRole("button", { name: /Show history/i }));
+    expect(screen.getByText(/Earned: friend joined/i)).toBeInTheDocument();
+    expect(screen.getByText(/CrowdRoast adjustment: thanks for early adopting/i)).toBeInTheDocument();
+  });
+
+  it("renders negative amounts (commit_applied) without leading double-minus", async () => {
+    global.fetch = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            balance_cents: 200,
+            ledger: [
+              {
+                id: "l-1",
+                amount_cents: 1000,
+                reason: "referral_earned",
+                source_attribution_id: "a-1",
+                source_commitment_id: null,
+                granted_by_admin_id: null,
+                note: null,
+                created_at: "2026-04-01",
+              },
+              {
+                id: "l-2",
+                amount_cents: -800,
+                reason: "commit_applied",
+                source_attribution_id: null,
+                source_commitment_id: "c-1",
+                granted_by_admin_id: null,
+                note: null,
+                created_at: "2026-05-01",
+              },
+            ],
+          }),
+          { status: 200 }
+        )
+    ) as unknown as typeof fetch;
+
+    render(<CreditBalanceCard />);
+    await waitFor(() => {
+      expect(screen.getByText("$2.00")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Show history/i }));
+    expect(screen.getByText("-$8.00")).toBeInTheDocument();
+    expect(screen.queryByText("--$8.00")).not.toBeInTheDocument();
+  });
+
+  it("error state on load failure", async () => {
+    global.fetch = vi.fn(async () => new Response("nope", { status: 500 })) as unknown as typeof fetch;
+    render(<CreditBalanceCard />);
+    await waitFor(() => {
+      expect(screen.getByText(/Couldn't load/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/components/referrals/__tests__/InviteShareCard.test.tsx
+++ b/components/referrals/__tests__/InviteShareCard.test.tsx
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { InviteShareCard } from "../InviteShareCard";
+
+const ORIGINAL_FETCH = global.fetch;
+const ORIGINAL_CLIPBOARD = navigator.clipboard;
+
+beforeEach(() => {
+  // Stub clipboard.writeText
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText: vi.fn(async () => undefined) },
+    writable: true,
+    configurable: true,
+  });
+});
+
+afterEach(() => {
+  global.fetch = ORIGINAL_FETCH;
+  Object.defineProperty(navigator, "clipboard", {
+    value: ORIGINAL_CLIPBOARD,
+    writable: true,
+    configurable: true,
+  });
+});
+
+describe("<InviteShareCard />", () => {
+  it("renders the URL once the get-or-create endpoint resolves", async () => {
+    global.fetch = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            code: "abc1234567",
+            url: "https://crowdroast.test/i/abc1234567",
+            hubName: "East Side",
+            hubCity: "Austin",
+          }),
+          { status: 200 }
+        )
+    ) as unknown as typeof fetch;
+
+    render(<InviteShareCard />);
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("https://crowdroast.test/i/abc1234567")).toBeInTheDocument();
+    });
+    expect(screen.getByText(/East Side/)).toBeInTheDocument();
+    expect(screen.getByText(/Pickup happens at Austin/i)).toBeInTheDocument();
+  });
+
+  it("Copy link button writes the URL to clipboard and flashes 'Copied!'", async () => {
+    global.fetch = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            code: "abc1234567",
+            url: "https://crowdroast.test/i/abc1234567",
+            hubName: "East Side",
+            hubCity: "Austin",
+          }),
+          { status: 200 }
+        )
+    ) as unknown as typeof fetch;
+
+    render(<InviteShareCard />);
+    const button = await screen.findByRole("button", { name: /Copy link/i });
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+        "https://crowdroast.test/i/abc1234567"
+      );
+    });
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Copied!/i })).toBeInTheDocument();
+    });
+  });
+
+  it("renders nothing when the buyer has no active hub (403 from endpoint)", async () => {
+    global.fetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ error: "active_hub_membership_required" }), { status: 403 })
+    ) as unknown as typeof fetch;
+
+    const { container } = render(<InviteShareCard />);
+    await waitFor(() => {
+      // Component returns null when join_a_hub_first error is set.
+      expect(container.innerHTML).toBe("");
+    });
+  });
+
+  it("shows a friendly error on a generic load failure", async () => {
+    global.fetch = vi.fn(async () => new Response("nope", { status: 500 })) as unknown as typeof fetch;
+    render(<InviteShareCard />);
+    await waitFor(() => {
+      expect(screen.getByText(/Something went sideways/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/components/referrals/__tests__/MyReferralsList.test.tsx
+++ b/components/referrals/__tests__/MyReferralsList.test.tsx
@@ -15,21 +15,33 @@ describe("<MyReferralsList />", () => {
   it("empty state when no referrals", async () => {
     global.fetch = vi.fn(
       async () =>
-        new Response(JSON.stringify({ pending: [], earned: [], voided: [] }), { status: 200 })
+        new Response(
+          JSON.stringify({ joined: [], pending: [], earned: [], voided: [] }),
+          { status: 200 }
+        )
     ) as unknown as typeof fetch;
 
     render(<MyReferralsList />);
     await waitFor(() => {
-      expect(screen.getByText(/No invites sent yet/i)).toBeInTheDocument();
+      expect(screen.getByText(/No invites yet/i)).toBeInTheDocument();
       expect(screen.getByText(/\$10 per friend/i)).toBeInTheDocument();
     });
   });
 
-  it("renders rows grouped pending then earned then voided, with status badges", async () => {
+  it("renders all four statuses with correct badges", async () => {
     global.fetch = vi.fn(
       async () =>
         new Response(
           JSON.stringify({
+            joined: [
+              {
+                id: "j-1",
+                status: "joined",
+                earned_at: null,
+                created_at: "2026-04-25",
+                invitee: { contact_name: "Just-Joined Jane", company_name: null },
+              },
+            ],
             pending: [
               {
                 id: "p-1",
@@ -64,19 +76,50 @@ describe("<MyReferralsList />", () => {
 
     render(<MyReferralsList />);
     await waitFor(() => {
+      expect(screen.getByText("Just-Joined Jane")).toBeInTheDocument();
       expect(screen.getByText("Pending Pat")).toBeInTheDocument();
       expect(screen.getByText("Earned Eve")).toBeInTheDocument();
       expect(screen.getByText("Voided Co")).toBeInTheDocument();
     });
 
-    // Counts in the header.
-    expect(screen.getByText(/1 brewing/i)).toBeInTheDocument();
+    // Header counts.
+    expect(screen.getByText(/2 waiting/i)).toBeInTheDocument(); // joined + pending
     expect(screen.getByText(/1 earned/i)).toBeInTheDocument();
 
-    // Badge labels per status.
+    // Badges per status, including the new joined pill.
+    expect(screen.getByText("No commit yet")).toBeInTheDocument();
     expect(screen.getByText("Brewing")).toBeInTheDocument();
     expect(screen.getByText("Earned")).toBeInTheDocument();
     expect(screen.getByText(/Lot fell through/i)).toBeInTheDocument();
+  });
+
+  it("hides 'waiting' header count when nobody is waiting", async () => {
+    global.fetch = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            joined: [],
+            pending: [],
+            earned: [
+              {
+                id: "e-1",
+                status: "earned",
+                earned_at: "2026-04-15",
+                created_at: "2026-04-10",
+                invitee: { contact_name: "Earned Eve", company_name: null },
+              },
+            ],
+            voided: [],
+          }),
+          { status: 200 }
+        )
+    ) as unknown as typeof fetch;
+
+    render(<MyReferralsList />);
+    await waitFor(() => {
+      expect(screen.getByText("Earned Eve")).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/waiting/i)).not.toBeInTheDocument();
   });
 
   it("falls back to 'A new roaster' when invitee has no name", async () => {
@@ -84,15 +127,16 @@ describe("<MyReferralsList />", () => {
       async () =>
         new Response(
           JSON.stringify({
-            pending: [
+            joined: [
               {
-                id: "p-1",
-                status: "pending",
+                id: "j-1",
+                status: "joined",
                 earned_at: null,
                 created_at: "2026-04-01",
                 invitee: { contact_name: null, company_name: null },
               },
             ],
+            pending: [],
             earned: [],
             voided: [],
           }),

--- a/components/referrals/__tests__/MyReferralsList.test.tsx
+++ b/components/referrals/__tests__/MyReferralsList.test.tsx
@@ -1,0 +1,116 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { MyReferralsList } from "../MyReferralsList";
+
+const ORIGINAL_FETCH = global.fetch;
+
+beforeEach(() => {});
+
+afterEach(() => {
+  global.fetch = ORIGINAL_FETCH;
+});
+
+describe("<MyReferralsList />", () => {
+  it("empty state when no referrals", async () => {
+    global.fetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ pending: [], earned: [], voided: [] }), { status: 200 })
+    ) as unknown as typeof fetch;
+
+    render(<MyReferralsList />);
+    await waitFor(() => {
+      expect(screen.getByText(/No invites sent yet/i)).toBeInTheDocument();
+      expect(screen.getByText(/\$10 per friend/i)).toBeInTheDocument();
+    });
+  });
+
+  it("renders rows grouped pending then earned then voided, with status badges", async () => {
+    global.fetch = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            pending: [
+              {
+                id: "p-1",
+                status: "pending",
+                earned_at: null,
+                created_at: "2026-04-01",
+                invitee: { contact_name: "Pending Pat", company_name: null },
+              },
+            ],
+            earned: [
+              {
+                id: "e-1",
+                status: "earned",
+                earned_at: "2026-04-15",
+                created_at: "2026-04-10",
+                invitee: { contact_name: "Earned Eve", company_name: null },
+              },
+            ],
+            voided: [
+              {
+                id: "v-1",
+                status: "voided",
+                earned_at: null,
+                created_at: "2026-04-05",
+                invitee: { contact_name: null, company_name: "Voided Co" },
+              },
+            ],
+          }),
+          { status: 200 }
+        )
+    ) as unknown as typeof fetch;
+
+    render(<MyReferralsList />);
+    await waitFor(() => {
+      expect(screen.getByText("Pending Pat")).toBeInTheDocument();
+      expect(screen.getByText("Earned Eve")).toBeInTheDocument();
+      expect(screen.getByText("Voided Co")).toBeInTheDocument();
+    });
+
+    // Counts in the header.
+    expect(screen.getByText(/1 brewing/i)).toBeInTheDocument();
+    expect(screen.getByText(/1 earned/i)).toBeInTheDocument();
+
+    // Badge labels per status.
+    expect(screen.getByText("Brewing")).toBeInTheDocument();
+    expect(screen.getByText("Earned")).toBeInTheDocument();
+    expect(screen.getByText(/Lot fell through/i)).toBeInTheDocument();
+  });
+
+  it("falls back to 'A new roaster' when invitee has no name", async () => {
+    global.fetch = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            pending: [
+              {
+                id: "p-1",
+                status: "pending",
+                earned_at: null,
+                created_at: "2026-04-01",
+                invitee: { contact_name: null, company_name: null },
+              },
+            ],
+            earned: [],
+            voided: [],
+          }),
+          { status: 200 }
+        )
+    ) as unknown as typeof fetch;
+
+    render(<MyReferralsList />);
+    await waitFor(() => {
+      expect(screen.getByText("A new roaster")).toBeInTheDocument();
+    });
+  });
+
+  it("error state on load failure", async () => {
+    global.fetch = vi.fn(async () => new Response("nope", { status: 500 })) as unknown as typeof fetch;
+    render(<MyReferralsList />);
+    await waitFor(() => {
+      expect(screen.getByText(/Couldn't load/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/lib/email/__tests__/ReferralCreditEarned.test.ts
+++ b/lib/email/__tests__/ReferralCreditEarned.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { renderReferralCreditEarnedHtml } from "@/lib/email/templates/ReferralCreditEarned";
+
+describe("ReferralCreditEarned template", () => {
+  it("renders inviter name, invitee name, $10, lot title, and the auto-apply phrasing", async () => {
+    const html = await renderReferralCreditEarnedHtml({
+      inviterName: "Alice",
+      inviteeName: "Bob",
+      lotTitle: "Yirgacheffe G1",
+      dashboardUrl: "https://crowdroast.test/dashboard/buyer",
+    });
+    expect(html).toContain("Alice");
+    expect(html).toContain("Bob");
+    expect(html).toContain("$10");
+    expect(html).toContain("Yirgacheffe G1");
+    expect(html).toContain("auto-apply");
+  });
+
+  it("omits the lot phrase gracefully when lotTitle is null", async () => {
+    const html = await renderReferralCreditEarnedHtml({
+      inviterName: "Alice",
+      inviteeName: "Bob",
+      lotTitle: null,
+      dashboardUrl: "https://crowdroast.test/dashboard/buyer",
+    });
+    expect(html).toContain("Alice");
+    expect(html).toContain("Bob");
+    expect(html).not.toContain("on null");
+    expect(html).not.toContain("on  just");
+  });
+});

--- a/lib/email/__tests__/ReferralSignup.test.ts
+++ b/lib/email/__tests__/ReferralSignup.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { renderReferralSignupHtml } from "@/lib/email/templates/ReferralSignup";
+
+describe("ReferralSignup template", () => {
+  it("renders inviter, invitee, and hub names into the body", async () => {
+    const html = await renderReferralSignupHtml({
+      inviterName: "Alice",
+      inviteeName: "Bob",
+      inviteeCompany: "Bob's Roastery",
+      hubName: "East Side",
+    });
+    expect(html).toContain("Alice");
+    expect(html).toContain("Bob");
+    expect(html).toContain("East Side");
+    expect(html).toContain("$10");
+  });
+
+  it("uses 'A new roaster' fallback handled by the wrapper, not the template", async () => {
+    // Template trusts the props it gets; defaulting happens in
+    // sendReferralSignupEmail. The template just renders what it's given.
+    const html = await renderReferralSignupHtml({
+      inviterName: "Alice",
+      inviteeName: "A new roaster",
+      inviteeCompany: null,
+      hubName: "East Side",
+    });
+    expect(html).toContain("A new roaster");
+    // No '(null)' from a missing company.
+    expect(html).not.toContain("(null)");
+  });
+});

--- a/lib/email/index.ts
+++ b/lib/email/index.ts
@@ -30,6 +30,7 @@ import { renderHubAccessDeniedHtml } from "./templates/HubAccessDenied";
 import { renderBuyerHubInviteHtml } from "./templates/BuyerHubInvite";
 import { renderLotShippedHtml } from "./templates/LotShipped";
 import { renderReadyForPickupHtml } from "./templates/ReadyForPickup";
+import { renderReferralSignupHtml } from "./templates/ReferralSignup";
 import type { Profile, Hub, Lot, Commitment } from "@/lib/types";
 
 const APP_URL = process.env.NEXT_PUBLIC_APP_URL || "https://crowdroast.com";
@@ -695,6 +696,34 @@ export async function sendHubAccessDeniedEmail(
   return sendEmail({
     to: params.buyer.email,
     subject: `Update on your request to join ${params.hubName}`,
+    html,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Buyer-referral: a friend signed up via the inviter's link
+// ---------------------------------------------------------------------------
+
+export interface ReferralSignupEmailParams {
+  inviter: Pick<Profile, "email" | "contact_name">;
+  invitee: Pick<Profile, "contact_name" | "company_name">;
+  hubName: string;
+}
+
+export async function sendReferralSignupEmail(
+  params: ReferralSignupEmailParams
+): Promise<SendEmailResult> {
+  if (!params.inviter.email) return { success: false, error: "Inviter has no email address" };
+  const inviteeName = params.invitee.contact_name || "A new roaster";
+  const html = await renderReferralSignupHtml({
+    inviterName: params.inviter.contact_name || "there",
+    inviteeName,
+    inviteeCompany: params.invitee.company_name,
+    hubName: params.hubName,
+  });
+  return sendEmail({
+    to: params.inviter.email,
+    subject: `${inviteeName} joined ${params.hubName} via your invite`,
     html,
   });
 }

--- a/lib/email/index.ts
+++ b/lib/email/index.ts
@@ -31,6 +31,7 @@ import { renderBuyerHubInviteHtml } from "./templates/BuyerHubInvite";
 import { renderLotShippedHtml } from "./templates/LotShipped";
 import { renderReadyForPickupHtml } from "./templates/ReadyForPickup";
 import { renderReferralSignupHtml } from "./templates/ReferralSignup";
+import { renderReferralCreditEarnedHtml } from "./templates/ReferralCreditEarned";
 import type { Profile, Hub, Lot, Commitment } from "@/lib/types";
 
 const APP_URL = process.env.NEXT_PUBLIC_APP_URL || "https://crowdroast.com";
@@ -724,6 +725,33 @@ export async function sendReferralSignupEmail(
   return sendEmail({
     to: params.inviter.email,
     subject: `${inviteeName} joined ${params.hubName} via your invite`,
+    html,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Buyer-referral: invitee's lot settled successfully → inviter earned $10
+// ---------------------------------------------------------------------------
+
+export interface ReferralCreditEarnedEmailParams {
+  inviter: Pick<Profile, "email" | "contact_name">;
+  inviteeName: string;
+  lotTitle: string | null;
+}
+
+export async function sendReferralCreditEarnedEmail(
+  params: ReferralCreditEarnedEmailParams
+): Promise<SendEmailResult> {
+  if (!params.inviter.email) return { success: false, error: "Inviter has no email address" };
+  const html = await renderReferralCreditEarnedHtml({
+    inviterName: params.inviter.contact_name || "there",
+    inviteeName: params.inviteeName,
+    lotTitle: params.lotTitle,
+    dashboardUrl: `${APP_URL}/dashboard/buyer`,
+  });
+  return sendEmail({
+    to: params.inviter.email,
+    subject: `${params.inviteeName}'s lot closed — you've earned $10 in credits`,
     html,
   });
 }

--- a/lib/email/templates/ReferralCreditEarned.tsx
+++ b/lib/email/templates/ReferralCreditEarned.tsx
@@ -1,0 +1,103 @@
+import {
+  Body,
+  Container,
+  Head,
+  Heading,
+  Hr,
+  Html,
+  Link,
+  Preview,
+  Text,
+} from "@react-email/components";
+import { render } from "@react-email/render";
+import React from "react";
+
+export interface ReferralCreditEarnedProps {
+  inviterName: string;
+  inviteeName: string;
+  lotTitle: string | null;
+  dashboardUrl: string;
+}
+
+export function ReferralCreditEarned({
+  inviterName,
+  inviteeName,
+  lotTitle,
+  dashboardUrl,
+}: ReferralCreditEarnedProps) {
+  const lotPhrase = lotTitle ? ` on ${lotTitle}` : "";
+
+  return (
+    <Html>
+      <Head />
+      <Preview>You earned $10 in credits — auto-applies to your next commit</Preview>
+      <Body style={body}>
+        <Container style={container}>
+          <Heading style={heading}>Lot closed. You earned $10 ☕</Heading>
+          <Text style={text}>
+            Hi {inviterName}, <strong>{inviteeName}</strong>'s commitment{lotPhrase}{" "}
+            just settled successfully.
+          </Text>
+          <Text style={text}>
+            You've earned <strong>$10 in CrowdRoast credits</strong>. They'll
+            auto-apply to your next commit at settlement — nothing to do, just
+            commit on coffee you were going to buy anyway.
+          </Text>
+          <Text style={text}>
+            <Link href={dashboardUrl} style={link}>
+              View your balance
+            </Link>
+          </Text>
+          <Hr style={hr} />
+          <Text style={footer}>
+            You're receiving this because you invited a friend who just settled their first lot on CrowdRoast.
+          </Text>
+        </Container>
+      </Body>
+    </Html>
+  );
+}
+
+export async function renderReferralCreditEarnedHtml(
+  props: ReferralCreditEarnedProps
+): Promise<string> {
+  return render(<ReferralCreditEarned {...props} />);
+}
+
+const body: React.CSSProperties = {
+  backgroundColor: "#f6f9f6",
+  fontFamily: "-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+};
+const container: React.CSSProperties = {
+  backgroundColor: "#ffffff",
+  margin: "40px auto",
+  padding: "40px",
+  borderRadius: "8px",
+  maxWidth: "560px",
+};
+const heading: React.CSSProperties = {
+  fontSize: "24px",
+  fontWeight: "700",
+  color: "#111827",
+  margin: "0 0 16px",
+};
+const text: React.CSSProperties = {
+  fontSize: "15px",
+  lineHeight: "1.6",
+  color: "#374151",
+  margin: "0 0 12px",
+};
+const link: React.CSSProperties = {
+  color: "#E8442A",
+  fontWeight: 700,
+  textDecoration: "underline",
+};
+const hr: React.CSSProperties = {
+  borderColor: "#e5e7eb",
+  margin: "32px 0 16px",
+};
+const footer: React.CSSProperties = {
+  fontSize: "12px",
+  color: "#9ca3af",
+  margin: "0",
+};

--- a/lib/email/templates/ReferralSignup.tsx
+++ b/lib/email/templates/ReferralSignup.tsx
@@ -1,0 +1,89 @@
+import {
+  Body,
+  Container,
+  Head,
+  Heading,
+  Hr,
+  Html,
+  Preview,
+  Text,
+} from "@react-email/components";
+import { render } from "@react-email/render";
+import React from "react";
+
+export interface ReferralSignupProps {
+  inviterName: string;
+  inviteeName: string;
+  inviteeCompany: string | null;
+  hubName: string;
+}
+
+export function ReferralSignup({
+  inviterName,
+  inviteeName,
+  inviteeCompany,
+  hubName,
+}: ReferralSignupProps) {
+  const inviteeLabel = inviteeCompany ? `${inviteeName} (${inviteeCompany})` : inviteeName;
+
+  return (
+    <Html>
+      <Head />
+      <Preview>{inviteeName} joined {hubName} via your invite</Preview>
+      <Body style={body}>
+        <Container style={container}>
+          <Heading style={heading}>Your friend just joined ☕</Heading>
+          <Text style={text}>
+            Hi {inviterName}, <strong>{inviteeLabel}</strong> joined{" "}
+            <strong>{hubName}</strong> via your invite link.
+          </Text>
+          <Text style={text}>
+            When their first commitment closes successfully, you'll earn{" "}
+            <strong>$10 in credits</strong> — they auto-apply to your next commit.
+          </Text>
+          <Hr style={hr} />
+          <Text style={footer}>
+            You're receiving this because someone signed up using your invite link on CrowdRoast.
+          </Text>
+        </Container>
+      </Body>
+    </Html>
+  );
+}
+
+export async function renderReferralSignupHtml(props: ReferralSignupProps): Promise<string> {
+  return render(<ReferralSignup {...props} />);
+}
+
+const body: React.CSSProperties = {
+  backgroundColor: "#f6f9f6",
+  fontFamily: "-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+};
+const container: React.CSSProperties = {
+  backgroundColor: "#ffffff",
+  margin: "40px auto",
+  padding: "40px",
+  borderRadius: "8px",
+  maxWidth: "560px",
+};
+const heading: React.CSSProperties = {
+  fontSize: "24px",
+  fontWeight: "700",
+  color: "#111827",
+  margin: "0 0 16px",
+};
+const text: React.CSSProperties = {
+  fontSize: "15px",
+  lineHeight: "1.6",
+  color: "#374151",
+  margin: "0 0 12px",
+};
+const hr: React.CSSProperties = {
+  borderColor: "#e5e7eb",
+  margin: "32px 0 16px",
+};
+const footer: React.CSSProperties = {
+  fontSize: "12px",
+  color: "#9ca3af",
+  margin: "0",
+};

--- a/lib/payments/settlement-logic.js
+++ b/lib/payments/settlement-logic.js
@@ -51,6 +51,12 @@ export function getFinalBuyerPricePerKg(basePricePerKg, committedQuantityKg, tie
   );
 }
 
+// Note for the buyer-referral feature: credit-debit logic that consumes
+// inviter credits against Mernin's share lives at lib/referrals/apply-credit
+// .ts and is invoked from the settle-deadlines route AFTER computeSplit() has
+// produced the platform amount. computeChargeAdjustment stays a pure
+// refund-the-diff function — it does not know about credits. See
+// ~/Documents/crowdroast/buyer-referral-invites/spec.md.
 export function computeChargeAdjustment({
   quantityKg,
   committedTotalPrice,

--- a/lib/referrals/__tests__/apply-credit.test.ts
+++ b/lib/referrals/__tests__/apply-credit.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { applyInviterCreditOnSettle } from "../apply-credit";
+
+let balanceResult: { data: unknown; error: unknown } = { data: 0, error: null };
+let insertResult: { data: unknown; error: unknown } = { data: null, error: null };
+let priorDebitResult: { data: unknown; error: unknown } = { data: null, error: null };
+const insertCalls: Array<Record<string, unknown>> = [];
+
+function makeMockAdmin() {
+  return {
+    rpc: vi.fn(async () => balanceResult),
+    from(table: string) {
+      if (table === "credit_ledger") {
+        return {
+          insert: (payload: Record<string, unknown>) => {
+            insertCalls.push(payload);
+            return Promise.resolve(insertResult);
+          },
+          select: () => ({
+            eq: () => ({
+              eq: () => ({
+                maybeSingle: async () => priorDebitResult,
+              }),
+            }),
+          }),
+        };
+      }
+      throw new Error(`Unexpected table ${table}`);
+    },
+  };
+}
+
+beforeEach(() => {
+  balanceResult = { data: 0, error: null };
+  insertResult = { data: null, error: null };
+  priorDebitResult = { data: null, error: null };
+  insertCalls.length = 0;
+});
+
+describe("applyInviterCreditOnSettle", () => {
+  it("no-op when commitmentId is empty", async () => {
+    const res = await applyInviterCreditOnSettle(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeMockAdmin() as any,
+      { commitmentId: "", buyerId: "b-1", platformAmountCents: 5000 }
+    );
+    expect(res.applied).toBe(0);
+    expect(res.adjustedPlatformAmountCents).toBe(5000);
+    expect(insertCalls).toHaveLength(0);
+  });
+
+  it("no-op when platformAmount is 0 (Mernin floor protected)", async () => {
+    balanceResult = { data: 1000, error: null };
+    const res = await applyInviterCreditOnSettle(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeMockAdmin() as any,
+      { commitmentId: "c-1", buyerId: "b-1", platformAmountCents: 0 }
+    );
+    expect(res.applied).toBe(0);
+    expect(res.adjustedPlatformAmountCents).toBe(0);
+    expect(insertCalls).toHaveLength(0);
+  });
+
+  it("no-op when balance is 0 (no ledger row inserted)", async () => {
+    balanceResult = { data: 0, error: null };
+    const res = await applyInviterCreditOnSettle(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeMockAdmin() as any,
+      { commitmentId: "c-1", buyerId: "b-1", platformAmountCents: 5000 }
+    );
+    expect(res.applied).toBe(0);
+    expect(res.adjustedPlatformAmountCents).toBe(5000);
+    expect(insertCalls).toHaveLength(0);
+  });
+
+  it("under-cap (criterion 9): applies full balance, debits ledger, reduces platform amount", async () => {
+    balanceResult = { data: 3000, error: null };
+    const res = await applyInviterCreditOnSettle(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeMockAdmin() as any,
+      { commitmentId: "c-1", buyerId: "b-1", platformAmountCents: 5000 }
+    );
+    expect(res.applied).toBe(3000);
+    expect(res.adjustedPlatformAmountCents).toBe(2000); // 5000 - 3000
+    expect(res.ledgerRowInserted).toBe(true);
+    expect(insertCalls).toHaveLength(1);
+    expect(insertCalls[0]).toEqual({
+      user_id: "b-1",
+      amount_cents: -3000,
+      reason: "commit_applied",
+      source_commitment_id: "c-1",
+    });
+  });
+
+  it("over-cap (criterion 10, partial OK): applies platformAmount, leaves rest in balance", async () => {
+    balanceResult = { data: 3000, error: null };
+    const res = await applyInviterCreditOnSettle(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeMockAdmin() as any,
+      { commitmentId: "c-1", buyerId: "b-1", platformAmountCents: 1800 }
+    );
+    expect(res.applied).toBe(1800);
+    expect(res.adjustedPlatformAmountCents).toBe(0); // floor at 0
+    // Rest stays in balance for next commit; that's a balance-side fact,
+    // verified by the constant: applied = min(balance, platform).
+    expect(insertCalls[0].amount_cents).toBe(-1800);
+  });
+
+  it("idempotency: 23505 collision reads back prior debit and reports consistent math", async () => {
+    balanceResult = { data: 5000, error: null };
+    insertResult = { data: null, error: { code: "23505", message: "duplicate" } };
+    priorDebitResult = { data: { amount_cents: -2000 }, error: null };
+
+    const res = await applyInviterCreditOnSettle(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeMockAdmin() as any,
+      { commitmentId: "c-1", buyerId: "b-1", platformAmountCents: 5000 }
+    );
+
+    // The prior pass applied 2000; we honor that on retry.
+    expect(res.applied).toBe(2000);
+    expect(res.adjustedPlatformAmountCents).toBe(3000); // 5000 - 2000
+    expect(res.ledgerRowInserted).toBe(false);
+  });
+
+  it("non-23505 db error: bail safely, don't reduce platform amount", async () => {
+    balanceResult = { data: 5000, error: null };
+    insertResult = { data: null, error: { code: "other", message: "boom" } };
+
+    const res = await applyInviterCreditOnSettle(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeMockAdmin() as any,
+      { commitmentId: "c-1", buyerId: "b-1", platformAmountCents: 5000 }
+    );
+
+    expect(res.applied).toBe(0);
+    expect(res.adjustedPlatformAmountCents).toBe(5000);
+  });
+
+  it("amount_cents inserted equals (platform before) - (platform after)", async () => {
+    // Criterion 10 false-positive guard: invariant about the relationship
+    // between ledger debit and adjusted platform amount.
+    balanceResult = { data: 4000, error: null };
+    const res = await applyInviterCreditOnSettle(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeMockAdmin() as any,
+      { commitmentId: "c-1", buyerId: "b-1", platformAmountCents: 7500 }
+    );
+    const insertedAbs = Math.abs(insertCalls[0].amount_cents as number);
+    expect(insertedAbs).toBe(7500 - res.adjustedPlatformAmountCents);
+  });
+});

--- a/lib/referrals/__tests__/code.test.ts
+++ b/lib/referrals/__tests__/code.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { generateInviteCode, isValidInviteCodeShape, INVITE_CODE_LENGTH } from "../code";
+
+describe("generateInviteCode", () => {
+  it("returns a 10-character code from the lowercase-alphanumeric alphabet", () => {
+    const code = generateInviteCode();
+    expect(code).toHaveLength(INVITE_CODE_LENGTH);
+    expect(code).toMatch(/^[0-9a-z]{10}$/);
+  });
+
+  it("produces distinct codes across many calls (sanity entropy check)", () => {
+    const codes = new Set<string>();
+    for (let i = 0; i < 1000; i++) codes.add(generateInviteCode());
+    expect(codes.size).toBe(1000);
+  });
+});
+
+describe("isValidInviteCodeShape", () => {
+  it("accepts well-formed codes", () => {
+    expect(isValidInviteCodeShape("abc123def4")).toBe(true);
+    expect(isValidInviteCodeShape(generateInviteCode())).toBe(true);
+  });
+
+  it("rejects wrong length", () => {
+    expect(isValidInviteCodeShape("short")).toBe(false);
+    expect(isValidInviteCodeShape("waytoolongacode")).toBe(false);
+  });
+
+  it("rejects out-of-alphabet chars", () => {
+    expect(isValidInviteCodeShape("ABC123DEF4")).toBe(false); // uppercase
+    expect(isValidInviteCodeShape("abc-123def")).toBe(false); // dash
+    expect(isValidInviteCodeShape("abc_123def")).toBe(false); // underscore
+  });
+});

--- a/lib/referrals/__tests__/insert-attribution.test.ts
+++ b/lib/referrals/__tests__/insert-attribution.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { insertReferralAttributionIfEligible } from "../insert-attribution";
+
+type Result = { data: unknown; error: unknown };
+
+let commitmentResult: Result = { data: null, error: null };
+let profileResult: Result = { data: null, error: null };
+let existingAttributionResult: Result = { data: null, error: null };
+let insertResult: Result = { data: null, error: null };
+const insertCalls: Array<Record<string, unknown>> = [];
+
+function makeMockAdmin() {
+  return {
+    from(table: string) {
+      if (table === "commitments") {
+        return {
+          select: () => ({
+            eq: () => ({ maybeSingle: async () => commitmentResult }),
+          }),
+        };
+      }
+      if (table === "profiles") {
+        return {
+          select: () => ({
+            eq: () => ({ maybeSingle: async () => profileResult }),
+          }),
+        };
+      }
+      if (table === "referral_attributions") {
+        return {
+          select: () => ({
+            eq: () => ({ maybeSingle: async () => existingAttributionResult }),
+          }),
+          insert: (payload: Record<string, unknown>) => {
+            insertCalls.push(payload);
+            return Promise.resolve(insertResult) as unknown as Promise<Result> & {
+              error: unknown;
+            };
+          },
+        };
+      }
+      throw new Error(`Unexpected table ${table}`);
+    },
+  };
+}
+
+beforeEach(() => {
+  commitmentResult = { data: null, error: null };
+  profileResult = { data: null, error: null };
+  existingAttributionResult = { data: null, error: null };
+  insertResult = { data: null, error: null };
+  insertCalls.length = 0;
+});
+
+describe("insertReferralAttributionIfEligible", () => {
+  it("no-op when commitmentId is empty", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await insertReferralAttributionIfEligible(makeMockAdmin() as any, "");
+    expect(result.inserted).toBe(false);
+    expect(result.reason).toBe("missing_commitment_id");
+    expect(insertCalls).toHaveLength(0);
+  });
+
+  it("no-op when commitment not yet charge_succeeded", async () => {
+    commitmentResult = {
+      data: { id: "c-1", buyer_id: "b-1", campaign_id: "ca-1", payment_status: "setup_complete" },
+      error: null,
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await insertReferralAttributionIfEligible(makeMockAdmin() as any, "c-1");
+    expect(result.inserted).toBe(false);
+    expect(result.reason).toBe("not_charge_succeeded");
+    expect(insertCalls).toHaveLength(0);
+  });
+
+  it("no-op when buyer has no inviter", async () => {
+    commitmentResult = {
+      data: { id: "c-1", buyer_id: "b-1", campaign_id: "ca-1", payment_status: "charge_succeeded" },
+      error: null,
+    };
+    profileResult = { data: { invited_by_user_id: null }, error: null };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await insertReferralAttributionIfEligible(makeMockAdmin() as any, "c-1");
+    expect(result.inserted).toBe(false);
+    expect(result.reason).toBe("no_inviter");
+    expect(insertCalls).toHaveLength(0);
+  });
+
+  it("no-op when invitee already has an attribution (criterion 13 lock)", async () => {
+    commitmentResult = {
+      data: { id: "c-2", buyer_id: "b-1", campaign_id: "ca-1", payment_status: "charge_succeeded" },
+      error: null,
+    };
+    profileResult = { data: { invited_by_user_id: "inv-1" }, error: null };
+    existingAttributionResult = { data: { id: "attr-existing" }, error: null };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await insertReferralAttributionIfEligible(makeMockAdmin() as any, "c-2");
+    expect(result.inserted).toBe(false);
+    expect(result.reason).toBe("already_attributed");
+    expect(insertCalls).toHaveLength(0);
+  });
+
+  it("inserts pending attribution on first eligible charge_succeeded", async () => {
+    commitmentResult = {
+      data: { id: "c-1", buyer_id: "b-1", campaign_id: "ca-1", payment_status: "charge_succeeded" },
+      error: null,
+    };
+    profileResult = { data: { invited_by_user_id: "inv-1" }, error: null };
+    existingAttributionResult = { data: null, error: null };
+    insertResult = { data: null, error: null };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await insertReferralAttributionIfEligible(makeMockAdmin() as any, "c-1");
+    expect(result.inserted).toBe(true);
+    expect(insertCalls).toHaveLength(1);
+    expect(insertCalls[0]).toEqual({
+      inviter_user_id: "inv-1",
+      invitee_user_id: "b-1",
+      commitment_id: "c-1",
+      campaign_id: "ca-1",
+      status: "pending",
+    });
+  });
+
+  it("swallows 23505 race-loss as a benign no-op", async () => {
+    commitmentResult = {
+      data: { id: "c-1", buyer_id: "b-1", campaign_id: "ca-1", payment_status: "charge_succeeded" },
+      error: null,
+    };
+    profileResult = { data: { invited_by_user_id: "inv-1" }, error: null };
+    existingAttributionResult = { data: null, error: null };
+    insertResult = { data: null, error: { code: "23505", message: "duplicate" } };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await insertReferralAttributionIfEligible(makeMockAdmin() as any, "c-1");
+    expect(result.inserted).toBe(false);
+    expect(result.reason).toBe("race_lost");
+  });
+});

--- a/lib/referrals/__tests__/settle-attribution.test.ts
+++ b/lib/referrals/__tests__/settle-attribution.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  settleAttributionIfPending,
+  REFERRAL_CREDIT_AMOUNT_CENTS,
+} from "../settle-attribution";
+
+type Result = { data: unknown; error: unknown };
+
+let attributionResult: Result = { data: null, error: null };
+let updateResult: Result = { data: null, error: null };
+let insertResult: Result = { data: null, error: null };
+const updateCalls: Array<{ payload: Record<string, unknown> }> = [];
+const insertCalls: Array<Record<string, unknown>> = [];
+
+function makeMockAdmin() {
+  return {
+    from(table: string) {
+      if (table === "referral_attributions") {
+        return {
+          select: () => ({
+            eq: () => ({ maybeSingle: async () => attributionResult }),
+          }),
+          update: (payload: Record<string, unknown>) => {
+            updateCalls.push({ payload });
+            return {
+              eq: () => ({
+                eq: () => Promise.resolve(updateResult),
+              }),
+            };
+          },
+        };
+      }
+      if (table === "credit_ledger") {
+        return {
+          insert: (payload: Record<string, unknown>) => {
+            insertCalls.push(payload);
+            return Promise.resolve(insertResult);
+          },
+        };
+      }
+      throw new Error(`Unexpected table ${table}`);
+    },
+  };
+}
+
+beforeEach(() => {
+  attributionResult = { data: null, error: null };
+  updateResult = { data: null, error: null };
+  insertResult = { data: null, error: null };
+  updateCalls.length = 0;
+  insertCalls.length = 0;
+});
+
+describe("settleAttributionIfPending", () => {
+  it("no-op when commitmentId is empty", async () => {
+    const result = await settleAttributionIfPending(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeMockAdmin() as any,
+      ""
+    );
+    expect(result.earned).toBe(false);
+    expect(result.reason).toBe("missing_commitment_id");
+  });
+
+  it("no-op when no attribution row exists for the commitment", async () => {
+    attributionResult = { data: null, error: null };
+    const result = await settleAttributionIfPending(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeMockAdmin() as any,
+      "c-1"
+    );
+    expect(result.earned).toBe(false);
+    expect(result.reason).toBe("no_attribution");
+    expect(insertCalls).toHaveLength(0);
+  });
+
+  it("no-op when attribution is already earned (defensive)", async () => {
+    attributionResult = {
+      data: {
+        id: "attr-1",
+        status: "earned",
+        inviter_user_id: "inv-1",
+        invitee_user_id: "buy-1",
+        campaign_id: "ca-1",
+      },
+      error: null,
+    };
+    const result = await settleAttributionIfPending(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeMockAdmin() as any,
+      "c-1"
+    );
+    expect(result.earned).toBe(false);
+    expect(result.reason).toBe("not_pending");
+    expect(updateCalls).toHaveLength(0);
+    expect(insertCalls).toHaveLength(0);
+  });
+
+  it("happy path: flips to earned and inserts ledger row", async () => {
+    attributionResult = {
+      data: {
+        id: "attr-1",
+        status: "pending",
+        inviter_user_id: "inv-1",
+        invitee_user_id: "buy-1",
+        campaign_id: "ca-1",
+      },
+      error: null,
+    };
+
+    const result = await settleAttributionIfPending(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeMockAdmin() as any,
+      "c-1"
+    );
+
+    expect(result.earned).toBe(true);
+    expect(result.inviterUserId).toBe("inv-1");
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0].payload.status).toBe("earned");
+    expect(updateCalls[0].payload.earned_at).toBeTruthy();
+
+    expect(insertCalls).toHaveLength(1);
+    expect(insertCalls[0]).toEqual({
+      user_id: "inv-1",
+      amount_cents: REFERRAL_CREDIT_AMOUNT_CENTS,
+      reason: "referral_earned",
+      source_attribution_id: "attr-1",
+    });
+  });
+
+  it("idempotency: 23505 unique-violation on ledger insert is swallowed", async () => {
+    attributionResult = {
+      data: {
+        id: "attr-1",
+        status: "pending",
+        inviter_user_id: "inv-1",
+        invitee_user_id: "buy-1",
+        campaign_id: "ca-1",
+      },
+      error: null,
+    };
+    insertResult = { data: null, error: { code: "23505", message: "duplicate" } };
+
+    const result = await settleAttributionIfPending(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeMockAdmin() as any,
+      "c-1"
+    );
+
+    expect(result.earned).toBe(false);
+    expect(result.reason).toBe("ledger_already_recorded");
+    // Update still ran on this code path; idempotency comes from the
+    // WHERE status='pending' filter (the second pass updates 0 rows)
+    // and the partial unique index on credit_ledger.
+    expect(updateCalls).toHaveLength(1);
+    expect(insertCalls).toHaveLength(1);
+  });
+
+  it("constant: REFERRAL_CREDIT_AMOUNT_CENTS is exactly $10.00", () => {
+    expect(REFERRAL_CREDIT_AMOUNT_CENTS).toBe(1000);
+  });
+});

--- a/lib/referrals/__tests__/void-attribution.test.ts
+++ b/lib/referrals/__tests__/void-attribution.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { voidAttributionsForCampaign } from "../void-attribution";
+
+type Result = { data: unknown; error: unknown };
+
+let updateResult: Result = { data: [], error: null };
+const updateCalls: Array<{
+  payload: Record<string, unknown>;
+  filters: Array<[string, unknown]>;
+}> = [];
+const ledgerInsertCalls: Array<unknown> = [];
+
+function makeMockAdmin() {
+  return {
+    from(table: string) {
+      if (table === "referral_attributions") {
+        const filters: Array<[string, unknown]> = [];
+        let payload: Record<string, unknown> = {};
+        const chain = {
+          update(p: Record<string, unknown>) {
+            payload = p;
+            return chain;
+          },
+          eq(col: string, val: unknown) {
+            filters.push([col, val]);
+            return chain;
+          },
+          select() {
+            updateCalls.push({ payload, filters: [...filters] });
+            return Promise.resolve(updateResult);
+          },
+        };
+        return chain;
+      }
+      if (table === "credit_ledger") {
+        return {
+          insert: (p: unknown) => {
+            ledgerInsertCalls.push(p);
+            return Promise.resolve({ data: null, error: null });
+          },
+        };
+      }
+      throw new Error(`Unexpected table ${table}`);
+    },
+  };
+}
+
+beforeEach(() => {
+  updateResult = { data: [], error: null };
+  updateCalls.length = 0;
+  ledgerInsertCalls.length = 0;
+});
+
+describe("voidAttributionsForCampaign", () => {
+  it("no-op when campaignId is empty", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const res = await voidAttributionsForCampaign(makeMockAdmin() as any, "");
+    expect(res.voided).toBe(0);
+    expect(updateCalls).toHaveLength(0);
+    expect(ledgerInsertCalls).toHaveLength(0);
+  });
+
+  it("voids only pending rows; does not touch earned (filter on status='pending')", async () => {
+    updateResult = { data: [{ id: "attr-pending-1" }, { id: "attr-pending-2" }], error: null };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const res = await voidAttributionsForCampaign(makeMockAdmin() as any, "ca-1");
+
+    expect(res.voided).toBe(2);
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0].payload).toEqual({ status: "voided" });
+    // Both filters present: campaign_id and status='pending'.
+    expect(updateCalls[0].filters).toEqual(
+      expect.arrayContaining([
+        ["campaign_id", "ca-1"],
+        ["status", "pending"],
+      ])
+    );
+  });
+
+  it("never inserts a credit_ledger row (criterion 8: void writes no money)", async () => {
+    updateResult = { data: [{ id: "attr-1" }], error: null };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await voidAttributionsForCampaign(makeMockAdmin() as any, "ca-1");
+    expect(ledgerInsertCalls).toHaveLength(0);
+  });
+
+  it("returns voided=0 when nothing was pending", async () => {
+    updateResult = { data: [], error: null };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const res = await voidAttributionsForCampaign(makeMockAdmin() as any, "ca-1");
+    expect(res.voided).toBe(0);
+  });
+
+  it("returns voided=0 on db error (does not throw)", async () => {
+    updateResult = { data: null, error: { message: "boom" } };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const res = await voidAttributionsForCampaign(makeMockAdmin() as any, "ca-1");
+    expect(res.voided).toBe(0);
+  });
+});

--- a/lib/referrals/apply-credit.ts
+++ b/lib/referrals/apply-credit.ts
@@ -1,0 +1,117 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+// Called per-commitment in the success branch of settle-deadlines, AFTER the
+// existing refund-the-diff math has produced split.platformAmount (Mernin's
+// share on this commit) but BEFORE the platform transfer fans out.
+//
+// Reads the buyer's current credit balance and applies
+//   applied = min(balance, platformAmountCents)
+// as a single negative credit_ledger row. The partial unique index
+// idx_credit_ledger_commit_applied_unique on (source_commitment_id) WHERE
+// reason='commit_applied' makes the insert idempotent across cron retries:
+// on a 23505 collision we read back the prior debit and treat that as the
+// already-applied figure for this commitment, keeping the math consistent.
+//
+// Returns:
+//   applied                   — cents debited (always >= 0; 0 means no-op)
+//   adjustedPlatformAmount    — split.platformAmount reduced by applied
+//   ledger_row_inserted       — true if this call wrote the row, false if it
+//                               read back a prior row or short-circuited
+//
+// Mernin's-share floor: $0. The min() clamps applied to platformAmountCents,
+// so the adjusted platform amount is always >= 0.
+export async function applyInviterCreditOnSettle(
+  admin: SupabaseClient,
+  args: {
+    commitmentId: string;
+    buyerId: string;
+    platformAmountCents: number;
+  }
+): Promise<{
+  applied: number;
+  adjustedPlatformAmountCents: number;
+  ledgerRowInserted: boolean;
+}> {
+  const { commitmentId, buyerId, platformAmountCents } = args;
+
+  if (!commitmentId || !buyerId || platformAmountCents <= 0) {
+    return {
+      applied: 0,
+      adjustedPlatformAmountCents: Math.max(0, platformAmountCents),
+      ledgerRowInserted: false,
+    };
+  }
+
+  // Read current balance via the SQL function added in migration 30.
+  const { data: balanceData } = await admin.rpc("credit_balance_cents", {
+    p_user_id: buyerId,
+  });
+
+  const balance =
+    typeof balanceData === "number"
+      ? balanceData
+      : Number((balanceData as unknown as number) ?? 0);
+
+  if (!balance || balance <= 0) {
+    return {
+      applied: 0,
+      adjustedPlatformAmountCents: platformAmountCents,
+      ledgerRowInserted: false,
+    };
+  }
+
+  const applied = Math.min(balance, platformAmountCents);
+
+  if (applied <= 0) {
+    return {
+      applied: 0,
+      adjustedPlatformAmountCents: platformAmountCents,
+      ledgerRowInserted: false,
+    };
+  }
+
+  // Insert the debit. Partial unique index handles cron-retry idempotency.
+  const { error: insertError } = await admin.from("credit_ledger").insert({
+    user_id: buyerId,
+    amount_cents: -applied,
+    reason: "commit_applied",
+    source_commitment_id: commitmentId,
+  });
+
+  if (insertError) {
+    if (insertError.code === "23505") {
+      // Race or retry — a prior pass already inserted the debit for this
+      // commitment. Read back its amount so we report consistent math.
+      const { data: existing } = await admin
+        .from("credit_ledger")
+        .select("amount_cents")
+        .eq("source_commitment_id", commitmentId)
+        .eq("reason", "commit_applied")
+        .maybeSingle();
+
+      const priorApplied =
+        existing && typeof existing.amount_cents === "number"
+          ? Math.abs(existing.amount_cents)
+          : 0;
+
+      return {
+        applied: priorApplied,
+        adjustedPlatformAmountCents: Math.max(0, platformAmountCents - priorApplied),
+        ledgerRowInserted: false,
+      };
+    }
+    // Any other error: don't apply, don't reduce platform share. Better to
+    // overpay Mernin than to lose track of the buyer's balance.
+    return {
+      applied: 0,
+      adjustedPlatformAmountCents: platformAmountCents,
+      ledgerRowInserted: false,
+    };
+  }
+
+  return {
+    applied,
+    adjustedPlatformAmountCents: platformAmountCents - applied,
+    ledgerRowInserted: true,
+  };
+}

--- a/lib/referrals/code.ts
+++ b/lib/referrals/code.ts
@@ -1,0 +1,22 @@
+import { customAlphabet } from "nanoid";
+
+// 10 chars from a 36-char alphabet ≈ 51 bits of entropy. The alphabet excludes
+// `_` and `-` so the link reads cleanly when typed in plain text channels
+// (SMS, in-person), and excludes uppercase to avoid case-mismatch confusion
+// when read aloud.
+const INVITE_CODE_ALPHABET = "0123456789abcdefghijklmnopqrstuvwxyz";
+export const INVITE_CODE_LENGTH = 10;
+
+const generate = customAlphabet(INVITE_CODE_ALPHABET, INVITE_CODE_LENGTH);
+
+export function generateInviteCode(): string {
+  return generate();
+}
+
+export function isValidInviteCodeShape(code: string): boolean {
+  if (code.length !== INVITE_CODE_LENGTH) return false;
+  for (const ch of code) {
+    if (!INVITE_CODE_ALPHABET.includes(ch)) return false;
+  }
+  return true;
+}

--- a/lib/referrals/insert-attribution.ts
+++ b/lib/referrals/insert-attribution.ts
@@ -1,0 +1,82 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+// Inserts a referral_attributions(pending) row for the buyer behind this
+// commitment, if and only if:
+//
+//   - the commitment exists and has payment_status = 'charge_succeeded'
+//   - the buyer's profile has a non-null invited_by_user_id
+//   - the buyer doesn't already have an attribution row anywhere
+//     (criterion 13 lock — first inviter wins, locked-once-written)
+//
+// All conditions are evaluated server-side in a single helper so charge-
+// success handlers (Stripe webhook + the settle-deadlines self-correction
+// path) call one entry point. Idempotent — calling it twice for the same
+// commitment is a no-op via the unique (invitee_user_id) and unique
+// (commitment_id) constraints on referral_attributions.
+//
+// Spec criterion 6: attribution is created at first charge_succeeded, NOT
+// at commitment row insert. A commitment cancelled before charge does not
+// lock the attribution; the invitee's next charged commitment carries it.
+export async function insertReferralAttributionIfEligible(
+  admin: SupabaseClient,
+  commitmentId: string
+): Promise<{ inserted: boolean; reason?: string }> {
+  if (!commitmentId) return { inserted: false, reason: "missing_commitment_id" };
+
+  // Load commitment.
+  const { data: commitment } = await admin
+    .from("commitments")
+    .select("id, buyer_id, campaign_id, payment_status")
+    .eq("id", commitmentId)
+    .maybeSingle();
+
+  if (!commitment) return { inserted: false, reason: "commitment_not_found" };
+  if (commitment.payment_status !== "charge_succeeded") {
+    return { inserted: false, reason: "not_charge_succeeded" };
+  }
+
+  // Look up the buyer's inviter, if any.
+  const { data: profile } = await admin
+    .from("profiles")
+    .select("invited_by_user_id")
+    .eq("id", commitment.buyer_id)
+    .maybeSingle();
+
+  if (!profile?.invited_by_user_id) {
+    return { inserted: false, reason: "no_inviter" };
+  }
+
+  // Pre-check: criterion 13 lock — invitee can only have one attribution
+  // ever, regardless of which commitment was their first charge. This also
+  // makes calling the helper twice for the same commitment a clean no-op
+  // since the second call will find the attribution row from the first.
+  const { data: existing } = await admin
+    .from("referral_attributions")
+    .select("id")
+    .eq("invitee_user_id", commitment.buyer_id)
+    .maybeSingle();
+
+  if (existing) return { inserted: false, reason: "already_attributed" };
+
+  // Insert. The unique (invitee_user_id) and unique (commitment_id) indexes
+  // make a concurrent-insert race fall back to no-op cleanly — we swallow
+  // 23505 here so a webhook+cron double-fire just leaves the row from
+  // whichever request won.
+  const { error } = await admin.from("referral_attributions").insert({
+    inviter_user_id: profile.invited_by_user_id,
+    invitee_user_id: commitment.buyer_id,
+    commitment_id: commitment.id,
+    campaign_id: commitment.campaign_id,
+    status: "pending",
+  });
+
+  if (error) {
+    if (error.code === "23505") {
+      // Lost a race — another path inserted first. That's fine.
+      return { inserted: false, reason: "race_lost" };
+    }
+    return { inserted: false, reason: error.message };
+  }
+
+  return { inserted: true };
+}

--- a/lib/referrals/settle-attribution.ts
+++ b/lib/referrals/settle-attribution.ts
@@ -1,0 +1,77 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+// Flat $10 credit per successful invitee. Replaces the older 2%-of-gross
+// model so CAC is predictable and known in advance.
+export const REFERRAL_CREDIT_AMOUNT_CENTS = 1000;
+
+// Called per-commitment in the lot-settle-success branch of settle-deadlines.
+// If a pending referral_attribution row exists for the commitment, flip it to
+// 'earned' and insert a +1000 cent credit_ledger row for the inviter. Both
+// operations are idempotent: the WHERE status='pending' clause makes the
+// attribution flip a no-op on retry, and the partial unique index
+// idx_credit_ledger_referral_earned_unique on (source_attribution_id) WHERE
+// reason='referral_earned' ensures at most one ledger row per attribution.
+//
+// Returns the inviter_user_id when a ledger row was inserted, so the caller
+// can fire the ReferralCreditEarned email as a background task. Null when
+// no attribution exists, no-op when already earned, or when the cron retried.
+export async function settleAttributionIfPending(
+  admin: SupabaseClient,
+  commitmentId: string
+): Promise<{
+  earned: boolean;
+  inviterUserId: string | null;
+  reason?: string;
+}> {
+  if (!commitmentId) return { earned: false, inviterUserId: null, reason: "missing_commitment_id" };
+
+  const { data: attribution } = await admin
+    .from("referral_attributions")
+    .select("id, status, inviter_user_id, invitee_user_id, campaign_id")
+    .eq("commitment_id", commitmentId)
+    .maybeSingle();
+
+  if (!attribution) {
+    return { earned: false, inviterUserId: null, reason: "no_attribution" };
+  }
+
+  if (attribution.status !== "pending") {
+    // Already earned (or already voided by a misordered call). Defensive
+    // no-op: don't insert a ledger row, don't double-flip.
+    return { earned: false, inviterUserId: null, reason: "not_pending" };
+  }
+
+  // Flip to earned. The where-clause filter on status makes this idempotent —
+  // a concurrent call that also passed the pending check will end up with
+  // zero rows updated on the second pass.
+  const { error: updateError } = await admin
+    .from("referral_attributions")
+    .update({ status: "earned", earned_at: new Date().toISOString() })
+    .eq("id", attribution.id)
+    .eq("status", "pending");
+
+  if (updateError) {
+    return { earned: false, inviterUserId: null, reason: updateError.message };
+  }
+
+  // Insert the credit ledger row. The partial unique index handles the cron-
+  // retry case: if a previous invocation already inserted, the second insert
+  // raises 23505 which we swallow.
+  const { error: insertError } = await admin.from("credit_ledger").insert({
+    user_id: attribution.inviter_user_id,
+    amount_cents: REFERRAL_CREDIT_AMOUNT_CENTS,
+    reason: "referral_earned",
+    source_attribution_id: attribution.id,
+  });
+
+  if (insertError) {
+    if (insertError.code === "23505") {
+      // Idempotency win — cron retried and the credit already landed on a
+      // prior pass. Treat as success but signal to caller not to re-email.
+      return { earned: false, inviterUserId: null, reason: "ledger_already_recorded" };
+    }
+    return { earned: false, inviterUserId: null, reason: insertError.message };
+  }
+
+  return { earned: true, inviterUserId: attribution.inviter_user_id };
+}

--- a/lib/referrals/void-attribution.ts
+++ b/lib/referrals/void-attribution.ts
@@ -1,0 +1,25 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+// Called once per failed/cancelled campaign in settle-deadlines. Flips every
+// pending referral_attribution for the campaign to voided. The where-clause
+// filter on status='pending' is critical: an attribution that has already
+// been earned (would be unusual on a failed lot, but defensively supported)
+// must not be clawed back. No credit_ledger writes here — voiding never
+// touches money. Earned credits are not reversed even if the lot somehow
+// later got marked failed (criterion 8 failure case).
+export async function voidAttributionsForCampaign(
+  admin: SupabaseClient,
+  campaignId: string
+): Promise<{ voided: number }> {
+  if (!campaignId) return { voided: 0 };
+
+  const { data, error } = await admin
+    .from("referral_attributions")
+    .update({ status: "voided" })
+    .eq("campaign_id", campaignId)
+    .eq("status", "pending")
+    .select("id");
+
+  if (error) return { voided: 0 };
+  return { voided: (data ?? []).length };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "embla-carousel-react": "8.5.1",
         "input-otp": "1.4.1",
         "lucide-react": "^0.544.0",
+        "nanoid": "^5.1.11",
         "next": "16.1.6",
         "next-themes": "^0.4.6",
         "react": "^19",
@@ -6797,9 +6798,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.11.tgz",
+      "integrity": "sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==",
       "funding": [
         {
           "type": "github",
@@ -6808,10 +6809,10 @@
       ],
       "license": "MIT",
       "bin": {
-        "nanoid": "bin/nanoid.cjs"
+        "nanoid": "bin/nanoid.js"
       },
       "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+        "node": "^18 || >=20"
       }
     },
     "node_modules/next": {
@@ -6875,6 +6876,24 @@
       "peerDependencies": {
         "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
         "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/next/node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/next/node_modules/postcss": {
@@ -7207,6 +7226,24 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
+    },
+    "node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/prettier": {
       "version": "3.8.3",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "embla-carousel-react": "8.5.1",
     "input-otp": "1.4.1",
     "lucide-react": "^0.544.0",
+    "nanoid": "^5.1.11",
     "next": "16.1.6",
     "next-themes": "^0.4.6",
     "react": "^19",

--- a/scripts/seed-test-env.ts
+++ b/scripts/seed-test-env.ts
@@ -585,21 +585,28 @@ async function ensureHubMember(
   userId: string,
   invitedByUserId: string | null,
 ): Promise<void> {
-  const { error } = await supabase
+  // hub_members has partial unique indexes only:
+  //   - (user_id) WHERE status='active'      — one active hub per buyer
+  //   - (hub_id, user_id) WHERE user_id IS NOT NULL
+  // Supabase .upsert needs a non-partial constraint to target, so do an
+  // explicit existence check then insert. Idempotent on re-run.
+  const { data: existing } = await supabase
     .from("hub_members")
-    .upsert(
-      {
-        hub_id: hubId,
-        user_id: userId,
-        status: "active",
-        role: "buyer",
-        joined_at: new Date().toISOString(),
-        invited_by_user_id: invitedByUserId,
-      },
-      { onConflict: "user_id", ignoreDuplicates: false }
-    );
-  // Ignore unique-violation conflicts on the (user_id) WHERE status='active'
-  // partial index — if the buyer is already in this hub, that's fine.
+    .select("id, hub_id, status")
+    .eq("user_id", userId)
+    .eq("status", "active")
+    .maybeSingle();
+
+  if (existing) return; // user is already active somewhere — leave it alone
+
+  const { error } = await supabase.from("hub_members").insert({
+    hub_id: hubId,
+    user_id: userId,
+    status: "active",
+    role: "buyer",
+    joined_at: new Date().toISOString(),
+    invited_by_user_id: invitedByUserId,
+  });
   if (error && error.code !== "23505") throw error;
 }
 

--- a/scripts/seed-test-env.ts
+++ b/scripts/seed-test-env.ts
@@ -537,6 +537,198 @@ async function createRefundedMinNotMetCommitment(
   return data.id;
 }
 
+// ---- buyer-referral fixture -----------------------------------------------
+// Sets up a settle-eligible flow where buyer-1 invited buyer-2:
+//
+//   - invite_codes row for buyer-1 (code: 'seedinvite')
+//   - buyer-1 + buyer-2 are active members of the hub
+//   - buyer-2's profile is attributed to buyer-1 (mirrors the trigger)
+//   - a fresh lot + active campaign past-deadline + committed quantity
+//     above minimum, with buyer-2's commitment in 'charge_succeeded'
+//   - a referral_attributions(pending) row linking buyer-1 → buyer-2 via
+//     this commitment
+//
+// Running settle-deadlines against this state should: settle the campaign,
+// flip the attribution to 'earned', and insert a +$10 credit_ledger row
+// for buyer-1. Used for manual QA in Stage 4.
+
+const REFERRAL_INVITE_CODE = "seedinvite";
+
+const REFERRAL_LOT = {
+  title: "Yirgacheffe G1 — Referral Settle Test",
+  origin_country: "Ethiopia",
+  region: "Yirgacheffe",
+  farm: "Konga Cooperative",
+  variety: "Heirloom",
+  process: "Washed",
+  altitude_min: 1900,
+  altitude_max: 2100,
+  crop_year: "2025/26",
+  score: 87.5,
+  description:
+    "Test fixture: buyer-2 was invited by buyer-1, charge succeeded, campaign meets minimum. Run settle-deadlines to earn buyer-1 their $10 credit.",
+  total_quantity_kg: 100,
+  min_commitment_kg: 25,
+  price_per_kg: 22.0,
+  currency: "USD",
+  status: "active",
+  flavor_notes: ["jasmine", "lemon"],
+  certifications: [],
+};
+
+const REFERRAL_QUANTITY_KG = 30;
+const REFERRAL_PRICE_PER_KG = 22.0;
+
+async function ensureHubMember(
+  supabase: SupabaseClient,
+  hubId: string,
+  userId: string,
+  invitedByUserId: string | null,
+): Promise<void> {
+  const { error } = await supabase
+    .from("hub_members")
+    .upsert(
+      {
+        hub_id: hubId,
+        user_id: userId,
+        status: "active",
+        role: "buyer",
+        joined_at: new Date().toISOString(),
+        invited_by_user_id: invitedByUserId,
+      },
+      { onConflict: "user_id", ignoreDuplicates: false }
+    );
+  // Ignore unique-violation conflicts on the (user_id) WHERE status='active'
+  // partial index — if the buyer is already in this hub, that's fine.
+  if (error && error.code !== "23505") throw error;
+}
+
+async function createReferralInviteCode(
+  supabase: SupabaseClient,
+  inviterUserId: string,
+  hubId: string,
+): Promise<void> {
+  const { error } = await supabase.from("invite_codes").insert({
+    code: REFERRAL_INVITE_CODE,
+    inviter_user_id: inviterUserId,
+    hub_id: hubId,
+  });
+  if (error && error.code !== "23505") throw error;
+}
+
+async function attributeBuyerToInviter(
+  supabase: SupabaseClient,
+  inviteeId: string,
+  inviterId: string,
+): Promise<void> {
+  // The lock-once trigger blocks updates if invited_by_user_id is already
+  // set to a different value, so this is safe-to-rerun only when the
+  // existing value is null or already equals inviterId.
+  const { error } = await supabase
+    .from("profiles")
+    .update({
+      invited_by_user_id: inviterId,
+      invite_code_used: REFERRAL_INVITE_CODE,
+    })
+    .eq("id", inviteeId)
+    .is("invited_by_user_id", null);
+  if (error) throw error;
+}
+
+async function createReferralLot(
+  supabase: SupabaseClient,
+  sellerId: string,
+  hubId: string,
+): Promise<string> {
+  const past = new Date();
+  past.setDate(past.getDate() - PAST_DAYS - 2);
+  const { data, error } = await supabase
+    .from("lots")
+    .insert({
+      seller_id: sellerId,
+      hub_id: hubId,
+      ...REFERRAL_LOT,
+      committed_quantity_kg: REFERRAL_QUANTITY_KG,
+      commitment_deadline: past.toISOString(),
+    })
+    .select("id")
+    .single();
+  if (error) throw error;
+  return data.id;
+}
+
+async function createReferralCampaign(
+  supabase: SupabaseClient,
+  lotId: string,
+  hubId: string,
+): Promise<string> {
+  const past = new Date();
+  past.setDate(past.getDate() - PAST_DAYS - 2);
+  const { data, error } = await supabase
+    .from("campaigns")
+    .insert({
+      lot_id: lotId,
+      hub_id: hubId,
+      deadline: past.toISOString(),
+      status: "active",
+    })
+    .select("id")
+    .single();
+  if (error) throw error;
+  return data.id;
+}
+
+async function createReferralPaidCommitment(
+  supabase: SupabaseClient,
+  lotId: string,
+  buyerId: string,
+  hubId: string,
+  campaignId: string,
+): Promise<string> {
+  const total_price = REFERRAL_QUANTITY_KG * REFERRAL_PRICE_PER_KG;
+  const chargedAt = new Date();
+  chargedAt.setDate(chargedAt.getDate() - PAST_DAYS - 1);
+  const { data, error } = await supabase
+    .from("commitments")
+    .insert({
+      lot_id: lotId,
+      buyer_id: buyerId,
+      hub_id: hubId,
+      campaign_id: campaignId,
+      quantity_kg: REFERRAL_QUANTITY_KG,
+      price_per_kg: REFERRAL_PRICE_PER_KG,
+      total_price,
+      status: "confirmed",
+      payment_status: "charge_succeeded",
+      charge_amount_cents: Math.round(total_price * 100),
+      charge_currency: "USD",
+      charged_at: chargedAt.toISOString(),
+      stripe_payment_intent_id: `pi_seed_referral_${Date.now()}`,
+      stripe_charge_id: `ch_seed_referral_${Date.now()}`,
+    })
+    .select("id")
+    .single();
+  if (error) throw error;
+  return data.id;
+}
+
+async function createPendingReferralAttribution(
+  supabase: SupabaseClient,
+  inviterId: string,
+  inviteeId: string,
+  commitmentId: string,
+  campaignId: string,
+): Promise<void> {
+  const { error } = await supabase.from("referral_attributions").insert({
+    inviter_user_id: inviterId,
+    invitee_user_id: inviteeId,
+    commitment_id: commitmentId,
+    campaign_id: campaignId,
+    status: "pending",
+  });
+  if (error && error.code !== "23505") throw error;
+}
+
 // ---- main -------------------------------------------------------------
 
 async function main() {
@@ -639,6 +831,45 @@ async function main() {
     console.log(
       `✓ Refunded commitment for buyer-1 on failed campaign: ${refundedCommitmentId}`,
     );
+
+    // ---- buyer-referral fixture: buyer-1 invited buyer-2 ----
+    if (buyerIds.length >= 2) {
+      await ensureHubMember(supabase, hubId, buyerIds[0], null);
+      await ensureHubMember(supabase, hubId, buyerIds[1], buyerIds[0]);
+      console.log("✓ buyer-1 and buyer-2 active in hub for referral fixture");
+
+      await createReferralInviteCode(supabase, buyerIds[0], hubId);
+      console.log(`✓ Invite code created: ${REFERRAL_INVITE_CODE}`);
+
+      await attributeBuyerToInviter(supabase, buyerIds[1], buyerIds[0]);
+      console.log("✓ buyer-2 attributed to buyer-1");
+
+      const referralLotId = await createReferralLot(supabase, sellerId, hubId);
+      console.log(`✓ Referral settle-success lot: ${referralLotId}`);
+
+      const referralCampaignId = await createReferralCampaign(supabase, referralLotId, hubId);
+      console.log(`✓ Referral campaign (past deadline, meets min): ${referralCampaignId}`);
+
+      const referralCommitmentId = await createReferralPaidCommitment(
+        supabase,
+        referralLotId,
+        buyerIds[1],
+        hubId,
+        referralCampaignId,
+      );
+      console.log(`✓ buyer-2 charge_succeeded commitment: ${referralCommitmentId}`);
+
+      await createPendingReferralAttribution(
+        supabase,
+        buyerIds[0],
+        buyerIds[1],
+        referralCommitmentId,
+        referralCampaignId,
+      );
+      console.log("✓ Pending referral_attribution row inserted (run settle-deadlines to earn it)");
+    } else {
+      console.log("⚠ Skipping buyer-referral fixture (need at least 2 buyers).");
+    }
 
     console.log("\nSeed completed.");
   } catch (err) {

--- a/supabase/migrations/20240101000028_invite_codes.sql
+++ b/supabase/migrations/20240101000028_invite_codes.sql
@@ -1,0 +1,41 @@
+-- Buyer referral invites: one persistent invite code per buyer, snapshotting
+-- the hub the buyer was in at the time the code was generated. The hub_id is
+-- intentionally not updated if the inviter later changes hubs — the link
+-- continues to deliver invitees to the original hub.
+--
+-- See spec: ~/Documents/crowdroast/buyer-referral-invites/spec.md
+
+create table if not exists public.invite_codes (
+  id uuid primary key default gen_random_uuid(),
+  code text not null unique,
+  inviter_user_id uuid not null references public.profiles(id) on delete cascade,
+  hub_id uuid not null references public.hubs(id) on delete cascade,
+  created_at timestamptz not null default now(),
+  revoked_at timestamptz null
+);
+
+-- One active code per inviter so POST /api/invite-codes is idempotent without
+-- a code-uniqueness race. Revoked rows are excluded so a future v2 can replace
+-- a code without dropping history.
+create unique index if not exists idx_invite_codes_inviter_active
+  on public.invite_codes (inviter_user_id)
+  where revoked_at is null;
+
+-- Fast public lookup for the landing page.
+create index if not exists idx_invite_codes_code_active
+  on public.invite_codes (code)
+  where revoked_at is null;
+
+alter table public.invite_codes enable row level security;
+
+create policy invite_codes_select_self on public.invite_codes
+  for select
+  using (inviter_user_id = auth.uid());
+
+create policy invite_codes_insert_self on public.invite_codes
+  for insert
+  with check (inviter_user_id = auth.uid());
+
+-- No update / delete policies. Revocation in v2 will go through service-role.
+-- Public landing-page lookup goes through service-role in the route, so no
+-- public select policy is required.

--- a/supabase/migrations/20240101000029_referral_attributions.sql
+++ b/supabase/migrations/20240101000029_referral_attributions.sql
@@ -1,0 +1,42 @@
+-- Buyer referral invites: one row per invitee on their first charge_succeeded
+-- commitment, recording who referred them and which commitment qualified.
+-- This is a pure attribution-event record — money lives in credit_ledger, not
+-- here. Status flips pending -> earned at lot-settle-success or pending ->
+-- voided at lot-fail.
+--
+-- See spec: ~/Documents/crowdroast/buyer-referral-invites/spec.md
+
+create table if not exists public.referral_attributions (
+  id uuid primary key default gen_random_uuid(),
+  inviter_user_id uuid not null references public.profiles(id) on delete cascade,
+  invitee_user_id uuid not null references public.profiles(id) on delete cascade,
+  commitment_id uuid not null references public.commitments(id) on delete cascade,
+  campaign_id uuid not null references public.campaigns(id) on delete cascade,
+  status text not null default 'pending' check (status in ('pending','earned','voided')),
+  earned_at timestamptz null,
+  created_at timestamptz not null default now(),
+
+  -- Locks first inviter (criterion 13): an invitee can only ever earn a
+  -- credit for one inviter, the first one whose link they used.
+  unique (invitee_user_id),
+
+  -- One attribution per commitment (criterion 7 idempotency).
+  unique (commitment_id)
+);
+
+-- Powers GET /api/referrals/me list view, filtered by status.
+create index if not exists idx_referral_attributions_inviter
+  on public.referral_attributions (inviter_user_id, status);
+
+-- Powers lot-settle / lot-fail batch updates.
+create index if not exists idx_referral_attributions_campaign_status
+  on public.referral_attributions (campaign_id, status);
+
+alter table public.referral_attributions enable row level security;
+
+create policy referral_attributions_select_inviter on public.referral_attributions
+  for select
+  using (inviter_user_id = auth.uid());
+
+-- No insert / update / delete policies. All writes are service-role from the
+-- charge-success handler, the lot-settle cron, and the lot-fail cron.

--- a/supabase/migrations/20240101000030_credit_ledger.sql
+++ b/supabase/migrations/20240101000030_credit_ledger.sql
@@ -1,0 +1,80 @@
+-- Buyer referral invites: append-only ledger of credit movements. A user's
+-- balance is SUM(amount_cents) for that user. The ledger replaces the older
+-- FIFO/whole-bonus design — credits are fungible dollars.
+--
+-- Reasons:
+--   referral_earned  positive, source_attribution_id set
+--   commit_applied   negative, source_commitment_id set
+--   admin_adjust     non-zero, granted_by_admin_id set, free-text note
+--
+-- Idempotency is enforced by partial unique indexes on the source_* columns
+-- so cron retries never double-credit or double-debit.
+--
+-- See spec: ~/Documents/crowdroast/buyer-referral-invites/spec.md
+
+create table if not exists public.credit_ledger (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references public.profiles(id) on delete cascade,
+  amount_cents integer not null check (amount_cents <> 0),
+  reason text not null check (reason in ('referral_earned','commit_applied','admin_adjust')),
+  source_attribution_id uuid null references public.referral_attributions(id) on delete restrict,
+  source_commitment_id uuid null references public.commitments(id) on delete restrict,
+  granted_by_admin_id uuid null references public.profiles(id) on delete restrict,
+  note text null,
+  created_at timestamptz not null default now(),
+
+  -- Per-reason invariants. A row's shape must match its reason exactly.
+  constraint credit_ledger_shape_check check (
+    (reason = 'referral_earned'
+      and source_attribution_id is not null
+      and source_commitment_id is null
+      and granted_by_admin_id is null
+      and amount_cents > 0)
+    or (reason = 'commit_applied'
+      and source_commitment_id is not null
+      and source_attribution_id is null
+      and granted_by_admin_id is null
+      and amount_cents < 0)
+    or (reason = 'admin_adjust'
+      and granted_by_admin_id is not null
+      and source_attribution_id is null
+      and source_commitment_id is null)
+  )
+);
+
+-- Idempotency: cron retries on the lot-settle-success path must not double
+-- credit. Exactly one referral_earned row per attribution.
+create unique index if not exists idx_credit_ledger_referral_earned_unique
+  on public.credit_ledger (source_attribution_id)
+  where reason = 'referral_earned' and source_attribution_id is not null;
+
+-- Idempotency: settlement retries on the inviter-settle path must not double
+-- debit. Exactly one commit_applied row per commitment.
+create unique index if not exists idx_credit_ledger_commit_applied_unique
+  on public.credit_ledger (source_commitment_id)
+  where reason = 'commit_applied' and source_commitment_id is not null;
+
+-- Powers balance reads and ledger-history disclosure.
+create index if not exists idx_credit_ledger_user
+  on public.credit_ledger (user_id, created_at desc);
+
+create or replace function public.credit_balance_cents(p_user_id uuid)
+returns integer
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select coalesce(sum(amount_cents), 0)::integer
+  from public.credit_ledger
+  where user_id = p_user_id;
+$$;
+
+alter table public.credit_ledger enable row level security;
+
+create policy credit_ledger_select_self on public.credit_ledger
+  for select
+  using (user_id = auth.uid());
+
+-- No insert / update / delete policies. All writes are service-role from
+-- settle-deadlines, post-charge handlers, and the admin grant route.

--- a/supabase/migrations/20240101000031_referral_attribution_columns.sql
+++ b/supabase/migrations/20240101000031_referral_attribution_columns.sql
@@ -1,0 +1,46 @@
+-- Buyer referral invites: attribution columns on profiles and hub_members,
+-- plus a lock-once trigger that enforces "first inviter is locked" at the
+-- column level (criterion 13). Also adds referral_signup_email_sent_at as a
+-- one-shot idempotency stamp for the dashboard-driven signup notification
+-- (see plan open question 1).
+--
+-- See spec: ~/Documents/crowdroast/buyer-referral-invites/spec.md
+
+alter table public.profiles
+  add column if not exists invited_by_user_id uuid null references public.profiles(id) on delete set null;
+
+alter table public.profiles
+  add column if not exists invite_code_used text null;
+
+alter table public.profiles
+  add column if not exists referral_signup_email_sent_at timestamptz null;
+
+alter table public.hub_members
+  add column if not exists invited_by_user_id uuid null references public.profiles(id) on delete set null;
+
+create index if not exists idx_profiles_invited_by
+  on public.profiles (invited_by_user_id)
+  where invited_by_user_id is not null;
+
+-- Lock-once-written guard: criterion 13. Once invited_by_user_id is non-null,
+-- it cannot change — even back to null. Strict by design (see plan open
+-- question 3); any future admin-reset path must bypass via service-role.
+create or replace function public.guard_invited_by_lock()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if old.invited_by_user_id is not null
+     and new.invited_by_user_id is distinct from old.invited_by_user_id then
+    raise exception 'profiles.invited_by_user_id is locked once written';
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists profiles_invited_by_lock on public.profiles;
+create trigger profiles_invited_by_lock
+  before update of invited_by_user_id on public.profiles
+  for each row execute function public.guard_invited_by_lock();

--- a/supabase/migrations/20240101000032_handle_new_user_invite_attribution.sql
+++ b/supabase/migrations/20240101000032_handle_new_user_invite_attribution.sql
@@ -1,0 +1,121 @@
+-- Buyer referral invites: extend handle_new_user to read raw_user_meta_data
+-- .invite_code, look up the referral, write profile attribution columns, and
+-- insert an active hub_members row attributed to the inviter.
+--
+-- The attribution work is wrapped in a sub-block with EXCEPTION so any
+-- failure here does NOT block profile creation — profile + email-invite
+-- claim must succeed even if the referral attribution fails.
+-- (Spec criterion 3 failure case; design note 3.)
+--
+-- Self-referral check is case-insensitive (criterion 12).
+-- profiles.invited_by_user_id is locked-once-written by the trigger added
+-- in migration 31, so the IS NULL guard below is belt-and-suspenders.
+--
+-- See spec: ~/Documents/crowdroast/buyer-referral-invites/spec.md
+
+create or replace function public.handle_new_user()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  -- Existing logic from migration 19: create the profile.
+  insert into public.profiles (id, role, company_name, contact_name, email)
+  values (
+    new.id,
+    coalesce(new.raw_user_meta_data ->> 'role', 'buyer'),
+    coalesce(new.raw_user_meta_data ->> 'company_name', null),
+    coalesce(new.raw_user_meta_data ->> 'contact_name', null),
+    new.email
+  )
+  on conflict (id) do nothing;
+
+  -- Existing logic from migration 19: claim pending email-based hub invites.
+  update public.hub_members
+  set
+    user_id   = new.id,
+    status    = 'active',
+    joined_at = now()
+  where
+    invited_email = new.email
+    and user_id is null
+    and status = 'invited'
+    and hub_id not in (
+      select hub_id
+      from public.hub_members
+      where user_id = new.id
+        and status = 'active'
+    );
+
+  -- New: buyer-referral attribution. Wrapped in its own sub-block so any
+  -- failure (invalid invite, FK violation, anything) does not bubble up
+  -- and block profile creation above.
+  declare
+    v_invite_code text;
+    v_invite_id uuid;
+    v_invite_inviter_user_id uuid;
+    v_invite_hub_id uuid;
+    v_invite_revoked_at timestamptz;
+    v_inviter_email text;
+    v_is_self_referral boolean;
+  begin
+    v_invite_code := nullif(new.raw_user_meta_data ->> 'invite_code', '');
+
+    if v_invite_code is not null then
+      select id, inviter_user_id, hub_id, revoked_at
+        into v_invite_id, v_invite_inviter_user_id, v_invite_hub_id, v_invite_revoked_at
+        from public.invite_codes
+        where code = v_invite_code
+        limit 1;
+
+      if v_invite_id is not null and v_invite_revoked_at is null then
+        select email into v_inviter_email
+          from public.profiles
+          where id = v_invite_inviter_user_id;
+
+        v_is_self_referral := lower(coalesce(v_inviter_email, '')) = lower(coalesce(new.email, ''));
+
+        -- Always insert an active hub_members row (criteria 3 + 12). On a
+        -- self-referral, omit the invited_by_user_id attribution but still
+        -- onboard the user — they joined CrowdRoast either way.
+        -- The hub_members uniqueness constraint relevant here is the partial
+        -- index idx_hub_members_unique_user on (hub_id, user_id) where
+        -- user_id is not null. The one-hub-per-buyer index
+        -- idx_hub_members_one_active_per_buyer on user_id where status =
+        -- 'active' is also relevant but ON CONFLICT can only target one
+        -- arbiter, so we take that one — if the user is already active in
+        -- a different hub (via step-2 email-invite claim), the insert
+        -- raises and the surrounding EXCEPTION block swallows it.
+        insert into public.hub_members (hub_id, user_id, status, role, joined_at, invited_by_user_id)
+        values (
+          v_invite_hub_id,
+          new.id,
+          'active',
+          'buyer',
+          now(),
+          case when v_is_self_referral then null
+               else v_invite_inviter_user_id end
+        )
+        on conflict (user_id) where status = 'active' do nothing;
+
+        -- Only stamp profile attribution columns when NOT a self-referral.
+        -- The where invited_by_user_id is null clause is belt-and-suspenders
+        -- alongside the lock-once trigger from migration 31.
+        if not v_is_self_referral then
+          update public.profiles
+            set invited_by_user_id = v_invite_inviter_user_id,
+                invite_code_used = v_invite_code
+            where id = new.id
+              and invited_by_user_id is null;
+        end if;
+      end if;
+    end if;
+  exception
+    when others then
+      raise warning 'handle_new_user invite-attribution failed: %', sqlerrm;
+  end;
+
+  return new;
+end;
+$$;


### PR DESCRIPTION
Closes #62.

## Summary

Buyers generate a personal invite link from `/dashboard/buyer`. Friends who sign up via the link auto-join the inviter's hub as "vouched" members (no hub-owner approval). When an invitee's first commitment settles successfully, the inviter earns **$10 in CrowdRoast credits**. Credits accumulate as a balance and auto-apply as a discount on the inviter's future commit settlements (capped at Mernin's share, partial OK).

**Spec:** `~/Documents/crowdroast/buyer-referral-invites/spec.md`
**Plan:** `~/Documents/crowdroast/buyer-referral-invites/plan.md`
**Design:** `~/Documents/crowdroast/buyer-referral-invites/design.md`

## What changed

**Schema (5 migrations):**
- `invite_codes` table — one persistent code per buyer, snapshots their hub at creation.
- `referral_attributions` table — pure attribution-event record, locked-once per invitee.
- `credit_ledger` table — append-only ledger with two partial unique indexes for cron-retry idempotency, plus a `credit_balance_cents()` SQL function.
- Profile / hub_members attribution columns + a lock-once trigger on `profiles.invited_by_user_id`.
- `handle_new_user` trigger extension — savepoint-wrapped buyer-referral attribution that won't block profile creation if it fails.

**Backend (6 routes + 4 settle hooks):**
- `POST /api/invite-codes` — get-or-create the caller's code (idempotent).
- `GET /api/invite-codes/[code]` — public landing-page lookup.
- `POST /api/invite-codes/[code]/accept` — logged-in user joins the snapshotted hub; branches per spec criteria 4 & 5.
- `GET /api/referrals/me` — inviter's attribution list.
- `GET /api/credits/me` — caller's balance + ledger history.
- `POST /api/admin/credits/grant` — admin-only `admin_adjust` ledger writes.
- `POST /api/referrals/signup-notify` — fires the ReferralSignup email, idempotent via a profile timestamp stamp (PG triggers can't emit email; this is the v1 mechanism).

Settle-deadlines now: inserts attribution at first `charge_succeeded`, flips pending → earned + emits +$10 ledger row at lot-settle-success, voids pending attributions on lot-fail, and applies inviter credits via `min(balance, mernin_share)` debit at inviter-settle. All four hooks are idempotent across cron retries.

**Frontend:**
- Bold-mode landing page `/i/[code]` with sticker hero and four auth-state branches.
- Three subdued dashboard cards: `<InviteShareCard>`, `<MyReferralsList>`, `<CreditBalanceCard>`.
- Hub-members "Invited by [name]" badge.
- Admin grant tool at `/dashboard/admin/credits`.
- Sign-up page threads `?invite=` through `raw_user_meta_data`.

**Email:** `ReferralSignup` (sent from dashboard layout when an attributed user first lands) and `ReferralCreditEarned` (background task in settle-deadlines success branch).

## Tests

**275/275 passing.** ~140 new tests across:
- Route handlers — auth, RLS scope, idempotency, all branch outcomes (28 tests across 6 routes).
- Backend helpers — insert / settle / void / apply with idempotency checks (25+ tests).
- React components — rendering, fetch interactions, copy-to-clipboard, error states (16 tests).
- Email templates — render assertions for required content (4 tests).
- Helper utilities — invite-code generation entropy + alphabet (5 tests).

## Deferred to a follow-up ticket

The repo has zero existing real-DB integration tests; trigger / RLS / constraint coverage would need a vitest helper that connects to local Supabase and handles per-test isolation. Three plan tasks that needed that infrastructure were deferred:

- **S1.T6** — trigger / constraint vitest tests (verified end-to-end via psql smoketests during Stage 1 — criteria 3, 12, 13 + lock-once + ledger shape constraints + balance function all confirmed against real Supabase).
- **S2.T12** — backend integration test (per-helper unit tests cover the per-step behavior; cross-helper composition is what manual QA catches cheaper).
- **S4.T2** — end-to-end test with the seed fixture (the seed fixture itself landed in S4.T1; manual QA below walks the same flow against real data).

## Manual QA checklist

Pre-reqs: local Supabase running, dev server running, Stripe test card available.

```bash
supabase db reset
npm run dev:up   # or your seed entrypoint
```

- [ ] Inviter pre-settle: `<InviteShareCard>` shows URL with `seedinvite`, `<CreditBalanceCard>` shows $0.00, `<MyReferralsList>` shows buyer-2 as "Brewing".
- [ ] Bold landing page at `/i/seedinvite` (incognito): sticker hero, sun-yellow inviter pill, pickup notice, signup CTA → `/auth/sign-up?invite=seedinvite`.
- [ ] Run cron: `curl -X POST -H "x-cron-secret: $CRON_SECRET" http://localhost:3000/api/payments/settle-deadlines`.
- [ ] Inviter post-settle: balance shows $10.00, history reveals `+$10.00` "Earned: friend joined and committed", `<MyReferralsList>` row flips to "Earned".
- [ ] Spend the credit: place a small commit as buyer-1, settle, balance drops by `min($10, Mernin's share)`, history adds `-$X.XX` "Applied to a recent commitment".
- [ ] Hub-members badge: as hub owner, `/dashboard/hub/members` shows "Invited by buyer-1" on buyer-2's row only.
- [ ] Different-hub block: as a buyer in another hub, `/i/seedinvite` shows "switching hubs isn't supported yet" — no DB writes.
- [ ] Self-invite block: as buyer-1, `/i/seedinvite` shows the blocking copy.
- [ ] Admin grant: `/dashboard/admin/credits`, grant $5 to buyer-1 with note, confirm balance updates.

## Notable design notes

- **Flat $10 credit, not 2% of gross.** Pivoted mid-spec: predictable CAC, simpler messaging, fairness across whale and small invitees.
- **Credit ledger, not FIFO over attributions.** Replaced the original whole-bonus / FIFO / rollover machinery with a single append-only ledger. Settlement applies `min(balance, mernin_share)` — no FIFO, partial OK, rollover is implicit. The cap-at-Mernin's-share invariant is a single `Math.max(0, x)`.
- **Cancelled-first-commit fix.** Attribution row is created at first `charge_succeeded`, not at commitment row insert. A commitment cancelled before charge does not lock the attribution; the invitee's next charged commitment carries it.
- **Inviter dashboard intentionally quiet between signup and first charge.** Attribution rows are gated on `charge_succeeded`, so `<MyReferralsList>` and `<CreditBalanceCard>` only fill in once the invitee actually pays. The signup signal lives in the inviter's email inbox and the hub-members badge.