### PR TITLE
Fix weight input validation by rounding display values

### DIFF
--- a/app/dashboard/seller/lots/[id]/edit/page.tsx
+++ b/app/dashboard/seller/lots/[id]/edit/page.tsx
@@ -426,6 +426,7 @@ export default function EditLotPage({
                       type="number"
                       required
                       min="1"
+                      step="0.01"
                       value={form.min_commitment_kg}
                       onChange={(e) =>
                         update("min_commitment_kg", e.target.value)
@@ -441,6 +442,7 @@ export default function EditLotPage({
                       type="number"
                       required
                       min="1"
+                      step="0.01"
                       value={form.total_quantity_kg}
                       onChange={(e) =>
                         update("total_quantity_kg", e.target.value)
@@ -551,6 +553,7 @@ export default function EditLotPage({
                           type="number"
                           min={minQty + 1}
                           max={maxQty}
+                          step="0.01"
                           value={tier.min_quantity_kg}
                           onChange={(e) =>
                             updateTier(idx, "min_quantity_kg", e.target.value)

--- a/app/dashboard/seller/lots/new/create-lot-form.tsx
+++ b/app/dashboard/seller/lots/new/create-lot-form.tsx
@@ -381,6 +381,7 @@ export function CreateLotForm() {
                     type="number"
                     required
                     min="1"
+                    step="0.01"
                     placeholder="300"
                     value={form.min_commitment_kg}
                     onChange={(e) => update("min_commitment_kg", e.target.value)}
@@ -398,6 +399,7 @@ export function CreateLotForm() {
                     type="number"
                     required
                     min="1"
+                    step="0.01"
                     placeholder="1000"
                     value={form.total_quantity_kg}
                     onChange={(e) => update("total_quantity_kg", e.target.value)}
@@ -517,6 +519,7 @@ export function CreateLotForm() {
                         type="number"
                         min={minQty + 1}
                         max={maxQty}
+                        step="0.01"
                         placeholder="500"
                         value={tier.min_quantity_kg}
                         onChange={(e) =>

--- a/lib/units.ts
+++ b/lib/units.ts
@@ -3,10 +3,12 @@ export type WeightUnit = "kg" | "lb";
 export const DEFAULT_WEIGHT_UNIT: WeightUnit = "kg";
 export const LB_PER_KG = 2.2046226218;
 const PRICE_CALC_DECIMALS = 5;
-// Display rounding matches the price input's step="0.01"; without it,
-// converting a kg-priced lot to lb yields a 5-decimal value that fails
-// HTML5 number validation on submit.
+const WEIGHT_CALC_DECIMALS = 5;
+// Display rounding matches the form inputs' step="0.01"; without it,
+// converting a kg-stored value to lb yields a many-decimal value that
+// fails HTML5 number validation on submit.
 const PRICE_DISPLAY_DECIMALS = 2;
+const WEIGHT_DISPLAY_DECIMALS = 2;
 
 function roundTo(value: number, decimals: number): number {
   const factor = 10 ** decimals;
@@ -14,11 +16,13 @@ function roundTo(value: number, decimals: number): number {
 }
 
 export function toDisplayWeight(kg: number, unit: WeightUnit): number {
-  return unit === "lb" ? kg * LB_PER_KG : kg;
+  const converted = unit === "lb" ? kg * LB_PER_KG : kg;
+  return roundTo(converted, WEIGHT_DISPLAY_DECIMALS);
 }
 
 export function fromDisplayWeight(value: number, unit: WeightUnit): number {
-  return unit === "lb" ? value / LB_PER_KG : value;
+  const converted = unit === "lb" ? value / LB_PER_KG : value;
+  return roundTo(converted, WEIGHT_CALC_DECIMALS);
 }
 
 export function toDisplayPricePerUnit(pricePerKg: number, unit: WeightUnit): number {


### PR DESCRIPTION
## Summary
Fixes HTML5 number input validation failures when converting weight values between kg and lb units. The issue occurred because unit conversions produced many decimal places that violated the `step="0.01"` constraint on weight input fields.

## Changes
- **lib/units.ts**
  - Added `WEIGHT_CALC_DECIMALS` and `WEIGHT_DISPLAY_DECIMALS` constants for consistent rounding
  - Updated `toDisplayWeight()` to round converted values to 2 decimal places before display
  - Updated `fromDisplayWeight()` to round converted values to 5 decimal places for internal calculations
  - Clarified comment to reflect that rounding applies to all form inputs, not just price

- **app/dashboard/seller/lots/[id]/edit/page.tsx**
  - Added `step="0.01"` attribute to three weight input fields:
    - `min_commitment_kg`
    - `total_quantity_kg`
    - `tier.min_quantity_kg`

- **app/dashboard/seller/lots/new/create-lot-form.tsx**
  - Added `step="0.01"` attribute to three weight input fields:
    - `min_commitment_kg`
    - `total_quantity_kg`
    - `tier.min_quantity_kg`

## Implementation Details
The fix uses a two-tier rounding approach:
- **Display rounding (2 decimals)**: Ensures user-facing values match the `step="0.01"` HTML5 constraint
- **Calculation rounding (5 decimals)**: Maintains precision during internal conversions while preventing floating-point accumulation errors

This mirrors the existing pattern used for price conversions and ensures form submission validation passes regardless of the selected weight unit.

https://claude.ai/code/session_01UBh5rkfcyhQoriJ28B7WUz