### PR TITLE
feat(referrals): refund inviter credit to buyer at settle + drawer line

### DIFF
--- a/app/api/payments/settle-deadlines/route.ts
+++ b/app/api/payments/settle-deadlines/route.ts
@@ -796,7 +796,10 @@ async function settleDeadlines(request: Request) {
           id?: string;
           amount?: number;
           payment_intent?: string | null;
-          metadata?: { commitment_id?: string };
+          metadata?: {
+            commitment_id?: string;
+            kind?: "price_adjustment" | "inviter_credit";
+          };
         }> = [];
         if (commitment.stripe_payment_intent_id) {
           try {
@@ -821,6 +824,7 @@ async function settleDeadlines(request: Request) {
             amountCents: refundAmountCents,
             commitmentId: commitment.id,
             idempotencySuffix: "price-adjustment",
+            kind: "price_adjustment",
           });
         }
 
@@ -958,6 +962,38 @@ async function settleDeadlines(request: Request) {
             commitmentId: commitment.id,
             role: "crowdroast",
           });
+        }
+
+        // Buyer-referral: refund the applied credit amount back to the buyer's
+        // original payment method. The platform transfer above is already net
+        // of `applied`, so CrowdRoast's operating account receives less by
+        // exactly that much; refunding the same amount to the buyer leaves
+        // seller and hub whole, gives the buyer the dollar value of the
+        // credit they earned, and books the cost cleanly to the platform.
+        //
+        // Idempotency: filter existingRefunds by metadata.kind === 'inviter_credit'
+        // so cron retries past Stripe's ~24h idempotency window don't double-
+        // refund. Only issue what's still missing relative to the applied
+        // total. Subtle: existingRefunds was loaded before this commitment's
+        // price-adjustment refund (if any), but that refund is tagged
+        // 'price_adjustment' so the kind filter excludes it correctly.
+        if (creditApplication.applied > 0 && commitment.stripe_payment_intent_id) {
+          const existingInviterCreditRefundAmount = existingRefunds
+            .filter((r) => r.metadata?.kind === "inviter_credit")
+            .reduce((sum, r) => sum + Number(r.amount || 0), 0);
+          const missingInviterCreditRefund = Math.max(
+            0,
+            creditApplication.applied - existingInviterCreditRefundAmount
+          );
+          if (missingInviterCreditRefund > 0) {
+            await createRefund({
+              paymentIntentId: commitment.stripe_payment_intent_id,
+              amountCents: missingInviterCreditRefund,
+              commitmentId: commitment.id,
+              idempotencySuffix: "inviter-credit",
+              kind: "inviter_credit",
+            });
+          }
         }
 
         await admin

--- a/app/dashboard/buyer/commitments/page.tsx
+++ b/app/dashboard/buyer/commitments/page.tsx
@@ -183,6 +183,26 @@ export default async function BuyerCommitmentsPage({
     }
   }
 
+  // commit_applied ledger rows tell the closed drawer how much inviter
+  // credit was redeemed against each commitment. RLS restricts the read to
+  // the caller's own user_id, so this is safe on the user-bound supabase
+  // client. amount_cents is stored negative; we surface positive cents to
+  // the UI to match the rest of the breakdown.
+  const creditAppliedByCommitmentId: Record<string, number> = {};
+  const { data: creditApplied } = await supabase
+    .from("credit_ledger")
+    .select("amount_cents, source_commitment_id")
+    .eq("reason", "commit_applied")
+    .not("source_commitment_id", "is", null);
+  for (const row of (creditApplied || []) as Array<{
+    amount_cents: number;
+    source_commitment_id: string;
+  }>) {
+    creditAppliedByCommitmentId[row.source_commitment_id] =
+      (creditAppliedByCommitmentId[row.source_commitment_id] || 0) +
+      Math.abs(Number(row.amount_cents || 0));
+  }
+
   // Group by campaign instance, not by lot — a lot can have multiple campaigns
   // (e.g. one failed, one succeeded). Legacy commitments without a campaign_id
   // fall back to a lot-scoped key so they still render.
@@ -202,6 +222,7 @@ export default async function BuyerCommitmentsPage({
         campaign: c.campaign_id ? (campaignById[c.campaign_id] as any) ?? null : null,
         commitments: [c],
         shipment: shipmentByLotId[c.lot_id] ?? null,
+        creditAppliedByCommitmentId,
       });
     }
   }

--- a/components/buyer-commitments/bucket-by-lifecycle.ts
+++ b/components/buyer-commitments/bucket-by-lifecycle.ts
@@ -46,6 +46,11 @@ export interface CommitmentGroup {
   campaign: Pick<Campaign, "id" | "status" | "deadline" | "settled_at"> | null;
   commitments: Commitment[];
   shipment: Pick<Shipment, "status" | "carrier" | "tracking_number" | "shipped_at" | "delivered_at"> & { hub?: { name: string } | null } | null;
+  // commit_applied credit_ledger amounts in cents (stored as a positive
+  // number for UI). Keyed by commitment_id; absent when no credit applied.
+  // Populated server-side at /dashboard/buyer/commitments and used by the
+  // closed drawer to surface the inviter-credit line.
+  creditAppliedByCommitmentId?: Record<string, number>;
 }
 
 export interface BucketedGroups {

--- a/components/buyer-commitments/commitment-drawer/__tests__/closed-body.test.tsx
+++ b/components/buyer-commitments/commitment-drawer/__tests__/closed-body.test.tsx
@@ -166,6 +166,42 @@ describe("ClosedDrawerBody — value mode", () => {
     );
     expect(screen.queryByTestId("closed-tier-summary")).not.toBeInTheDocument();
   });
+
+  it("renders the inviter-credit redeemed line with refund framing when credits were applied", () => {
+    // 1000 cents on c-1, 0 on c-2. Sum = $10 redeemed.
+    const group = makeGroup({
+      creditAppliedByCommitmentId: { "c-1": 1000 },
+    });
+    render(<ClosedDrawerBody group={group} mode="value" />);
+    const box = screen.getByTestId("closed-inviter-credit");
+    expect(box.textContent).toContain("Inviter credit redeemed");
+    expect(box.textContent).toContain("-$10.00");
+    expect(box.textContent).toContain("Refunded to your card");
+    expect(box.textContent).toMatch(/CrowdRoast covers/);
+  });
+
+  it("hides the inviter-credit line when no credits were applied", () => {
+    const group = makeGroup();
+    render(<ClosedDrawerBody group={group} mode="value" />);
+    expect(screen.queryByTestId("closed-inviter-credit")).not.toBeInTheDocument();
+  });
+
+  it("ignores credit applied to cancelled commitments in the same group", () => {
+    // commit_applied rows are written at settle, but a defensive group might
+    // include a sibling cancelled commitment in the same group (e.g. user
+    // cancelled and re-committed). Only count credits on the succeeded set.
+    const group = makeGroup({
+      commitments: [
+        makeCommit({ id: "c-1" }),
+        makeCommit({ id: "c-cancelled", status: "cancelled", payment_status: "cancelled" }),
+      ],
+      creditAppliedByCommitmentId: { "c-1": 1000, "c-cancelled": 500 },
+    });
+    render(<ClosedDrawerBody group={group} mode="value" />);
+    const box = screen.getByTestId("closed-inviter-credit");
+    expect(box.textContent).toContain("-$10.00");
+    expect(box.textContent).not.toContain("$15.00");
+  });
 });
 
 describe("ClosedDrawerBody — refund mode", () => {

--- a/components/buyer-commitments/commitment-drawer/closed-body.tsx
+++ b/components/buyer-commitments/commitment-drawer/closed-body.tsx
@@ -45,6 +45,17 @@ export function ClosedDrawerBody({
     0
   );
 
+  // Sum inviter credit applied across all commitments in this group. Source
+  // is the credit_ledger commit_applied rows the page already fetched and
+  // attached to the group. Settle-deadlines also issues a Stripe refund on
+  // the buyer's payment method for this exact amount, so the copy frames it
+  // as money returned to their card — not a soft "credit redeemed" only.
+  const creditAppliedDollars = succeeded.reduce(
+    (s, c) =>
+      s + (group.creditAppliedByCommitmentId?.[c.id] ?? 0) / 100,
+    0
+  );
+
   if (mode === "refund") {
     return (
       <div className="flex flex-col gap-5" data-testid="closed-drawer-body">
@@ -156,6 +167,24 @@ export function ClosedDrawerBody({
                 includePlatformFee
               />
             </span>
+          </div>
+        </div>
+      )}
+
+      {creditAppliedDollars > 0 && (
+        <div
+          className="rounded-md border-2 border-sun bg-sun/15 px-4 py-3"
+          data-testid="closed-inviter-credit"
+        >
+          <div className="font-body text-[11px] font-extrabold uppercase tracking-[0.14em] text-espresso">
+            Inviter credit redeemed
+          </div>
+          <div className="mt-1 font-headline text-2xl font-bold text-espresso tabular-nums">
+            -{fmtMoney(creditAppliedDollars)}
+          </div>
+          <div className="mt-1 font-body text-sm text-espresso/70">
+            Refunded to your card. Sellers and your hub still receive the
+            full amount — CrowdRoast covers the credit.
           </div>
         </div>
       )}

--- a/lib/stripe.ts
+++ b/lib/stripe.ts
@@ -122,6 +122,7 @@ export interface StripeRefund {
   payment_intent?: string | null;
   metadata?: {
     commitment_id?: string;
+    kind?: "price_adjustment" | "inviter_credit";
   };
 }
 
@@ -280,14 +281,26 @@ export async function createRefund(params: {
   commitmentId: string;
   reason?: "duplicate" | "fraudulent" | "requested_by_customer";
   idempotencySuffix?: string;
+  // Stamps metadata.kind so settle-time retries can detect prior refunds of
+  // the same kind via listRefundsForPaymentIntent (the Stripe idempotency
+  // key only covers ~24h; this filter is the durable retry guard).
+  kind?: "price_adjustment" | "inviter_credit";
 }) {
   const suffix = params.idempotencySuffix ? `-${params.idempotencySuffix}` : "";
-  return stripeRequest<{ id: string }>("/refunds", {
+  const body: Record<string, string | number | undefined> = {
     payment_intent: params.paymentIntentId,
     amount: params.amountCents,
     reason: params.reason,
     "metadata[commitment_id]": params.commitmentId,
-  }, `refund-${params.commitmentId}${suffix}`);
+  };
+  if (params.kind) {
+    body["metadata[kind]"] = params.kind;
+  }
+  return stripeRequest<{ id: string }>(
+    "/refunds",
+    body,
+    `refund-${params.commitmentId}${suffix}`
+  );
 }
 
 export async function listRefundsForPaymentIntent(paymentIntentId: string) {


### PR DESCRIPTION
## Summary

Closes the loop on inviter-credit redemption so the buyer actually gets the dollar value back, and surfaces the redemption on the settled commitment drawer.

### The bug

`applyInviterCreditOnSettle` was already reducing CrowdRoast's transfer to the operating account by the applied amount, but the matching dollars just sat in Mernin's platform Stripe balance. A buyer with $10 credit who committed $500 was charged $500, got $500 worth of coffee, and saw a `commit_applied` -$10 row in `credit_ledger` for a redemption that never reached their card.

### The fix

**Money flow** (`app/api/payments/settle-deadlines/route.ts`, `lib/stripe.ts`)
- After `applyInviterCreditOnSettle` returns `applied > 0`, settle issues a Stripe refund of `applied` cents on the buyer's payment intent.
- Math closes: seller transfer = full, hub transfer = full, CrowdRoast operating account transfer = `platform - applied`, buyer refund = `applied`. Sum = `finalAmountCents`. CrowdRoast eats the credit cost as intended.
- `createRefund` now stamps `metadata.kind` (`price_adjustment` or `inviter_credit`). Settle filters `existingRefunds` by `kind === "inviter_credit"` so cron retries past Stripe's ~24h idempotency window can detect prior inviter-credit refunds and only issue what's still missing.

**UI** (`components/buyer-commitments/commitment-drawer/closed-body.tsx`, `app/dashboard/buyer/commitments/page.tsx`)
- Settled drawer now shows a sun-colored "Inviter credit redeemed: -$X.XX" panel with explicit "Refunded to your card. Sellers and your hub still receive the full amount — CrowdRoast covers the credit." copy.
- Page server-fetches `credit_ledger` `commit_applied` rows for the caller (RLS-scoped), indexes by `source_commitment_id`, and threads the map through `CommitmentGroup`.

## Test plan

- [x] Unit tests pass — 50 relevant tests including 3 new closed-body cases (shows panel when applied, hides when zero, ignores cancelled siblings).
- [x] TypeScript clean for all touched files.
- [ ] **Manual e2e on staging or live test mode**: invite a buyer, both inviter and invitee commit, lot settles. Verify:
  - [ ] Invitee's payment intent shows a partial refund tagged `metadata.kind=inviter_credit`.
  - [ ] Seller and hub Stripe transfers are unchanged (full amounts).
  - [ ] CrowdRoast operating-account transfer is reduced by the credit.
  - [ ] Drawer's settled view shows "Inviter credit redeemed: -$10.00 — Refunded to your card."
- [ ] **Cron retry safety**: re-run `/api/payments/settle-deadlines` after a settle — no second refund should be issued for the same commitment.

https://claude.ai/code/session_01EU6AnhxRLCQEoqVSYmhYRT

---
_Generated by [Claude Code](https://claude.ai/code/session_01EU6AnhxRLCQEoqVSYmhYRT)_