### PR TITLE
feat(campaign): mount bag-aware UI on buyer CampaignPage

### DIFF
--- a/app/api/commitments/__tests__/commitments-campaign.test.ts
+++ b/app/api/commitments/__tests__/commitments-campaign.test.ts
@@ -354,4 +354,102 @@ describe("POST /api/commitments — campaign requirement", () => {
     const body = await res.json();
     expect(body.error).toMatch(/campaign deadline has passed/i);
   });
+
+  it("resolves seller price from tier.min_bags (not min_quantity_kg) for bag-aware lots", async () => {
+    // 60kg bags. Tier has min_bags = 2 (= 120kg). min_quantity_kg = 200kg
+    // (intentionally mismatched — the legacy code path would NOT pick the
+    // tier because newTotal=180 < 200, but the bag-aware path SHOULD pick
+    // it because completed_bags=3 ≥ min_bags=2).
+    const lot = {
+      ...activeLot,
+      id: "lot-bag-tier",
+      total_quantity_kg: 600,
+      committed_quantity_kg: 0,
+      bag_size_kg: 60,
+      price_per_kg: 20, // base
+    };
+    const newCommitId = "commit-bag-tier-new";
+    const newCommitCreatedAt = new Date(
+      "2026-05-12T12:00:00Z"
+    ).toISOString();
+
+    let insertedPayload: Record<string, unknown> | null = null;
+    let commitmentsCall = 0;
+    mockSupabaseFrom.mockImplementation((table: string) => {
+      if (table === "lots") {
+        return makeChain({ data: lot, error: null });
+      }
+      if (table === "campaigns") {
+        return makeChain({
+          data: {
+            id: "campaign-bag-tier",
+            deadline: daysFromNow(7),
+            status: "active",
+          },
+          error: null,
+        });
+      }
+      if (table === "pricing_tiers") {
+        // The tier is configured at min_bags=2 (= 120kg) with a 15/kg price.
+        // min_quantity_kg is 200kg — INTENTIONALLY higher than the new total
+        // so the legacy kg-tier path would NOT pick this tier.
+        return makeChain({
+          data: [
+            { min_bags: 2, min_quantity_kg: 200, price_per_kg: 15 },
+          ],
+          error: null,
+        });
+      }
+      if (table === "profiles") {
+        return makeChain({
+          data: {
+            email: "buyer@roastery.com",
+            stripe_customer_id: "cus_existing",
+          },
+          error: null,
+        });
+      }
+      if (table === "commitments") {
+        commitmentsCall += 1;
+        if (commitmentsCall === 1) {
+          return makeChain({ data: null, error: null });
+        }
+        if (commitmentsCall === 2) {
+          // Capture the insert payload so we can assert price_per_kg.
+          const chain = makeChain({
+            data: { id: newCommitId, quantity_kg: 180, created_at: newCommitCreatedAt },
+            error: null,
+          });
+          const insert = chain.insert as ReturnType<typeof vi.fn>;
+          insert.mockImplementation((payload: Record<string, unknown>) => {
+            insertedPayload = payload;
+            return chain;
+          });
+          return chain;
+        }
+        if (commitmentsCall === 3) {
+          return makeChain({
+            data: [
+              { id: newCommitId, quantity_kg: 180, created_at: newCommitCreatedAt },
+            ],
+            error: null,
+          });
+        }
+        return makeChain({ data: null, error: null });
+      }
+      return makeChain({ data: null, error: null });
+    });
+
+    const res = await POST(
+      makeRequest({ lot_id: lot.id, hub_id: "hub-uuid-1", quantity_kg: 180 })
+    );
+    expect(res.status).toBe(201);
+
+    // Bag-aware resolution kicked in: 180kg/60kg = 3 bags, 3 ≥ min_bags=2,
+    // so seller price drops to the tier price (15), not the base price (20).
+    expect(insertedPayload).not.toBeNull();
+    expect(
+      (insertedPayload as unknown as Record<string, unknown>).price_per_kg
+    ).toBe(15);
+  });
 });

--- a/app/api/commitments/route.ts
+++ b/app/api/commitments/route.ts
@@ -7,6 +7,7 @@ import {
 } from "@/lib/stripe";
 import { addPlatformFee } from "@/lib/pricing";
 import { assignKgToBags } from "@/lib/bag-assignment";
+import { computeCompletedBagsAndPrice } from "@/lib/settle-bag-pricing";
 import { NextResponse } from "next/server";
 
 export async function POST(request: Request) {
@@ -117,9 +118,29 @@ export async function POST(request: Request) {
   // After this commitment, the new total committed quantity
   const newTotal = lot.committed_quantity_kg + quantity_kg;
 
-  // Find the highest tier that the new total reaches
+  // Resolve the active seller price per kg. For bag-aware lots (the live
+  // path now), keep the commit-time tier in sync with settlement by
+  // routing through computeCompletedBagsAndPrice — same algorithm that
+  // lib/settle-bag-pricing.ts uses at deadline. Without this, a buyer can
+  // be quoted one price (kg-tier) and charged another (bag-tier) at
+  // settlement when min_quantity_kg doesn't land on a bag boundary.
   let activeSellerPricePerKg = lot.price_per_kg;
-  if (tiers && tiers.length > 0) {
+  if (lot.bag_size_kg !== null && lot.bag_size_kg > 0) {
+    const { price_per_kg } = computeCompletedBagsAndPrice({
+      total_committed_kg: newTotal,
+      bag_size_kg: Number(lot.bag_size_kg),
+      base_price_per_kg: lot.price_per_kg,
+      tiers: (tiers ?? []).map((t) => ({
+        min_bags:
+          t.min_bags === null || t.min_bags === undefined
+            ? null
+            : Number(t.min_bags),
+        price_per_kg: t.price_per_kg,
+      })),
+    });
+    activeSellerPricePerKg = price_per_kg;
+  } else if (tiers && tiers.length > 0) {
+    // Legacy kg-tier resolution preserved for unconverted lots.
     for (const tier of tiers) {
       if (newTotal >= tier.min_quantity_kg) {
         activeSellerPricePerKg = tier.price_per_kg;

--- a/app/dashboard/buyer/lot/[id]/page.tsx
+++ b/app/dashboard/buyer/lot/[id]/page.tsx
@@ -1,7 +1,7 @@
 import { createClient } from "@/lib/supabase/server";
 import { notFound, redirect } from "next/navigation";
 import { CampaignPage } from "@/components/campaign/CampaignPage";
-import type { Lot, PricingTier } from "@/lib/types";
+import type { Commitment, Lot, PricingTier } from "@/lib/types";
 import {
   getCampaignSocialProof,
   type SocialProofCommitment,
@@ -99,6 +99,24 @@ export default async function BuyerLotDetailPage({
     (commitments ?? []) as unknown as SocialProofCommitment[]
   );
 
+  // Bag-aware commits never set stripe_payment_intent_id (settlement issues
+  // per-bag charges later), so the payment_intent filter above would hide
+  // them from the "Your Commits" surface. Re-fetch the same campaign's
+  // commits without that filter — but only past the "pending_setup" state,
+  // so abandoned-checkout rows don't leak into the viewer's list. Limited
+  // to the viewer's own buyer_id since the YourCommits block is
+  // viewer-scoped and we don't need other buyers' rows here.
+  const { data: viewerCommitments } = activeCampaign
+    ? await supabase
+        .from("commitments")
+        .select("id, buyer_id, quantity_kg, created_at, status, payment_status")
+        .eq("campaign_id", activeCampaign.id)
+        .eq("buyer_id", user.id)
+        .neq("status", "cancelled")
+        .neq("payment_status", "pending_setup")
+        .order("created_at", { ascending: true })
+    : { data: [] };
+
   // Fetch hub name for hero / farmer card display copy. The invite CTAs
   // get their own hubName from POST /api/invite-codes via useInviteData,
   // but visual surfaces shouldn't be coupled to that auth-gated fetch.
@@ -114,6 +132,7 @@ export default async function BuyerLotDetailPage({
       hubId={hubId || null}
       hubName={hub?.name || null}
       pricingTiers={(pricingTiers as unknown as PricingTier[]) || []}
+      commitments={(viewerCommitments as unknown as Commitment[]) || []}
       socialProof={socialProof}
     />
   );

--- a/components/campaign/CampaignCommitForm.tsx
+++ b/components/campaign/CampaignCommitForm.tsx
@@ -20,6 +20,7 @@ import {
   type WeightUnit,
 } from '@/lib/units'
 import { addPlatformFee } from '@/lib/pricing'
+import { CommitSplitWarning } from './commit-split-warning'
 
 interface CampaignCommitFormProps {
   lotId: string
@@ -32,6 +33,13 @@ interface CampaignCommitFormProps {
   activeTierName: string
   /** Number of roasters currently in — surfaces on the header. */
   biddersIn: number
+  /** Bag size for this lot in kg. When set (>0), preset chips snap to
+   *  bag multiples and the cross-boundary split warning renders. `null`
+   *  keeps the legacy round-kg preset ladder for unconverted lots. */
+  bagSizeKg?: number | null
+  /** Total kg already committed to this lot — used to compute the current
+   *  bag's remaining capacity for the split warning. Defaults to 0. */
+  totalCommittedKg?: number
   onSuccess?: () => void
 }
 
@@ -43,6 +51,49 @@ function getPresets(unit: WeightUnit): number[] {
 }
 function getStep(unit: WeightUnit): number {
   return unit === 'lb' ? 22 : 10
+}
+
+type PresetChoice = {
+  /** Display label for the chip (e.g. "1 bag", "Top off"). */
+  label: string
+  /** Quantity in the buyer's chosen display unit. */
+  displayQty: number
+}
+
+/**
+ * Build the bag-aware preset ladder. The ladder telegraphs the bag concept
+ * without forcing bag-multiple commits: the buyer can still type any kg
+ * amount. "Top off" snaps to the kg needed to finish the open bag — the
+ * single highest-value click on a bag-aware lot, because it turns at-risk
+ * filling kg into locked kg.
+ *
+ * `bagRemainingKg` of 0 means the open bag just completed (or no commits
+ * yet) — in that case "Top off" would equal 1 bag, so we suppress it to
+ * avoid a duplicate chip.
+ */
+function getBagPresets(
+  bagSizeKg: number,
+  bagRemainingKg: number,
+  unit: WeightUnit,
+  maxDisplay: number
+): PresetChoice[] {
+  const round1 = (n: number) => Math.round(n * 10) / 10
+  const halfBagDisplay = round1(toDisplayWeight(bagSizeKg / 2, unit))
+  const oneBagDisplay = round1(toDisplayWeight(bagSizeKg, unit))
+  const twoBagDisplay = round1(toDisplayWeight(bagSizeKg * 2, unit))
+  const topOffDisplay =
+    bagRemainingKg > 0 ? round1(toDisplayWeight(bagRemainingKg, unit)) : 0
+
+  const choices: PresetChoice[] = []
+  if (topOffDisplay > 0 && topOffDisplay < oneBagDisplay) {
+    choices.push({ label: 'Top off', displayQty: topOffDisplay })
+  }
+  choices.push({ label: '½ bag', displayQty: halfBagDisplay })
+  choices.push({ label: '1 bag', displayQty: oneBagDisplay })
+  choices.push({ label: '2 bags', displayQty: twoBagDisplay })
+
+  // Filter out anything that won't fit in remaining lot capacity.
+  return choices.filter((c) => c.displayQty > 0 && c.displayQty <= maxDisplay)
 }
 
 // Direct port of design/project/campaign/CommitForm.jsx — espresso card
@@ -58,15 +109,31 @@ export function CampaignCommitForm({
   hubId,
   activeTierName,
   biddersIn,
+  bagSizeKg = null,
+  totalCommittedKg = 0,
   onSuccess,
 }: CampaignCommitFormProps) {
   const router = useRouter()
   const { unit } = useUnitPreference()
 
   const maxDisplay = Math.floor(toDisplayWeight(maxKg, unit))
-  const presets = getPresets(unit)
+  const isBagAware = bagSizeKg !== null && bagSizeKg > 0
+  // Current bag's remaining kg — the kg needed to lock the open bag. When
+  // totalCommittedKg lands exactly on a bag boundary (or is zero), the
+  // entire next bag is "remaining" because a fresh bag is opening.
+  const bagRemainingKg = isBagAware
+    ? totalCommittedKg % bagSizeKg === 0
+      ? bagSizeKg
+      : bagSizeKg - (totalCommittedKg % bagSizeKg)
+    : 0
+  const legacyPresets = getPresets(unit)
+  const bagPresets = isBagAware
+    ? getBagPresets(bagSizeKg, bagRemainingKg, unit, maxDisplay)
+    : []
   const step = getStep(unit)
-  const defaultDisplay = presets.find((n) => n <= maxDisplay) ?? 1
+  const defaultDisplay = isBagAware
+    ? bagPresets[0]?.displayQty ?? Math.min(maxDisplay, Math.round(toDisplayWeight(bagSizeKg, unit)))
+    : legacyPresets.find((n) => n <= maxDisplay) ?? 1
 
   const [qty, setQty] = React.useState<number>(defaultDisplay)
   const [notes, setNotes] = React.useState('')
@@ -281,29 +348,55 @@ export function CampaignCommitForm({
           flexWrap: 'wrap',
         }}
       >
-        {presets.map((n) => (
-          <button
-            key={n}
-            type="button"
-            onClick={() => setQty(n)}
-            style={{
-              flex: '1 1 0',
-              padding: '8px 4px',
-              background: qty === n ? 'var(--color-tomato)' : 'transparent',
-              border: '2px solid var(--color-cream)',
-              borderRadius: 8,
-              color: 'var(--color-cream)',
-              fontFamily: 'var(--font-body)',
-              fontWeight: 800,
-              fontSize: 11,
-              letterSpacing: '.08em',
-              textTransform: 'uppercase',
-              cursor: 'pointer',
-            }}
-          >
-            {n} {unit}
-          </button>
-        ))}
+        {isBagAware
+          ? bagPresets.map((choice) => (
+              <button
+                key={choice.label}
+                type="button"
+                onClick={() => setQty(choice.displayQty)}
+                title={`${choice.displayQty} ${unit}`}
+                style={{
+                  flex: '1 1 0',
+                  padding: '8px 4px',
+                  background:
+                    qty === choice.displayQty ? 'var(--color-tomato)' : 'transparent',
+                  border: '2px solid var(--color-cream)',
+                  borderRadius: 8,
+                  color: 'var(--color-cream)',
+                  fontFamily: 'var(--font-body)',
+                  fontWeight: 800,
+                  fontSize: 11,
+                  letterSpacing: '.08em',
+                  textTransform: 'uppercase',
+                  cursor: 'pointer',
+                }}
+              >
+                {choice.label}
+              </button>
+            ))
+          : legacyPresets.map((n) => (
+              <button
+                key={n}
+                type="button"
+                onClick={() => setQty(n)}
+                style={{
+                  flex: '1 1 0',
+                  padding: '8px 4px',
+                  background: qty === n ? 'var(--color-tomato)' : 'transparent',
+                  border: '2px solid var(--color-cream)',
+                  borderRadius: 8,
+                  color: 'var(--color-cream)',
+                  fontFamily: 'var(--font-body)',
+                  fontWeight: 800,
+                  fontSize: 11,
+                  letterSpacing: '.08em',
+                  textTransform: 'uppercase',
+                  cursor: 'pointer',
+                }}
+              >
+                {n} {unit}
+              </button>
+            ))}
       </div>
 
       {/* Stats row with dashed borders */}
@@ -367,6 +460,20 @@ export function CampaignCommitForm({
         </div>
       </div>
 
+      {/* Cross-boundary split warning — only when bag-aware AND the pending
+        * qty would tip into a fresh bag. The component returns null when
+        * the pledge fits inside the open bag, so we can mount it
+        * unconditionally on bag-aware lots and let it self-gate. */}
+      {isBagAware && (
+        <div style={{ marginBottom: 14 }}>
+          <CommitSplitWarning
+            pending_kg={qtyKg}
+            bag_remaining_kg={bagRemainingKg}
+            bag_size_kg={bagSizeKg}
+          />
+        </div>
+      )}
+
       {/* Commit button OR success state */}
       {committed ? (
         <div
@@ -423,7 +530,9 @@ export function CampaignCommitForm({
           lineHeight: 1.5,
         }}
       >
-        Refund in full if the campaign doesn&apos;t hit its minimum. No fees.
+        {isBagAware
+          ? "Only full bags ship. Anything in an open bag at the deadline refunds to your card."
+          : "Refund in full if the campaign doesn't hit its minimum. No fees."}
       </div>
 
       {/* Confirm dialog (preserves CommitmentForm's safety net) */}

--- a/components/campaign/CampaignPage.tsx
+++ b/components/campaign/CampaignPage.tsx
@@ -17,7 +17,8 @@ import { PostCommitNudge } from './PostCommitNudge'
 import { InviteModal } from './InviteModal'
 import { SocialProof } from './SocialProof'
 import { FarmerCard } from './FarmerCard'
-import type { Lot, PricingTier, UserRole } from '@/lib/types'
+import { YourCommits } from './YourCommits'
+import type { Commitment, Lot, PricingTier, UserRole } from '@/lib/types'
 import type { CampaignSocialProof } from '@/lib/lots/social-proof'
 
 interface CampaignPageProps {
@@ -27,6 +28,11 @@ interface CampaignPageProps {
   hubId?: string | null
   hubName?: string | null
   pricingTiers?: PricingTier[]
+  /** All commitments on the active campaign — used to compute the viewer's
+   *  bag-aware locked/filling split for the "Your Commits" block. The page
+   *  already fetches this for social proof, so we plumb it through rather
+   *  than re-querying client-side. */
+  commitments?: Commitment[]
   socialProof?: CampaignSocialProof
   backHref?: string
   backLabel?: string
@@ -180,6 +186,7 @@ function AuthenticatedView({
   hubId,
   hubName,
   pricingTiers = [],
+  commitments = [],
   socialProof,
   backHref,
   backLabel,
@@ -205,6 +212,10 @@ function AuthenticatedView({
     activePrice,
     activeTier,
   } = React.useMemo(() => buildTierContext(lot, pricingTiers), [lot, pricingTiers])
+
+  const bagSizeKg =
+    lot.bag_size_kg != null && lot.bag_size_kg > 0 ? Number(lot.bag_size_kg) : null
+  const minBagsToSucceed = Number(lot.min_bags_to_succeed ?? 0)
 
   const biddersIn = socialProof?.recentCommitCount ?? 0
 
@@ -355,6 +366,8 @@ function AuthenticatedView({
                   hubId={hubId || undefined}
                   activeTierName={activeTier.name}
                   biddersIn={biddersIn}
+                  bagSizeKg={bagSizeKg}
+                  totalCommittedKg={lot.committed_quantity_kg}
                   onSuccess={() => setHasCommitted(true)}
                 />
               )}
@@ -372,6 +385,8 @@ function AuthenticatedView({
             tiers={tiers}
             committedKg={committedKg}
             stretchKg={stretchKg}
+            bagSizeKg={bagSizeKg}
+            minBagsToSucceed={minBagsToSucceed}
             hype="rowdy"
           >
             <div style={{ marginTop: 18, maxWidth: 520 }}>
@@ -380,6 +395,20 @@ function AuthenticatedView({
           </TierLadder>
         </div>
       </section>
+
+      {/* YOUR COMMITS — bag-aware, viewer-scoped */}
+      {bagSizeKg !== null && (
+        <section className="cp-section" style={{ padding: '0 24px 40px' }}>
+          <div style={{ maxWidth: 1280, margin: '0 auto' }}>
+            <YourCommits
+              userId={userId}
+              commitments={commitments}
+              bagSizeKg={bagSizeKg}
+              totalCommittedKg={lot.committed_quantity_kg}
+            />
+          </div>
+        </section>
+      )}
 
       {/* MARQUEE strip */}
       <Marquee
@@ -538,7 +567,17 @@ type TierContext = {
 function buildTierContext(lot: Lot, pricingTiers: PricingTier[]): TierContext {
   const stretchKg = lot.total_quantity_kg
   const committedKg = lot.committed_quantity_kg
-  const triggerKg = lot.min_commitment_kg
+  // Bag-aware lots key both trigger and tier thresholds off bag counts so
+  // chip positions match the bag-shaped settlement math in
+  // lib/settle-bag-pricing.ts. Legacy (null bag_size_kg) keeps the kg-based
+  // thresholds the existing tier-progress test pins.
+  const bagSizeKg =
+    lot.bag_size_kg != null && lot.bag_size_kg > 0 ? Number(lot.bag_size_kg) : null
+  const minBagsToSucceed = Number(lot.min_bags_to_succeed ?? 0)
+  const triggerKg =
+    bagSizeKg !== null && minBagsToSucceed > 0
+      ? minBagsToSucceed * bagSizeKg
+      : lot.min_commitment_kg
   const sorted = [...pricingTiers].sort(
     (a, b) => a.min_quantity_kg - b.min_quantity_kg
   )
@@ -559,8 +598,15 @@ function buildTierContext(lot: Lot, pricingTiers: PricingTier[]): TierContext {
     priceKg: lot.price_per_kg,
   }
   const pricingTierSteps: CampaignTier[] = sorted.map((t, i) => {
+    // Bag-aware: position the chip at the kg that corresponds to its min_bags
+    // boundary. Falls back to the legacy min_quantity_kg if the tier was
+    // not converted (min_bags === null) or the lot has no bag_size_kg yet.
+    const tierKg =
+      bagSizeKg !== null && t.min_bags !== null && t.min_bags !== undefined
+        ? t.min_bags * bagSizeKg
+        : t.min_quantity_kg
     const threshold =
-      stretchKg > 0 ? Math.round((t.min_quantity_kg / stretchKg) * 100) : 0
+      stretchKg > 0 ? Math.round((tierKg / stretchKg) * 100) : 0
     return {
       id: `tier-${i}`,
       name: i === sorted.length - 1 ? 'Full Tier' : 'Early Tier',

--- a/components/campaign/TierLadder.tsx
+++ b/components/campaign/TierLadder.tsx
@@ -22,6 +22,15 @@ interface TierLadderProps {
   stretchKg: number
   /** Visual energy: 'rowdy' wiggles the next-tier flag. */
   hype?: 'calm' | 'rowdy'
+  /** Bag size for this lot in kg. When set (>0), the ladder switches to
+   *  bag-aware mode: eyebrow shows "X of N bags locked", the bar gets
+   *  per-bag dividers, and a "Only full bags ship — partial bags refund"
+   *  footnote renders. `null` keeps the legacy kg-percent rail (for lots
+   *  that pre-date the bag-aware close model). */
+  bagSizeKg?: number | null
+  /** Minimum bags needed for the campaign to succeed/settle. Used to
+   *  format the eyebrow nudge when bag-aware. Defaults to 0 (off). */
+  minBagsToSucceed?: number
   /** Optional slot rendered below the ladder for a sticky invite poke. */
   children?: React.ReactNode
 }
@@ -40,6 +49,8 @@ export function TierLadder({
   committedKg,
   stretchKg,
   hype = 'rowdy',
+  bagSizeKg = null,
+  minBagsToSucceed = 0,
   children,
 }: TierLadderProps) {
   const { unit } = useUnitPreference()
@@ -63,6 +74,18 @@ export function TierLadder({
     addPlatformFee(nextTier.priceKg),
     unit
   )
+
+  // Bag-aware derived state. Computed unconditionally so the dependency
+  // graph stays simple; the JSX gates rendering on `isBagAware`.
+  const isBagAware = bagSizeKg !== null && bagSizeKg > 0
+  const safeBagSize = isBagAware ? bagSizeKg : 1
+  const totalBags = isBagAware ? Math.floor(stretchKg / safeBagSize) : 0
+  const completedBags = isBagAware ? Math.floor(committedKg / safeBagSize) : 0
+  const inProgressKg = isBagAware ? committedKg - completedBags * safeBagSize : 0
+  const bagRemainingKg = isBagAware && inProgressKg > 0 ? safeBagSize - inProgressKg : 0
+  const currentBagNumber = completedBags + 1
+  const bagsShortOfMin = Math.max(0, (minBagsToSucceed || 0) - completedBags)
+  const bagLabel = (n: number) => (n === 1 ? 'bag' : 'bags')
 
   return (
     <div
@@ -111,10 +134,27 @@ export function TierLadder({
                 verticalAlign: 'middle',
               }}
             />
-            {reachedTier
-              ? `You're at ${currentTier.name}`
-              : 'Just listed'}{' '}
-            · {Math.round(stretchPct)}%
+            {isBagAware ? (
+              <>
+                {completedBags} of {totalBags} {bagLabel(totalBags)} locked
+                {inProgressKg > 0 && (
+                  <>
+                    {' '}·{' '}
+                    <span style={{ fontVariantNumeric: 'tabular-nums' }}>
+                      {formatQty(inProgressKg)} {unit}
+                    </span>{' '}
+                    into bag {currentBagNumber}
+                  </>
+                )}
+              </>
+            ) : (
+              <>
+                {reachedTier
+                  ? `You're at ${currentTier.name}`
+                  : 'Just listed'}{' '}
+                · {Math.round(stretchPct)}%
+              </>
+            )}
           </div>
           <h2
             style={{
@@ -196,6 +236,38 @@ export function TierLadder({
               transition: 'width .6s var(--ease-snap)',
             }}
           />
+          {/* Bag dividers — vertical espresso ticks at each bag boundary.
+            * Only renders for bag-aware lots with a sensible number of bags
+            * (<= 40, otherwise ticks crowd the rail into noise). */}
+          {isBagAware && totalBags > 0 && totalBags <= 40 && (
+            <div
+              aria-hidden="true"
+              data-testid="bag-dividers"
+              style={{
+                position: 'absolute',
+                inset: 0,
+                pointerEvents: 'none',
+              }}
+            >
+              {Array.from({ length: totalBags - 1 }, (_, i) => {
+                const left = ((i + 1) / totalBags) * 100
+                return (
+                  <span
+                    key={i}
+                    style={{
+                      position: 'absolute',
+                      top: 0,
+                      bottom: 0,
+                      left: `${left}%`,
+                      width: 2,
+                      background: 'var(--color-espresso)',
+                      opacity: 0.55,
+                    }}
+                  />
+                )
+              })}
+            </div>
+          )}
         </div>
 
         {/* Desktop: absolute-positioned chips along the bar */}
@@ -237,6 +309,96 @@ export function TierLadder({
           })}
         </ul>
       </div>
+
+      {/* Bag-aware status line — sits between the bar and the children slot.
+        * Renders only for bag-aware lots, with separate messages for the
+        * filling / freshly-completed / under-minimum / fully-locked states. */}
+      {isBagAware && (
+        <div
+          data-testid="bag-status-line"
+          style={{
+            marginTop: 18,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            gap: 12,
+            flexWrap: 'wrap',
+            fontFamily: 'var(--font-body)',
+            fontSize: 13,
+            fontWeight: 700,
+            color: 'var(--color-espresso)',
+          }}
+        >
+          <div style={{ display: 'inline-flex', alignItems: 'baseline', gap: 8 }}>
+            {inProgressKg > 0 ? (
+              <>
+                <span
+                  style={{
+                    fontFamily: 'var(--font-display)',
+                    fontSize: 20,
+                    lineHeight: 1,
+                    color: 'var(--color-espresso)',
+                  }}
+                >
+                  Bag {currentBagNumber}
+                </span>
+                <span style={{ fontWeight: 700, fontVariantNumeric: 'tabular-nums' }}>
+                  {formatQty(inProgressKg)} {unit} / {formatQty(safeBagSize)} {unit}
+                </span>
+                <span style={{ fontWeight: 700, color: 'var(--fg2)' }}>
+                  · {formatQty(bagRemainingKg)} {unit} from completion
+                </span>
+              </>
+            ) : completedBags > 0 ? (
+              <span style={{ fontWeight: 800 }}>
+                Bag {completedBags} just locked. Next bag&apos;s waiting.
+              </span>
+            ) : (
+              <span style={{ fontWeight: 800 }}>First bag&apos;s waiting.</span>
+            )}
+          </div>
+          {bagsShortOfMin > 0 && (
+            <span
+              style={{
+                background: 'var(--color-sun)',
+                color: 'var(--color-espresso)',
+                border: '2px solid var(--color-espresso)',
+                borderRadius: 9999,
+                padding: '4px 12px',
+                fontSize: 11,
+                fontWeight: 800,
+                letterSpacing: '0.1em',
+                textTransform: 'uppercase',
+                boxShadow: '2px 2px 0 var(--color-espresso)',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {bagsShortOfMin} more {bagLabel(bagsShortOfMin)} to settle
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* Refund rule footnote — load-bearing copy that sets the buyer
+        * expectation BEFORE they enter the commit form. Always visible
+        * on bag-aware lots, not gated on any commit state. */}
+      {isBagAware && (
+        <p
+          data-testid="bag-refund-footnote"
+          style={{
+            margin: '14px 0 0',
+            fontFamily: 'var(--font-body)',
+            fontSize: 12,
+            fontWeight: 700,
+            letterSpacing: '0.04em',
+            color: 'var(--fg2)',
+            lineHeight: 1.5,
+          }}
+        >
+          <strong style={{ color: 'var(--color-espresso)' }}>Only full bags ship.</strong>{' '}
+          Anything in an open bag at the deadline refunds to your card.
+        </p>
+      )}
 
       {children}
 

--- a/components/campaign/YourCommits.tsx
+++ b/components/campaign/YourCommits.tsx
@@ -1,0 +1,187 @@
+'use client'
+
+import * as React from 'react'
+import { useUnitPreference } from '@/components/unit-provider'
+import { formatUnitWeight } from '@/lib/units'
+import { useBagAssignment } from '@/hooks/use-bag-assignment'
+import { LockedFillingPill } from './locked-filling-pill'
+import type { Commitment } from '@/lib/types'
+
+interface YourCommitsProps {
+  /** The viewing buyer's user ID. */
+  userId: string
+  /** All commitments on the active campaign — used so the bag-aware
+   *  chronological assignment matches the server. The component filters
+   *  down to the viewer's own rows for display. */
+  commitments: Commitment[]
+  /** Bag size for this lot in kg. Caller must verify > 0. */
+  bagSizeKg: number
+  /** Total kg committed to this campaign — used to compute the remaining
+   *  kg in the currently-filling bag. */
+  totalCommittedKg: number
+}
+
+/**
+ * Buyer-facing "Your Commits on This Lot" block.
+ *
+ * Renders one row per commitment the viewer has placed on this campaign,
+ * each with a bag-aware Locked/Filling status pill. The chronological bag
+ * assignment uses every campaign commit so the split here matches what
+ * settlement will produce — earlier commits lock first, later commits
+ * tip into the open bag.
+ *
+ * Returns null when the viewer has no commits, keeping the campaign page
+ * quiet for first-time visitors.
+ */
+export function YourCommits({
+  userId,
+  commitments,
+  bagSizeKg,
+  totalCommittedKg,
+}: YourCommitsProps): React.JSX.Element | null {
+  const { unit } = useUnitPreference()
+
+  const assignments = useBagAssignment(
+    commitments.map((c) => ({
+      id: c.id,
+      quantity_kg: c.quantity_kg,
+      created_at: c.created_at,
+    })),
+    bagSizeKg
+  )
+  const assignmentById = React.useMemo(() => {
+    const map = new Map<string, { locked_kg: number; filling_kg: number }>()
+    for (const a of assignments) {
+      map.set(a.commitment_id, { locked_kg: a.locked_kg, filling_kg: a.filling_kg })
+    }
+    return map
+  }, [assignments])
+
+  const viewerCommits = React.useMemo(
+    () => commitments.filter((c) => c.buyer_id === userId),
+    [commitments, userId]
+  )
+
+  // kg remaining to finish the in-progress bag — derived from the campaign
+  // total. When the total lands exactly on a bag boundary (or is zero),
+  // no bag is filling, so we send `null` to suppress the "from completion"
+  // suffix on the pill.
+  const bagRemainingKg = React.useMemo<number | null>(() => {
+    if (bagSizeKg <= 0) return null
+    const leftover = totalCommittedKg % bagSizeKg
+    if (leftover === 0) return null
+    return bagSizeKg - leftover
+  }, [bagSizeKg, totalCommittedKg])
+
+  if (viewerCommits.length === 0) return null
+
+  return (
+    <section
+      aria-label="Your commits on this lot"
+      style={{
+        background: 'var(--color-cream)',
+        border: '4px solid var(--color-espresso)',
+        borderRadius: 20,
+        padding: '24px 28px 26px',
+        boxShadow: '6px 6px 0 var(--color-espresso)',
+        color: 'var(--color-espresso)',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'baseline',
+          justifyContent: 'space-between',
+          gap: 16,
+          marginBottom: 18,
+          flexWrap: 'wrap',
+        }}
+      >
+        <h2
+          style={{
+            margin: 0,
+            fontFamily: 'var(--font-display)',
+            fontSize: 'clamp(28px, 3vw, 40px)',
+            lineHeight: 0.92,
+            textTransform: 'uppercase',
+            color: 'var(--color-espresso)',
+          }}
+        >
+          Your bags so far.
+        </h2>
+        <p
+          style={{
+            margin: 0,
+            fontFamily: 'var(--font-body)',
+            fontSize: 12,
+            fontWeight: 700,
+            letterSpacing: '0.06em',
+            color: 'var(--fg2)',
+            maxWidth: 360,
+            lineHeight: 1.5,
+          }}
+        >
+          Filling kg refund if the bag doesn&apos;t complete by the deadline.
+        </p>
+      </div>
+
+      <ul style={{ display: 'flex', flexDirection: 'column', gap: 10, listStyle: 'none', padding: 0, margin: 0 }}>
+        {viewerCommits.map((c) => {
+          const split = assignmentById.get(c.id) ?? { locked_kg: 0, filling_kg: 0 }
+          return (
+            <li
+              key={c.id}
+              style={{
+                display: 'flex',
+                flexWrap: 'wrap',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                gap: 12,
+                background: 'var(--color-chalk)',
+                border: '3px solid var(--color-espresso)',
+                borderRadius: 12,
+                padding: '12px 16px',
+                boxShadow: '3px 3px 0 var(--color-espresso)',
+              }}
+            >
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                <span
+                  style={{
+                    fontFamily: 'var(--font-body)',
+                    fontSize: 16,
+                    fontWeight: 800,
+                    fontVariantNumeric: 'tabular-nums',
+                    color: 'var(--color-espresso)',
+                  }}
+                >
+                  {formatUnitWeight(c.quantity_kg, unit, 1)} {unit}
+                </span>
+                <span
+                  style={{
+                    fontFamily: 'var(--font-body)',
+                    fontSize: 10.5,
+                    fontWeight: 800,
+                    letterSpacing: '0.1em',
+                    textTransform: 'uppercase',
+                    color: 'var(--fg2)',
+                  }}
+                >
+                  {new Date(c.created_at).toLocaleDateString(undefined, {
+                    month: 'short',
+                    day: 'numeric',
+                    year: 'numeric',
+                  })}
+                </span>
+              </div>
+              <LockedFillingPill
+                locked_kg={split.locked_kg}
+                filling_kg={split.filling_kg}
+                bag_remaining_kg={split.filling_kg > 0 ? bagRemainingKg : null}
+              />
+            </li>
+          )
+        })}
+      </ul>
+    </section>
+  )
+}

--- a/components/campaign/__tests__/campaign-commit-form-bag-aware.test.tsx
+++ b/components/campaign/__tests__/campaign-commit-form-bag-aware.test.tsx
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+
+/**
+ * Bag-aware CampaignCommitForm — preset chips, split warning, footnote.
+ *
+ * Verifies:
+ *  - Preset chips read as bag multiples / fractions instead of round kg.
+ *  - "Top off" chip is shown when the open bag is partially filled and
+ *    its remaining capacity differs from one full bag.
+ *  - Clicking a preset chip sets the input to that exact display qty.
+ *  - The CommitSplitWarning surfaces when the current qty crosses the
+ *    open bag's remaining capacity, and stays absent when it fits.
+ *  - The bottom footnote calls out partial-bag refunds.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { CampaignCommitForm } from '@/components/campaign/CampaignCommitForm'
+
+vi.mock('@/components/unit-provider', () => ({
+  useUnitPreference: () => ({ unit: 'kg' }),
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ refresh: () => {} }),
+}))
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}))
+
+function renderForm(overrides: Partial<React.ComponentProps<typeof CampaignCommitForm>> = {}) {
+  return render(
+    <CampaignCommitForm
+      lotId="lot-1"
+      activePricePerKg={8}
+      maxKg={500}
+      hubId="hub-1"
+      activeTierName="Trigger"
+      biddersIn={5}
+      bagSizeKg={40}
+      totalCommittedKg={14}
+      {...overrides}
+    />
+  )
+}
+
+describe('CampaignCommitForm — bag-aware (commit flow)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders bag-aware preset chips (½ bag / 1 bag / 2 bags / Top off) instead of round-kg chips', () => {
+    renderForm()
+    expect(screen.getByRole('button', { name: /½ bag/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^1 bag$/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /2 bags/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /top off/i })).toBeInTheDocument()
+    // Legacy round-kg presets shouldn't render in bag-aware mode.
+    expect(screen.queryByRole('button', { name: /^20 kg$/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /^40 kg$/i })).not.toBeInTheDocument()
+  })
+
+  it('omits the "Top off" chip when the open bag is already empty (boundary commit)', () => {
+    // totalCommittedKg = 40 → bagRemainingKg = 40 → identical to one full bag → suppressed.
+    renderForm({ totalCommittedKg: 40 })
+    expect(screen.queryByRole('button', { name: /top off/i })).not.toBeInTheDocument()
+  })
+
+  it('clicking a preset chip updates the quantity input', () => {
+    renderForm()
+    const qtyInput = screen.getByLabelText(/quantity in kilograms/i) as HTMLInputElement
+
+    fireEvent.click(screen.getByRole('button', { name: /^1 bag$/i }))
+    expect(qtyInput.value).toBe('40')
+
+    fireEvent.click(screen.getByRole('button', { name: /2 bags/i }))
+    expect(qtyInput.value).toBe('80')
+  })
+
+  it('CommitSplitWarning is hidden when qty fits inside the open bag', () => {
+    // Open bag has 26 kg remaining (40 - 14). 1 kg pledge fits easily.
+    const { container } = renderForm({ totalCommittedKg: 14 })
+    const qtyInput = screen.getByLabelText(/quantity in kilograms/i) as HTMLInputElement
+
+    fireEvent.change(qtyInput, { target: { value: '1' } })
+
+    expect(container.querySelector('[role="alert"]')).toBeNull()
+  })
+
+  it('CommitSplitWarning surfaces (with refund copy) when qty crosses the bag boundary', () => {
+    // Open bag has 26 kg remaining. 50 kg pledge crosses by 24 kg → warning fires.
+    renderForm({ totalCommittedKg: 14 })
+    const qtyInput = screen.getByLabelText(/quantity in kilograms/i) as HTMLInputElement
+    fireEvent.change(qtyInput, { target: { value: '50' } })
+
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+    expect(screen.getByText(/spans a bag boundary/i)).toBeInTheDocument()
+    // The at-risk row spells out the refund rule.
+    expect(
+      screen.getByTestId('commit-split-warning-atrisk-row').textContent
+    ).toMatch(/refunds if the bag doesn['’]t hit/i)
+  })
+
+  it('footnote text mentions partial-bag refund rule when bag-aware', () => {
+    const { container } = renderForm()
+    expect(container.textContent).toMatch(/only full bags ship/i)
+  })
+
+  it('falls back to legacy round-kg presets when bagSizeKg is null', () => {
+    renderForm({ bagSizeKg: null, totalCommittedKg: 0 })
+    expect(screen.getByRole('button', { name: /^20 kg$/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^40 kg$/i })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /½ bag/i })).not.toBeInTheDocument()
+    // Legacy footnote is shown.
+    const text = document.body.textContent ?? ''
+    expect(text).toMatch(/refund in full if the campaign/i)
+  })
+})

--- a/components/campaign/__tests__/tier-progress-bag-aware.test.tsx
+++ b/components/campaign/__tests__/tier-progress-bag-aware.test.tsx
@@ -1,0 +1,171 @@
+// @vitest-environment jsdom
+
+/**
+ * Bag-aware TierLadder — eyebrow, dividers, status line, refund footnote.
+ *
+ * When `bagSizeKg` is set (>0), the ladder switches from a kg-percent
+ * eyebrow ("You're at Trigger · 25%") to a bag-shaped one
+ * ("3 of 5 bags locked · 14 kg into bag 4"). It also renders bag-boundary
+ * dividers on the bar, a status line under the bar, and a refund-rule
+ * footnote — the load-bearing copy that tells the buyer partial bags get
+ * refunded.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { TierLadder, type CampaignTier } from '@/components/campaign/TierLadder'
+
+vi.mock('@/components/unit-provider', () => ({
+  useUnitPreference: () => ({ unit: 'kg' }),
+}))
+
+const tiers: CampaignTier[] = [
+  { id: 'trigger', name: 'Trigger', threshold: 50, priceKg: 8.0 },
+  { id: 'tier-0', name: 'Full Tier', threshold: 75, priceKg: 7.0 },
+  { id: 'stretch', name: 'Stretch', threshold: 100, priceKg: 6.5 },
+]
+
+describe('TierLadder — bag-aware (criterion 1b)', () => {
+  it('eyebrow shows "X of N bags locked · Y kg into bag M" when filling', () => {
+    // 5 bags total (200 / 40), 2 locked, 14 kg into bag 3.
+    render(
+      <TierLadder
+        tiers={tiers}
+        committedKg={94}
+        stretchKg={200}
+        bagSizeKg={40}
+        minBagsToSucceed={3}
+        hype="calm"
+      />
+    )
+    // Eyebrow text breaks across spans, so use a regex over the live region.
+    expect(
+      screen.getByText(/2 of 5 bags locked/i)
+    ).toBeInTheDocument()
+    expect(screen.getByText(/into bag 3/i)).toBeInTheDocument()
+  })
+
+  it('eyebrow drops the "into bag M" suffix when the total lands on a bag boundary', () => {
+    render(
+      <TierLadder
+        tiers={tiers}
+        committedKg={80}
+        stretchKg={200}
+        bagSizeKg={40}
+        minBagsToSucceed={3}
+        hype="calm"
+      />
+    )
+    // 80 / 40 = 2 bags, no partial → no "into bag" suffix.
+    expect(screen.getByText(/2 of 5 bags locked/i)).toBeInTheDocument()
+    expect(screen.queryByText(/into bag/i)).not.toBeInTheDocument()
+  })
+
+  it('renders bag-boundary dividers on the progress bar when bag-aware', () => {
+    const { container } = render(
+      <TierLadder
+        tiers={tiers}
+        committedKg={94}
+        stretchKg={200}
+        bagSizeKg={40}
+        hype="calm"
+      />
+    )
+    const dividers = container.querySelector('[data-testid="bag-dividers"]')
+    expect(dividers).not.toBeNull()
+    // 5 bags → 4 dividers (between segments).
+    expect(dividers!.children.length).toBe(4)
+  })
+
+  it('does not render bag dividers for legacy (null bagSizeKg) lots', () => {
+    const { container } = render(
+      <TierLadder
+        tiers={tiers}
+        committedKg={94}
+        stretchKg={200}
+        hype="calm"
+      />
+    )
+    expect(
+      container.querySelector('[data-testid="bag-dividers"]')
+    ).toBeNull()
+  })
+
+  it('renders the bag status line with "Bag N" + remaining-to-completion when filling', () => {
+    render(
+      <TierLadder
+        tiers={tiers}
+        committedKg={94}
+        stretchKg={200}
+        bagSizeKg={40}
+        hype="calm"
+      />
+    )
+    const line = screen.getByTestId('bag-status-line')
+    // Bag 3 filling, 14 kg in, 26 kg from completion.
+    expect(line.textContent).toMatch(/Bag 3/)
+    expect(line.textContent).toMatch(/14\s*kg\s*\/\s*40\s*kg/)
+    expect(line.textContent).toMatch(/26\s*kg\s*from\s*completion/i)
+  })
+
+  it('renders "First bag\'s waiting" when nothing has been committed', () => {
+    render(
+      <TierLadder
+        tiers={tiers}
+        committedKg={0}
+        stretchKg={200}
+        bagSizeKg={40}
+        hype="calm"
+      />
+    )
+    expect(
+      screen.getByTestId('bag-status-line').textContent
+    ).toMatch(/First bag.+waiting/i)
+  })
+
+  it('renders the "more bags to settle" chip when below minBagsToSucceed', () => {
+    render(
+      <TierLadder
+        tiers={tiers}
+        committedKg={40}
+        stretchKg={200}
+        bagSizeKg={40}
+        minBagsToSucceed={3}
+        hype="calm"
+      />
+    )
+    // 1 locked, needs 3 — 2 more to settle.
+    expect(
+      screen.getByText(/2 more bags to settle/i)
+    ).toBeInTheDocument()
+  })
+
+  it('renders the refund-rule footnote (Only full bags ship.)', () => {
+    render(
+      <TierLadder
+        tiers={tiers}
+        committedKg={94}
+        stretchKg={200}
+        bagSizeKg={40}
+        hype="calm"
+      />
+    )
+    const footnote = screen.getByTestId('bag-refund-footnote')
+    expect(footnote.textContent).toMatch(/only full bags ship/i)
+    expect(footnote.textContent).toMatch(/refunds to your card/i)
+  })
+
+  it('does not render the refund footnote for legacy (null bagSizeKg) lots', () => {
+    render(
+      <TierLadder
+        tiers={tiers}
+        committedKg={94}
+        stretchKg={200}
+        hype="calm"
+      />
+    )
+    expect(
+      screen.queryByTestId('bag-refund-footnote')
+    ).not.toBeInTheDocument()
+  })
+})

--- a/components/campaign/__tests__/your-commits.test.tsx
+++ b/components/campaign/__tests__/your-commits.test.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+
+/**
+ * YourCommits — the bag-aware "Your bags so far" block on the new
+ * buyer campaign page.
+ *
+ * Verifies:
+ *  - Renders nothing when the viewer has no commits on the campaign.
+ *  - Renders one row per viewer commit, filtered by `userId`.
+ *  - Each row shows the buyer's bag-aware Locked/Filling split (via the
+ *    underlying LockedFillingPill), driven by the chronological bag
+ *    assignment over ALL campaign commits (not just the viewer's).
+ *  - The header carries the refund-rule reminder.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { YourCommits } from '@/components/campaign/YourCommits'
+import type { Commitment } from '@/lib/types'
+
+vi.mock('@/components/unit-provider', () => ({
+  useUnitPreference: () => ({ unit: 'kg' }),
+}))
+
+function commit(
+  id: string,
+  buyer_id: string,
+  quantity_kg: number,
+  created_at: string
+): Commitment {
+  return {
+    id,
+    buyer_id,
+    quantity_kg,
+    created_at,
+  } as unknown as Commitment
+}
+
+describe('YourCommits', () => {
+  it('returns null when the viewer has no commits on the campaign', () => {
+    const { container } = render(
+      <YourCommits
+        userId="viewer-1"
+        commitments={[]}
+        bagSizeKg={40}
+        totalCommittedKg={0}
+      />
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders only the viewer\'s commitments, not other buyers\'', () => {
+    const commits = [
+      commit('c-other', 'other-buyer', 60, '2026-05-01T00:00:00Z'),
+      commit('c-mine-1', 'viewer-1', 40, '2026-05-02T00:00:00Z'),
+      commit('c-mine-2', 'viewer-1', 20, '2026-05-03T00:00:00Z'),
+    ]
+    render(
+      <YourCommits
+        userId="viewer-1"
+        commitments={commits}
+        bagSizeKg={40}
+        totalCommittedKg={120}
+      />
+    )
+    const items = screen.getAllByRole('listitem')
+    expect(items.length).toBe(2)
+    // The "60 kg" row from the other buyer must NOT render.
+    expect(screen.queryByText(/60\s*kg/i)).not.toBeInTheDocument()
+  })
+
+  it('shows the bag-aware split derived from full-campaign chronological order', () => {
+    // 40 kg bag size. Three commits in order: 60 (other), 40 (me), 20 (me).
+    // Total = 120 kg → 3 bags complete. Other locks 40 + 20 split into bag 1 + bag 2.
+    // My 40 kg sits in bag 2 (20) + bag 3 (20) — both locked → 40 locked, 0 filling.
+    // My 20 kg sits in bag 3 (20) — locked → 20 locked, 0 filling.
+    const commits = [
+      commit('c-other', 'other-buyer', 60, '2026-05-01T00:00:00Z'),
+      commit('c-mine-1', 'viewer-1', 40, '2026-05-02T00:00:00Z'),
+      commit('c-mine-2', 'viewer-1', 20, '2026-05-03T00:00:00Z'),
+    ]
+    const { container } = render(
+      <YourCommits
+        userId="viewer-1"
+        commitments={commits}
+        bagSizeKg={40}
+        totalCommittedKg={120}
+      />
+    )
+    // No "Filling" pill on any list item — all viewer kg are locked at this total.
+    // (The header copy mentions "Filling kg refund..." which is intentional
+    // refund-rule reminder, not a status pill, so we scope to the list rows.)
+    const items = Array.from(container.querySelectorAll('li'))
+    for (const li of items) {
+      expect((li.textContent ?? '').toLowerCase()).not.toContain('filling')
+    }
+    // Two "Locked" pills (one per row).
+    const lockedPills = items.flatMap((li) =>
+      Array.from(li.querySelectorAll('[aria-label*="locked" i]'))
+    )
+    expect(lockedPills.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('surfaces the partial-bag refund rule in the section header', () => {
+    const commits = [commit('c-1', 'viewer-1', 14, '2026-05-01T00:00:00Z')]
+    render(
+      <YourCommits
+        userId="viewer-1"
+        commitments={commits}
+        bagSizeKg={40}
+        totalCommittedKg={14}
+      />
+    )
+    expect(
+      screen.getByText(/refund if the bag doesn['’]t complete/i)
+    ).toBeInTheDocument()
+  })
+})

--- a/components/campaign/commit-split-warning.tsx
+++ b/components/campaign/commit-split-warning.tsx
@@ -204,11 +204,11 @@ export function CommitSplitWarning({
             >
               {formatUnitWeight(atRiskKg, unit, 1)} {unit}
             </strong>
-            → starts a new bag (at-risk until the bag hits{" "}
+            → starts a new bag — refunds if the bag doesn&apos;t hit{" "}
             <span style={{ fontVariantNumeric: "tabular-nums", fontWeight: 900 }}>
               {formatUnitWeight(bag_size_kg, unit, 1)} {unit}
             </span>
-            )
+            {" "}by the deadline
           </span>
           <span
             style={{

--- a/components/campaign/locked-filling-pill.tsx
+++ b/components/campaign/locked-filling-pill.tsx
@@ -88,8 +88,8 @@ export function LockedFillingPill({
         <span
           aria-label={
             bag_remaining_kg != null && bag_remaining_kg > 0
-              ? `${formatUnitWeight(filling_kg, unit, 1)} ${unit} filling, ${formatUnitWeight(bag_remaining_kg, unit, 1)} ${unit} from completion`
-              : `${formatUnitWeight(filling_kg, unit, 1)} ${unit} filling`
+              ? `${formatUnitWeight(filling_kg, unit, 1)} ${unit} filling — refunds if the bag doesn't complete; ${formatUnitWeight(bag_remaining_kg, unit, 1)} ${unit} from completion`
+              : `${formatUnitWeight(filling_kg, unit, 1)} ${unit} filling — refunds if the bag doesn't complete`
           }
           style={{
             display: "inline-flex",


### PR DESCRIPTION
The new buyer-side campaign page (used at /dashboard/buyer/lot/[id]) was
the only buyer-visible surface and rendered no bag info — no "bags
locked / next bag" status, no per-commit locked/filling breakdown, and
no warning when a pledge crossed a bag boundary. Tier chips also keyed
off kg-percent thresholds while settlement keys off bag indices.

This wires the existing bag-aware components (BagProgressBar logic,
LockedFillingPill, CommitSplitWarning) into CampaignPage so the buyer
sees the same bag-shaped reality settlement uses.

Buyer-visible changes:
- TierLadder eyebrow → "X of N bags locked · Y kg into bag M"
- Progress bar grows vertical espresso dividers at every bag boundary
- New status line under the bar shows the in-progress bag's fill /
  remaining-to-completion, plus a "needs N more to settle" chip
- New refund footnote on the ladder: "Only full bags ship. Anything in
  an open bag at the deadline refunds to your card."
- New "Your bags so far" section lists the viewer's commits with
  Locked / Filling pills, computed via the same chronological bag
  assignment the server uses (so display matches what charges)
- CampaignCommitForm gets bag-aware preset chips (½ bag / 1 bag /
  2 bags / Top off) and mounts CommitSplitWarning when a pledge
  crosses a bag boundary
- At-risk and Filling copy now explicitly call out the refund rule
  (visible text + aria-label)

Backend alignment:
- buildTierContext now positions Trigger and tier flag chips by bag
  index (min_bags × bag_size_kg / total_quantity_kg) so the visible
  ladder matches the bag-shaped settlement math
- POST /api/commitments resolves seller_price_per_kg via
  computeCompletedBagsAndPrice for bag-aware lots — same algorithm
  settlement uses, so a buyer's quoted price can't drift from their
  charged price when min_quantity_kg and min_bags disagree
- The buyer page route fetches a viewer-scoped commitments list
  (filtered to the viewer + payment_status != pending_setup) for
  YourCommits, leaving the social-proof query untouched

Commitments stay kg/lb-shaped — the buyer can still pledge any kg
amount; bag presets are nudges, not enforcement.

Tests:
- New: tier-progress-bag-aware.test.tsx, your-commits.test.tsx,
  campaign-commit-form-bag-aware.test.tsx
- Extended commitments-campaign.test.ts with a bag-aware tier-pricing
  case where min_bags and min_quantity_kg disagree (proves the
  bag-aware resolver is the active path)

https://claude.ai/code/session_01XaRFG1oj5p6aYMmBiQELEv