### PR TITLE
fix(referrals): create attribution row at settle as a safety net

### DIFF
--- a/app/api/payments/settle-deadlines/route.ts
+++ b/app/api/payments/settle-deadlines/route.ts
@@ -380,7 +380,7 @@ async function settleDeadlines(request: Request) {
     const { data: lot, error: lotFetchError } = await admin
       .from("lots")
       .select(
-        "id, seller_id, status, currency, price_per_kg, committed_quantity_kg, min_commitment_kg, commitment_deadline"
+        "id, title, seller_id, status, currency, price_per_kg, committed_quantity_kg, min_commitment_kg, commitment_deadline"
       )
       .eq("id", campaign.lot_id)
       .single();
@@ -633,7 +633,7 @@ async function settleDeadlines(request: Request) {
     const { data: commitments, error: commitmentsError } = await admin
       .from("commitments")
       .select(
-        "id, status, payment_status, hub_id, quantity_kg, total_price, charge_amount_cents, charge_currency, stripe_charge_id, stripe_payment_intent_id"
+        "id, buyer_id, status, payment_status, hub_id, quantity_kg, total_price, charge_amount_cents, charge_currency, stripe_charge_id, stripe_payment_intent_id"
       )
       .eq("campaign_id", campaign.id)
       .not("stripe_payment_intent_id", "is", null)
@@ -977,7 +977,17 @@ async function settleDeadlines(request: Request) {
         // When the helper signals a fresh ledger insert (earned=true), fire
         // ReferralCreditEarned to the inviter as a background task so a
         // delivery hiccup never fails the cron loop.
+        //
+        // Safety net: also try to insert the attribution row here. The
+        // webhook is the primary creator (at first charge_succeeded), but a
+        // missed/delayed/failed webhook would leave the invitee permanently
+        // un-attributed and the inviter would never earn the credit. Calling
+        // the helper here is idempotent — no-op when an attribution already
+        // exists — and guarantees that any commitment reaching settlement in
+        // charge_succeeded with profiles.invited_by_user_id set gets a row
+        // before settleAttributionIfPending runs.
         if (!debug) {
+          await insertReferralAttributionIfEligible(admin, commitment.id);
           const settleResult = await settleAttributionIfPending(admin, commitment.id);
           if (settleResult.earned && settleResult.inviterUserId) {
             const inviterUserId = settleResult.inviterUserId;


### PR DESCRIPTION
A successful end-to-end referral on the live site (inviter and invitee
both committed, lot settled cleanly) produced no $10 credit. The data
showed profile.invited_by_user_id correctly stamped on the invitee, the
commitment in charge_succeeded with stripe_charge_id populated, and the
campaign in 'settled' — but no referral_attributions row, and therefore
no credit_ledger row, ever existed.

Root cause: the attribution row is created exclusively at first
charge_succeeded by the Stripe webhook. If that webhook call to
insertReferralAttributionIfEligible silently fails or is dropped (deploy
race during the merge to main, transient DB error, network blip), the
invitee is permanently un-attributed. Settlement only flips a *pending*
row to earned via settleAttributionIfPending; with no row to flip, the
inviter never gets credit and there is no later recovery path. The
existing self-correcting call at the missed-charge branch (~line 753)
only fires when stripe_charge_id is null, which it isn't once the
webhook updates the commitment.

Fix: call insertReferralAttributionIfEligible immediately before
settleAttributionIfPending in the success branch. The helper is
idempotent — both unique(invitee_user_id) and unique(commitment_id)
make a webhook+settle double-fire converge on a single row, and the
existing checks gate the insert on payment_status='charge_succeeded'
and a non-null invited_by_user_id. Any commitment that reaches
settlement in good standing now gets a row before the flip-to-earned
runs.

Also includes two adjacent fixes:
- Add buyer_id to the commitments SELECT. It was missing, so
  applyInviterCreditOnSettle was passed buyerId=undefined and silently
  skipped (the buyer's credit balance never gets applied against
  Mernin's share), and the ReferralCreditEarned email's invitee-name
  lookup was hitting .eq("id", undefined).
- Add title to the lot SELECT. The email payload was reading
  lot?.title which TypeScript flagged as a missing field — lotTitle
  would always have been null in the inviter's email body.

Backfilled the live referral_attributions + credit_ledger rows for the
already-settled lot so the inviter sees the $10 they earned. Future
referrals are covered by the safety net; the partial unique index on
credit_ledger source_attribution_id keeps the cron retry-safe.

https://claude.ai/code/session_01EU6AnhxRLCQEoqVSYmhYRT