### PR TITLE
fix(campaign): drop redundant Listed rung when trigger > 0

### DIFF
--- a/components/campaign/CampaignPage.tsx
+++ b/components/campaign/CampaignPage.tsx
@@ -577,9 +577,18 @@ function buildTierContext(lot: Lot, pricingTiers: PricingTier[]): TierContext {
     priceKg: stretchPrice,
   }
 
-  // Dedupe by ascending threshold so we don't surface a "Trigger" rung that
-  // collides with a pricing tier at the same percentage.
-  const allRungs = [listedTier, triggerTier, ...pricingTierSteps, stretchTier]
+  // Listed and Trigger both carry the base price (lot.price_per_kg). When the
+  // trigger sits above 0%, showing both rungs duplicates the same price on the
+  // ladder — and the Listed chip reads as "✓ Unlocked" before the campaign
+  // has actually triggered. Drop Listed in that case so the trigger price
+  // shows as the next milestone, not as already unlocked.
+  const allRungs =
+    triggerTier.threshold > 0
+      ? [triggerTier, ...pricingTierSteps, stretchTier]
+      : [listedTier, ...pricingTierSteps, stretchTier]
+
+  // Dedupe by ascending threshold so we don't surface a rung that collides
+  // with a pricing tier at the same percentage.
   const tiers: CampaignTier[] = []
   for (const rung of allRungs) {
     const last = tiers[tiers.length - 1]

--- a/components/campaign/TierLadder.tsx
+++ b/components/campaign/TierLadder.tsx
@@ -48,8 +48,10 @@ export function TierLadder({
     Math.max(0, (committedKg / Math.max(0.0001, stretchKg)) * 100)
   )
 
-  const currentTier =
-    [...tiers].reverse().find((t) => committedKg >= kgAtTier(t)) ?? tiers[0]
+  const reachedTier = [...tiers]
+    .reverse()
+    .find((t) => committedKg >= kgAtTier(t))
+  const currentTier = reachedTier ?? tiers[0]
   const nextTier =
     tiers.find((t) => kgAtTier(t) > committedKg) ?? tiers[tiers.length - 1]
   const kgToNext = Math.max(0, kgAtTier(nextTier) - committedKg)
@@ -105,7 +107,10 @@ export function TierLadder({
                 verticalAlign: 'middle',
               }}
             />
-            You&apos;re at {currentTier.name} · {Math.round(stretchPct)}%
+            {reachedTier
+              ? `You're at ${currentTier.name}`
+              : 'Just listed'}{' '}
+            · {Math.round(stretchPct)}%
           </div>
           <h2
             style={{


### PR DESCRIPTION
The Listed and Trigger rungs both carry the base price. When the trigger
sits above 0%, both rendered as separate chips with the same price — and
the Listed chip read as "✓ Unlocked" before the campaign had actually
triggered. Omit Listed in that case so the trigger price shows as the
next milestone, and surface "Just listed" in the eyebrow when no tier
has been reached.

https://claude.ai/code/session_011xPcP6td2T9dgURcV4YYkL