### PR TITLE
feat(payments): CrowdRoast covers Stripe processing fee out of platform share

### DIFF
--- a/app/api/payments/settle-deadlines/__tests__/orphan-cancellation.test.ts
+++ b/app/api/payments/settle-deadlines/__tests__/orphan-cancellation.test.ts
@@ -114,6 +114,7 @@ vi.mock("@/lib/stripe", () => ({
     capabilities: { transfers: "active" },
   }),
   getPaymentIntent: vi.fn().mockResolvedValue({ latest_charge: null }),
+  getChargeFeeCents: vi.fn().mockResolvedValue(0),
   listRefundsForPaymentIntent: vi.fn().mockResolvedValue({ data: [] }),
   listTransfersForSourceCharge: vi.fn().mockResolvedValue({ data: [] }),
   createTransfer: vi.fn().mockResolvedValue({ id: "tr_x" }),
@@ -125,6 +126,11 @@ vi.mock("@/lib/payments/settlement-logic", () => ({
   computeChargeAdjustment: vi.fn(() => ({ finalAmountCents: 100000, refundAmountCents: 0 })),
   computeSellerNetAmountCents: vi.fn(() => 90000),
   computeSplit: vi.fn(() => ({ sellerAmount: 90000, hubAmount: 2000, platformAmount: 8000 })),
+  applyStripeFeeToPlatformShare: vi.fn((platformAmountCents: number, stripeFeeCents: number) => ({
+    adjustedPlatformAmountCents: Math.max(0, (platformAmountCents || 0) - (stripeFeeCents || 0)),
+    feeAbsorbed: Math.min(platformAmountCents || 0, stripeFeeCents || 0),
+    feeShortfall: Math.max(0, (stripeFeeCents || 0) - (platformAmountCents || 0)),
+  })),
 }));
 
 import { POST } from "@/app/api/payments/settle-deadlines/route";

--- a/app/api/payments/settle-deadlines/__tests__/stripe-fee-coverage.test.ts
+++ b/app/api/payments/settle-deadlines/__tests__/stripe-fee-coverage.test.ts
@@ -1,0 +1,320 @@
+/**
+ * CrowdRoast covers Stripe processing fees out of its own platform share.
+ *
+ * This test verifies that on the success path, the fee fetched from
+ * BalanceTransaction is deducted from the CrowdRoast platform transfer
+ * (so seller and hub receive their full split) and persisted on the
+ * commitment row for accounting.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+type Update = { table: string; payload: Record<string, unknown>; eqId?: unknown };
+const updateCalls: Update[] = [];
+const fromQueue: Array<() => Record<string, unknown>> = [];
+let pendingTable: string | null = null;
+
+function makeChain(response: { data: unknown; error: unknown }) {
+  let pendingPayload: Record<string, unknown> | null = null;
+  let pendingEqId: unknown = undefined;
+  const table = pendingTable!;
+  const chain: Record<string, unknown> = {
+    update: vi.fn((p: Record<string, unknown>) => {
+      pendingPayload = p;
+      return chain;
+    }),
+    insert: vi.fn().mockReturnThis(),
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn((col: string, val: unknown) => {
+      if (col === "id") pendingEqId = val;
+      return chain;
+    }),
+    neq: vi.fn().mockReturnThis(),
+    in: vi.fn().mockReturnThis(),
+    is: vi.fn().mockReturnThis(),
+    lte: vi.fn().mockReturnThis(),
+    not: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    maybeSingle: vi.fn(() => {
+      if (pendingPayload) updateCalls.push({ table, payload: pendingPayload, eqId: pendingEqId });
+      return Promise.resolve(response);
+    }),
+    single: vi.fn(() => {
+      if (pendingPayload) updateCalls.push({ table, payload: pendingPayload, eqId: pendingEqId });
+      return Promise.resolve(response);
+    }),
+    then: (resolve: (v: unknown) => void) => {
+      if (pendingPayload) updateCalls.push({ table, payload: pendingPayload, eqId: pendingEqId });
+      return Promise.resolve(response).then(resolve);
+    },
+  };
+  return chain;
+}
+
+function enqueue(table: string, response: { data: unknown; error: unknown }) {
+  fromQueue.push(() => {
+    pendingTable = table;
+    return makeChain(response);
+  });
+}
+
+const PASSIVE_TABLES = new Set(["referral_attributions", "credit_ledger"]);
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({
+    from: vi.fn((table: string) => {
+      const next = fromQueue.shift();
+      if (!next) {
+        if (PASSIVE_TABLES.has(table)) {
+          pendingTable = table;
+          return makeChain({ data: [], error: null });
+        }
+        throw new Error(`Unexpected from(${table}) — queue empty`);
+      }
+      return next();
+    }),
+    rpc: vi.fn(() => Promise.resolve({ data: null, error: null })),
+  })),
+}));
+
+vi.mock("@/lib/auth/admin", () => ({
+  getConfiguredAdminEmails: () => ["admin@test.local"],
+}));
+
+vi.mock("@/lib/email", () => ({
+  sendLotClosedEmailsBatch: vi.fn().mockResolvedValue({ success: true }),
+  sendLotFailedEmail: vi.fn().mockResolvedValue({ success: true }),
+  sendReferralCreditEarnedEmail: vi.fn().mockResolvedValue({ success: true }),
+}));
+
+vi.mock("@/lib/shipments", () => ({
+  createShipmentForLot: vi.fn().mockResolvedValue({ ok: true }),
+}));
+
+const { createTransferMock, createRefundMock, getChargeFeeCentsMock } = vi.hoisted(() => ({
+  createTransferMock: vi.fn().mockResolvedValue({ id: "tr_x" }),
+  createRefundMock: vi.fn().mockResolvedValue({ id: "re_x" }),
+  getChargeFeeCentsMock: vi.fn(),
+}));
+
+vi.mock("@/lib/stripe", () => ({
+  getConnectedAccount: vi.fn().mockResolvedValue({
+    capabilities: { transfers: "active" },
+  }),
+  getPaymentIntent: vi.fn().mockResolvedValue({
+    latest_charge: "ch_test_123",
+    status: "succeeded",
+  }),
+  getChargeFeeCents: getChargeFeeCentsMock,
+  listRefundsForPaymentIntent: vi.fn().mockResolvedValue({ data: [] }),
+  listTransfersForSourceCharge: vi.fn().mockResolvedValue({ data: [] }),
+  createTransfer: createTransferMock,
+  createRefund: createRefundMock,
+}));
+
+// Deterministic numbers so the test can assert exact transfer cent values.
+// Gross $137.50 → seller $125 (base), hub $2.75 (2%), platform $9.75.
+// Fee $4.28 (~Stripe US: 2.9% + $0.30) → CrowdRoast keeps $9.75 - $4.28 = $5.47.
+vi.mock("@/lib/payments/settlement-logic", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/payments/settlement-logic")>(
+    "@/lib/payments/settlement-logic"
+  );
+  return {
+    ...actual,
+    getFinalPricePerKg: vi.fn(() => 12.5),
+    computeChargeAdjustment: vi.fn(() => ({
+      committedAmountCents: 13750,
+      finalAmountCents: 13750,
+      refundAmountCents: 0,
+    })),
+    computeSellerNetAmountCents: vi.fn(() => 12500),
+    computeSplit: vi.fn(() => ({ sellerAmount: 12500, hubAmount: 275, platformAmount: 975 })),
+    // applyStripeFeeToPlatformShare uses the real implementation from `actual`.
+  };
+});
+
+vi.mock("@/lib/referrals/insert-attribution", () => ({
+  insertReferralAttributionIfEligible: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("@/lib/referrals/settle-attribution", () => ({
+  settleAttributionIfPending: vi.fn().mockResolvedValue({ earned: false, inviterUserId: null }),
+}));
+vi.mock("@/lib/referrals/void-attribution", () => ({
+  voidAttributionsForCampaign: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("@/lib/referrals/apply-credit", () => ({
+  applyInviterCreditOnSettle: vi.fn(async (_admin, args: { platformAmountCents: number }) => ({
+    applied: 0,
+    adjustedPlatformAmountCents: args.platformAmountCents,
+    ledgerRowInserted: false,
+  })),
+}));
+
+import { POST } from "@/app/api/payments/settle-deadlines/route";
+
+const CRON_SECRET = "test-secret";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  updateCalls.length = 0;
+  fromQueue.length = 0;
+  process.env.CRON_SECRET = CRON_SECRET;
+  process.env.SUPABASE_SERVICE_ROLE_KEY = "test";
+  process.env.NEXT_PUBLIC_SUPABASE_URL = "http://localhost:54321";
+});
+
+function makeReq(): Request {
+  return new Request("http://localhost/api/payments/settle-deadlines", {
+    method: "POST",
+    headers: { authorization: `Bearer ${CRON_SECRET}` },
+  });
+}
+
+function enqueueSettlingCampaign() {
+  enqueue("platform_settings", {
+    data: { platform_connect_account_id: "acct_crowdroast" },
+    error: null,
+  });
+  enqueue("profiles", { data: [], error: null }); // payout profiles list
+  enqueue("campaigns", {
+    data: [
+      {
+        id: "camp-1",
+        lot_id: "lot-1",
+        hub_id: "hub-1",
+        deadline: new Date(Date.now() - 60_000).toISOString(),
+        status: "active",
+      },
+    ],
+    error: null,
+  });
+  // 1) orphan query — none
+  enqueue("commitments", { data: [], error: null });
+  // 2) lot fetch — minimum met
+  enqueue("lots", {
+    data: {
+      id: "lot-1",
+      seller_id: "seller-1",
+      status: "active",
+      currency: "usd",
+      price_per_kg: 12.5,
+      committed_quantity_kg: 100,
+      min_commitment_kg: 50,
+      commitment_deadline: new Date(Date.now() - 60_000).toISOString(),
+      settlement_status: "pending",
+      expiry_date: new Date(Date.now() - 60_000).toISOString(),
+    },
+    error: null,
+  });
+  // 3) seller profile
+  enqueue("profiles", {
+    data: { stripe_connect_account_id: "acct_seller" },
+    error: null,
+  });
+  // 4) pricing tiers
+  enqueue("pricing_tiers", { data: [], error: null });
+  // 5) chargeable commitments — one settled buyer
+  enqueue("commitments", {
+    data: [
+      {
+        id: "commit-1",
+        buyer_id: "buyer-1",
+        status: "active",
+        payment_status: "charge_succeeded",
+        hub_id: "hub-1",
+        quantity_kg: 10,
+        total_price: 137.5,
+        charge_amount_cents: 13750,
+        charge_currency: "usd",
+        stripe_charge_id: "ch_test_123",
+        stripe_payment_intent_id: "pi_test_123",
+      },
+    ],
+    error: null,
+  });
+  // 6) hub fetch
+  enqueue("hubs", { data: { owner_id: "hub-owner-1" }, error: null });
+  // 7) hub-owner profile (Connect account for hub)
+  enqueue("profiles", {
+    data: { stripe_connect_account_id: "acct_hub" },
+    error: null,
+  });
+  // 8) commitment update on confirm — observed via updateCalls
+  enqueue("commitments", { data: null, error: null });
+  // 9) success notifications: lot fetch
+  enqueue("lots", {
+    data: { id: "lot-1", title: "Test Lot", seller_id: "seller-1", committed_quantity_kg: 100 },
+    error: null,
+  });
+  enqueue("profiles", { data: { email: "seller@test", contact_name: "Seller" }, error: null });
+  enqueue("commitments", { data: [], error: null });
+  enqueue("hubs", {
+    data: {
+      id: "hub-1",
+      name: "Hub",
+      address: null,
+      city: null,
+      state: null,
+      country: null,
+      owner_id: "hub-owner-1",
+    },
+    error: null,
+  });
+  enqueue("profiles", { data: { email: "owner@test", contact_name: "Owner" }, error: null });
+}
+
+describe("settle-deadlines — Stripe fee coverage", () => {
+  it("deducts the Stripe processing fee from the CrowdRoast platform transfer", async () => {
+    getChargeFeeCentsMock.mockResolvedValueOnce(428); // $4.28 typical US card fee
+    enqueueSettlingCampaign();
+
+    const res = await POST(makeReq());
+    expect(res.status).toBe(200);
+
+    // Three transfers: seller ($125), hub ($2.75), CrowdRoast ($9.75 - $4.28 = $5.47)
+    expect(createTransferMock).toHaveBeenCalledTimes(3);
+
+    const sellerTransfer = createTransferMock.mock.calls.find(
+      ([args]) => args.role === "seller"
+    )?.[0];
+    expect(sellerTransfer).toMatchObject({ amountCents: 12500, role: "seller" });
+
+    const hubTransfer = createTransferMock.mock.calls.find(([args]) => args.role === "hub")?.[0];
+    expect(hubTransfer).toMatchObject({ amountCents: 275, role: "hub" });
+
+    const platformTransfer = createTransferMock.mock.calls.find(
+      ([args]) => args.role === "crowdroast"
+    )?.[0];
+    expect(platformTransfer).toMatchObject({ amountCents: 547, role: "crowdroast" });
+
+    // Confirm update persists the actual fee for accounting.
+    const confirmUpdate = updateCalls.find(
+      (c) => c.table === "commitments" && c.eqId === "commit-1"
+    );
+    expect(confirmUpdate?.payload).toMatchObject({
+      status: "confirmed",
+      stripe_fee_cents: 428,
+    });
+  });
+
+  it("falls back to a 0 fee deduction when BalanceTransaction lookup fails", async () => {
+    getChargeFeeCentsMock.mockRejectedValueOnce(new Error("balance_transaction not ready"));
+    enqueueSettlingCampaign();
+
+    const res = await POST(makeReq());
+    expect(res.status).toBe(200);
+
+    // Without a known fee, CrowdRoast transfers the full unadjusted platform share.
+    // The next cron pass that learns the real fee will book the deduction.
+    const platformTransfer = createTransferMock.mock.calls.find(
+      ([args]) => args.role === "crowdroast"
+    )?.[0];
+    expect(platformTransfer).toMatchObject({ amountCents: 975, role: "crowdroast" });
+
+    const confirmUpdate = updateCalls.find(
+      (c) => c.table === "commitments" && c.eqId === "commit-1"
+    );
+    // Persisted as null (unknown) rather than 0, so reporting can flag it.
+    expect(confirmUpdate?.payload).toMatchObject({ stripe_fee_cents: null });
+  });
+});

--- a/app/api/payments/settle-deadlines/route.ts
+++ b/app/api/payments/settle-deadlines/route.ts
@@ -11,12 +11,14 @@ import { createShipmentForLot } from "@/lib/shipments";
 import {
   createRefund,
   createTransfer,
+  getChargeFeeCents,
   getConnectedAccount,
   getPaymentIntent,
   listRefundsForPaymentIntent,
   listTransfersForSourceCharge,
 } from "@/lib/stripe";
 import {
+  applyStripeFeeToPlatformShare,
   computeChargeAdjustment,
   computeSellerNetAmountCents,
   computeSplit,
@@ -400,7 +402,7 @@ async function settleDeadlines(request: Request) {
     if (!minimumMet) {
       const { data: lotCommitments, error: lotCommitmentsError } = await admin
         .from("commitments")
-        .select("id, payment_status, stripe_payment_intent_id")
+        .select("id, payment_status, stripe_payment_intent_id, stripe_charge_id")
         .eq("campaign_id", campaign.id);
 
       if (lotCommitmentsError) {
@@ -462,11 +464,26 @@ async function settleDeadlines(request: Request) {
               idempotencySuffix: "minimum-not-met",
             });
 
+            // Stripe doesn't refund the processing fee on a refund — it stays
+            // a real cost to the platform balance. Stamp the fee on the
+            // commitment for accounting visibility (best-effort; never block
+            // the cancel update on this).
+            let failedStripeFeeCents: number | null = null;
+            if (commitment.stripe_charge_id) {
+              try {
+                const fee = await getChargeFeeCents(commitment.stripe_charge_id);
+                if (fee !== null) failedStripeFeeCents = fee;
+              } catch {
+                failedStripeFeeCents = null;
+              }
+            }
+
             await admin
               .from("commitments")
               .update({
                 status: "cancelled",
                 payment_status: "cancelled",
+                stripe_fee_cents: failedStripeFeeCents,
                 payment_error: "Refunded: lot minimum not met by deadline",
               })
               .eq("id", commitment.id);
@@ -832,6 +849,29 @@ async function settleDeadlines(request: Request) {
           grossAmountCents: finalAmountCents,
           sellerNetAmountCents,
         });
+
+        // Stripe debits its processing fee from the platform's main balance
+        // when the charge clears — not from source_transaction-tied transfers.
+        // To stop the platform balance from running short by ~3% per commit,
+        // pull the actual fee from BalanceTransaction and absorb it out of
+        // CrowdRoast's platform share. Seller and hub shares stay whole.
+        let stripeFeeCents = 0;
+        try {
+          const fee = await getChargeFeeCents(stripeChargeId);
+          if (fee !== null) stripeFeeCents = fee;
+        } catch {
+          // BalanceTransaction may not be ready yet (rare for cards); leave
+          // fee at 0 for this run. The next cron pass will retry — transfers
+          // are idempotent via existing-amount diffing below, so a later run
+          // that learns the real fee will still book it correctly because
+          // we re-derive missingPlatformAmount each run.
+          stripeFeeCents = 0;
+        }
+        const platformFeeApplication = applyStripeFeeToPlatformShare(
+          split.platformAmount,
+          stripeFeeCents
+        );
+
         let existingTransfers: Array<{
           amount?: number;
           destination?: string | null;
@@ -893,12 +933,17 @@ async function settleDeadlines(request: Request) {
         // credit_ledger row and reduces Mernin's effective platform target
         // by that amount. Idempotent across cron retries via the partial
         // unique index on (source_commitment_id) WHERE reason='commit_applied'.
+        //
+        // Note: platformAmountAfterFee already has the Stripe processing fee
+        // deducted, so inviter credits stack on top of fee absorption — both
+        // costs land on CrowdRoast.
+        const platformAmountAfterFee = platformFeeApplication.adjustedPlatformAmountCents;
         const creditApplication = debug
-          ? { applied: 0, adjustedPlatformAmountCents: split.platformAmount, ledgerRowInserted: false }
+          ? { applied: 0, adjustedPlatformAmountCents: platformAmountAfterFee, ledgerRowInserted: false }
           : await applyInviterCreditOnSettle(admin, {
               commitmentId: commitment.id,
               buyerId: commitment.buyer_id,
-              platformAmountCents: split.platformAmount,
+              platformAmountCents: platformAmountAfterFee,
             });
 
         const adjustedPlatformAmount = creditApplication.adjustedPlatformAmountCents;
@@ -919,6 +964,9 @@ async function settleDeadlines(request: Request) {
               amountCents - existingRefundAmount
             ),
             split,
+            stripe_fee_cents: stripeFeeCents,
+            platform_fee_application: platformFeeApplication,
+            platform_amount_after_fee: platformAmountAfterFee,
             existing_transfer_amounts: {
               seller: existingSellerAmount,
               hub: existingHubAmount,
@@ -1002,6 +1050,7 @@ async function settleDeadlines(request: Request) {
             status: "confirmed",
             charge_amount_cents: finalAmountCents,
             charge_currency: currency,
+            stripe_fee_cents: stripeFeeCents || null,
             payment_error: null,
           })
           .eq("id", commitment.id);

--- a/lib/payments/settlement-logic.js
+++ b/lib/payments/settlement-logic.js
@@ -29,6 +29,22 @@ export function computeSplit({ grossAmountCents, sellerNetAmountCents }) {
   return { sellerAmount, hubAmount: cappedHubAmount, platformAmount };
 }
 
+// CrowdRoast covers Stripe processing fees out of its own platform share so
+// seller and hub always receive their full split. Floor at 0; if the fee
+// exceeds the platform amount on a tiny commit, the residual `feeShortfall`
+// stays as a real deficit on the platform's main Stripe balance — surface it
+// so callers can log/alert.
+export function applyStripeFeeToPlatformShare(platformAmountCents, stripeFeeCents) {
+  const platform = Math.max(0, Math.round(Number(platformAmountCents || 0)));
+  const fee = Math.max(0, Math.round(Number(stripeFeeCents || 0)));
+  const feeAbsorbed = Math.min(platform, fee);
+  return {
+    adjustedPlatformAmountCents: platform - feeAbsorbed,
+    feeAbsorbed,
+    feeShortfall: fee - feeAbsorbed,
+  };
+}
+
 export function getFinalPricePerKg(basePricePerKg, committedQuantityKg, tiers) {
   const basePrice = Number(basePricePerKg || 0);
   const committedQty = Number(committedQuantityKg || 0);

--- a/lib/payments/settlement-logic.test.js
+++ b/lib/payments/settlement-logic.test.js
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import {
   applyPlatformFee,
+  applyStripeFeeToPlatformShare,
   computeChargeAdjustment,
   computeGrossAmountCents,
   computeSellerNetAmountCents,
@@ -72,4 +73,31 @@ test("computeChargeAdjustment does not refund when final price is equal or highe
 test("gross and seller net amount helpers stay aligned", () => {
   assert.equal(computeSellerNetAmountCents(10, 12.5), 12500);
   assert.equal(computeGrossAmountCents(10, 12.5), 13750);
+});
+
+test("applyStripeFeeToPlatformShare deducts fee from platform share, leaving seller and hub whole", () => {
+  // Example: gross=$137.50, seller=$125, hub=$2.75, platform=$9.75; fee=$4.28
+  // CrowdRoast keeps platform - fee = $5.47
+  const result = applyStripeFeeToPlatformShare(975, 428);
+  assert.equal(result.adjustedPlatformAmountCents, 547);
+  assert.equal(result.feeAbsorbed, 428);
+  assert.equal(result.feeShortfall, 0);
+});
+
+test("applyStripeFeeToPlatformShare floors platform share at 0 when fee exceeds it", () => {
+  const result = applyStripeFeeToPlatformShare(100, 250);
+  assert.equal(result.adjustedPlatformAmountCents, 0);
+  assert.equal(result.feeAbsorbed, 100);
+  assert.equal(result.feeShortfall, 150); // residual deficit on platform balance
+});
+
+test("applyStripeFeeToPlatformShare is a no-op when fee is zero or missing", () => {
+  const zero = applyStripeFeeToPlatformShare(975, 0);
+  assert.equal(zero.adjustedPlatformAmountCents, 975);
+  assert.equal(zero.feeAbsorbed, 0);
+  assert.equal(zero.feeShortfall, 0);
+
+  const undef = applyStripeFeeToPlatformShare(975, undefined);
+  assert.equal(undef.adjustedPlatformAmountCents, 975);
+  assert.equal(undef.feeAbsorbed, 0);
 });

--- a/lib/stripe.ts
+++ b/lib/stripe.ts
@@ -98,6 +98,25 @@ export interface StripePaymentIntent {
   latest_charge?: string | null;
 }
 
+export interface StripeBalanceTransaction {
+  id: string;
+  fee?: number;
+  currency?: string;
+  fee_details?: Array<{
+    amount: number;
+    currency: string;
+    type: string;
+    description?: string | null;
+  }>;
+}
+
+export interface StripeCharge {
+  id: string;
+  amount?: number;
+  currency?: string;
+  balance_transaction?: string | StripeBalanceTransaction | null;
+}
+
 export interface StripeSetupIntent {
   id: string;
   payment_method?: string | null;
@@ -215,6 +234,22 @@ export async function getSetupIntent(setupIntentId: string) {
 
 export async function getPaymentIntent(paymentIntentId: string) {
   return stripeGetRequest<StripePaymentIntent>(`/payment_intents/${paymentIntentId}`);
+}
+
+// Fetches the Stripe processing fee for a settled charge by expanding the
+// associated BalanceTransaction. Returns null when the balance transaction
+// hasn't been written yet (rare — Stripe writes it synchronously for
+// card charges, but ACH and some async methods can lag). Callers should
+// treat null as "fee unknown" and skip the platform-share deduction this run.
+export async function getChargeFeeCents(chargeId: string): Promise<number | null> {
+  const charge = await stripeGetRequest<StripeCharge>(`/charges/${chargeId}`, {
+    "expand[]": "balance_transaction",
+  });
+  const balanceTx = charge.balance_transaction;
+  if (!balanceTx || typeof balanceTx === "string") return null;
+  const fee = Number(balanceTx.fee);
+  if (!Number.isFinite(fee) || fee < 0) return null;
+  return Math.round(fee);
 }
 
 export async function createAndConfirmPaymentIntent(params: {

--- a/supabase/migrations/20240101000033_commitment_stripe_fee_cents.sql
+++ b/supabase/migrations/20240101000033_commitment_stripe_fee_cents.sql
@@ -1,0 +1,13 @@
+-- Track the actual Stripe processing fee per commitment.
+--
+-- CrowdRoast covers the Stripe processing fee out of its own platform share at
+-- settlement time, so seller and hub always receive their full split. Storing
+-- the actual fee from balance_transaction.fee makes it auditable per-commit
+-- and allows accounting/reporting to surface the real cost (especially for
+-- minimum-not-met campaigns where Stripe does not refund the fee).
+
+alter table public.commitments
+  add column if not exists stripe_fee_cents integer;
+
+comment on column public.commitments.stripe_fee_cents is
+  'Stripe processing fee for this commitment''s charge (BalanceTransaction.fee). Absorbed by CrowdRoast — deducted from platform share at settle time.';


### PR DESCRIPTION
Stripe debits the processing fee from the platform's main balance when a
charge clears, not from source_transaction-tied transfers. Until now the
three settle-time transfers summed to gross, leaving the platform balance
short by ~3% per commit. Pull the actual fee from BalanceTransaction at
settlement and absorb it out of CrowdRoast's platform share so seller and
hub stay whole and the platform balance settles to zero.

Persist stripe_fee_cents on commitments (success and failed-refund paths)
for accounting visibility — Stripe doesn't refund the fee on refunds, so
min-not-met campaigns book a real platform cost.