### PR TITLE
fix(tier-progress): bag-aware volume tier display across buyer, seller, hub surfaces

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -197,7 +197,7 @@ Fetch all lots where:
 | Hub | 2% of gross (gross = seller price × 1.10 platform markup) |
 | Platform | Gross − Seller − Hub |
 
-Volume tiers in `pricing_tiers` unlock lower prices per kg as total committed quantity grows.
+Volume tiers in `pricing_tiers` unlock lower prices per kg as the number of completed bags grows. A tier applies when `floor(total_committed_kg / bag_size_kg)` reaches the tier's `min_bags`. The legacy `min_quantity_kg` column is nullable (migrations #36–#37) and only used for unconverted legacy lots; new lots store thresholds in `min_bags`. Buyer, seller, and hub UI resolve "current price" and "X to next tier" through `lib/tier-progress.ts`, which mirrors the bag-aware rule used at settlement (`lib/settle-bag-pricing.ts`).
 
 ### Stripe Connect Architecture
 

--- a/app/api/cron/price-drops/route.ts
+++ b/app/api/cron/price-drops/route.ts
@@ -1,6 +1,6 @@
 import { createAdminClient } from "@/lib/supabase/admin";
 import { sendPriceDropInvestorEmail, sendPriceDropNonInvestorEmail } from "@/lib/email";
-import { getFinalPricePerKg } from "@/lib/payments/settlement-logic";
+import { getTierProgress } from "@/lib/tier-progress";
 import { authorizeCronRequest } from "@/lib/auth/cron-route";
 import { NextResponse } from "next/server";
 
@@ -53,10 +53,16 @@ async function sendPriceDropNotifications(request: Request) {
     );
   }
 
-  // Fetch active lots that have pricing tiers (volume discounts)
+  // Fetch active lots that have pricing tiers (volume discounts).
+  // bag_size_kg is needed so getTierProgress can resolve bag-aware tiers
+  // the same way settlement does (lib/settle-bag-pricing.ts) — without it,
+  // we'd fire price-drop notifications at weight thresholds even though
+  // settlement only credits the tier at completed-bag boundaries.
   const { data: lots, error: lotsError } = await admin
     .from("lots")
-    .select("id, title, price_per_kg, currency, committed_quantity_kg, commitment_deadline")
+    .select(
+      "id, title, price_per_kg, currency, committed_quantity_kg, commitment_deadline, bag_size_kg"
+    )
     .in("status", ["active", "fully_committed"]);
 
   if (lotsError) {
@@ -68,17 +74,23 @@ async function sendPriceDropNotifications(request: Request) {
   for (const lot of lots || []) {
     const { data: tiers } = await admin
       .from("pricing_tiers")
-      .select("min_quantity_kg, price_per_kg")
-      .eq("lot_id", lot.id)
-      .order("min_quantity_kg", { ascending: false });
+      .select("min_bags, min_quantity_kg, price_per_kg")
+      .eq("lot_id", lot.id);
 
     if (!tiers || tiers.length === 0) continue;
 
-    const effectivePrice = getFinalPricePerKg(
-      lot.price_per_kg,
-      lot.committed_quantity_kg,
-      tiers
-    );
+    const effectivePrice = getTierProgress(
+      {
+        committed_quantity_kg: Number(lot.committed_quantity_kg || 0),
+        price_per_kg: Number(lot.price_per_kg || 0),
+        bag_size_kg: lot.bag_size_kg ?? null,
+      },
+      tiers.map((t) => ({
+        min_bags: t.min_bags ?? null,
+        min_quantity_kg: t.min_quantity_kg === null ? null : Number(t.min_quantity_kg),
+        price_per_kg: Number(t.price_per_kg),
+      }))
+    ).currentPricePerKg;
 
     // No tier crossed — base price still applies
     if (effectivePrice >= lot.price_per_kg) continue;

--- a/app/browse/page.tsx
+++ b/app/browse/page.tsx
@@ -3,6 +3,7 @@ import { SiteHeader } from "@/components/site-header";
 import { UnitPriceText, UnitWeightText } from "@/components/unit-value";
 import { Clock, TrendingDown } from "lucide-react";
 import Link from "next/link";
+import { getTierProgress } from "@/lib/tier-progress";
 
 const marqueeItems = [
   "Specialty green coffee",
@@ -35,8 +36,7 @@ export default async function BrowsePage() {
     const { data: allTiers } = await supabase
       .from("pricing_tiers")
       .select("*")
-      .in("lot_id", lotIds)
-      .order("min_quantity_kg", { ascending: true });
+      .in("lot_id", lotIds);
     for (const tier of allTiers || []) {
       if (!tiersMap[tier.lot_id]) tiersMap[tier.lot_id] = [];
       tiersMap[tier.lot_id].push(tier);
@@ -135,17 +135,16 @@ export default async function BrowsePage() {
                           ? Math.min(...tiers.map((t: any) => t.price_per_kg))
                           : lot.price_per_kg;
 
-                      let currentPrice = lot.price_per_kg;
-                      const sortedDesc = [...tiers].sort(
-                        (a: any, b: any) =>
-                          b.min_quantity_kg - a.min_quantity_kg
-                      );
-                      for (const t of sortedDesc) {
-                        if (lot.committed_quantity_kg >= t.min_quantity_kg) {
-                          currentPrice = t.price_per_kg;
-                          break;
-                        }
-                      }
+                      const currentPrice = getTierProgress(
+                        {
+                          committed_quantity_kg: Number(
+                            lot.committed_quantity_kg
+                          ),
+                          price_per_kg: Number(lot.price_per_kg),
+                          bag_size_kg: lot.bag_size_kg ?? null,
+                        },
+                        tiers
+                      ).currentPricePerKg;
 
                       // Bag-aware lots: progress is measured in completed
                       // bags toward `min_bags_to_succeed`. Legacy lots keep

--- a/app/dashboard/buyer/browse/page.tsx
+++ b/app/dashboard/buyer/browse/page.tsx
@@ -6,6 +6,7 @@ import { Progress } from "@/components/ui/progress";
 import { Coffee, TrendingDown, Clock } from "lucide-react";
 import Link from "next/link";
 import { UnitPriceText, UnitWeightText } from "@/components/unit-value";
+import { getTierProgress } from "@/lib/tier-progress";
 
 export default async function BuyerBrowsePage() {
   const supabase = await createClient();
@@ -63,8 +64,7 @@ export default async function BuyerBrowsePage() {
     const { data: allTiers } = await supabase
       .from("pricing_tiers")
       .select("*")
-      .in("lot_id", lotIds)
-      .order("min_quantity_kg", { ascending: true });
+      .in("lot_id", lotIds);
     for (const tier of allTiers || []) {
       if (!tiersMap[tier.lot_id]) tiersMap[tier.lot_id] = [];
       tiersMap[tier.lot_id].push(tier);
@@ -171,18 +171,17 @@ export default async function BuyerBrowsePage() {
                       ? Math.min(...tiers.map((t: any) => t.price_per_kg))
                       : lot.price_per_kg;
 
-                  // Current active price
-                  let currentPrice = lot.price_per_kg;
-                  const sortedDesc = [...tiers].sort(
-                    (a: any, b: any) =>
-                      b.min_quantity_kg - a.min_quantity_kg
-                  );
-                  for (const t of sortedDesc) {
-                    if (lot.committed_quantity_kg >= t.min_quantity_kg) {
-                      currentPrice = t.price_per_kg;
-                      break;
-                    }
-                  }
+                  // Current active price — bag-aware via shared helper.
+                  const currentPrice = getTierProgress(
+                    {
+                      committed_quantity_kg: Number(
+                        lot.committed_quantity_kg
+                      ),
+                      price_per_kg: Number(lot.price_per_kg),
+                      bag_size_kg: lot.bag_size_kg ?? null,
+                    },
+                    tiers
+                  ).currentPricePerKg;
 
                   const hasDeadline = !!lot.campaign_deadline;
                   const deadlineDate = hasDeadline

--- a/app/dashboard/buyer/commitments/page.tsx
+++ b/app/dashboard/buyer/commitments/page.tsx
@@ -176,18 +176,21 @@ export default async function BuyerCommitmentsPage({
     }
   }
 
-  let tiersByLotId: Record<string, { min_quantity_kg: number; price_per_kg: number }[]> = {};
+  let tiersByLotId: Record<
+    string,
+    { min_bags: number | null; min_quantity_kg: number | null; price_per_kg: number }[]
+  > = {};
   if (lotIds.length > 0) {
     const { data: pricingTiers } = await supabase
       .from("pricing_tiers")
-      .select("lot_id, min_quantity_kg, price_per_kg")
-      .in("lot_id", lotIds)
-      .order("min_quantity_kg", { ascending: true });
+      .select("lot_id, min_bags, min_quantity_kg, price_per_kg")
+      .in("lot_id", lotIds);
 
     for (const tier of pricingTiers || []) {
       if (!tiersByLotId[tier.lot_id]) tiersByLotId[tier.lot_id] = [];
       tiersByLotId[tier.lot_id].push({
-        min_quantity_kg: Number(tier.min_quantity_kg),
+        min_bags: tier.min_bags ?? null,
+        min_quantity_kg: tier.min_quantity_kg === null ? null : Number(tier.min_quantity_kg),
         price_per_kg: Number(tier.price_per_kg),
       });
     }

--- a/app/dashboard/buyer/page.tsx
+++ b/app/dashboard/buyer/page.tsx
@@ -9,6 +9,7 @@ import { FeaturedRoastHero } from "@/components/featured-roast-hero";
 import { InviteShareCard } from "@/components/referrals/InviteShareCard";
 import { MyReferralsList } from "@/components/referrals/MyReferralsList";
 import { CreditBalanceCard } from "@/components/referrals/CreditBalanceCard";
+import { getTierProgress } from "@/lib/tier-progress";
 
 function getHubName(memberships: any[], hubId: string) {
   const membership = memberships.find((m: any) => m.hub_id === hubId);
@@ -128,9 +129,8 @@ export default async function BuyerOverview({
   if (allLotIds.length > 0) {
     const { data: allTiers } = await supabase
       .from("pricing_tiers")
-      .select("lot_id, min_quantity_kg, price_per_kg")
-      .in("lot_id", allLotIds)
-      .order("min_quantity_kg", { ascending: true });
+      .select("lot_id, min_bags, min_quantity_kg, price_per_kg")
+      .in("lot_id", allLotIds);
 
     for (const tier of allTiers || []) {
       if (!tiersMap[tier.lot_id]) tiersMap[tier.lot_id] = [];
@@ -177,73 +177,78 @@ export default async function BuyerOverview({
     const tiers = tiersMap[lot.id] || [];
     const committed = Number(lot.committed_quantity_kg || 0);
     const minCommitment = Number(lot.min_commitment_kg || 0);
-
-    // Bag-aware lots: surface progress in completed-bag terms so the buyer
-    // sees the same units the campaign settles in. Legacy lots stay kg-based.
-    const bagSizeKg =
-      lot.bag_size_kg != null && Number(lot.bag_size_kg) > 0
-        ? Number(lot.bag_size_kg)
-        : null;
     const minBagsToSucceed = Number(lot.min_bags_to_succeed || 0);
-    const isBagAware = bagSizeKg !== null;
-    const completedBags = isBagAware
-      ? Math.floor(committed / bagSizeKg)
-      : 0;
 
-    const currentPrice = (() => {
-      if (tiers.length === 0) return Number(lot.price_per_kg);
-      const sortedDesc = [...tiers].sort(
-        (a: any, b: any) => b.min_quantity_kg - a.min_quantity_kg
-      );
-      for (const t of sortedDesc) {
-        if (committed >= t.min_quantity_kg) return Number(t.price_per_kg);
-      }
-      return Number(lot.price_per_kg);
-    })();
+    const progress = getTierProgress(
+      {
+        committed_quantity_kg: committed,
+        price_per_kg: Number(lot.price_per_kg),
+        bag_size_kg: lot.bag_size_kg ?? null,
+      },
+      tiers
+    );
+
+    const { isBagAware, bagSize, completedBags, currentPricePerKg, nextTier } = progress;
+    const currentPrice = currentPricePerKg;
 
     const lowestPrice =
       tiers.length > 0
         ? Math.min(...tiers.map((t: any) => Number(t.price_per_kg)))
         : Number(lot.price_per_kg);
 
-    const nextTier = tiers.find((t: any) => committed < t.min_quantity_kg) || null;
+    // Next milestone: for bag-aware lots we phrase progress in bags; legacy
+    // lots stay kg-based. "Trigger campaign" still gates on minCommitment kg
+    // (or min_bags_to_succeed when bag-aware) before any tier unlocks.
+    const triggerBagsRemaining =
+      isBagAware && minBagsToSucceed > 0
+        ? Math.max(0, minBagsToSucceed - completedBags)
+        : null;
+    const triggerNotMet =
+      isBagAware && minBagsToSucceed > 0
+        ? completedBags < minBagsToSucceed
+        : committed < minCommitment;
 
-    const nextMilestone =
-      committed < minCommitment
+    const nextMilestone = triggerNotMet
+      ? {
+          label: "Trigger campaign",
+          targetKg: isBagAware && bagSize ? minBagsToSucceed * bagSize : minCommitment,
+          remainingKg: Math.max(0, minCommitment - committed),
+          remainingBags: triggerBagsRemaining,
+          nextPricePerKg: null as number | null,
+        }
+      : nextTier
         ? {
-            label: "Trigger campaign",
-            targetKg: minCommitment,
-            remainingKg: Math.max(0, minCommitment - committed),
+            label: "Next tier",
+            targetKg: nextTier.threshold_kg,
+            remainingKg: Math.max(0, nextTier.threshold_kg - committed),
             remainingBags:
-              isBagAware && minBagsToSucceed > 0
-                ? Math.max(0, minBagsToSucceed - completedBags)
+              isBagAware && nextTier.min_bags !== null
+                ? Math.max(0, nextTier.min_bags - completedBags)
                 : null,
-            nextPricePerKg: null as number | null,
+            nextPricePerKg: nextTier.price_per_kg,
           }
-        : nextTier
-          ? {
-              label: "Next tier",
-              targetKg: Number(nextTier.min_quantity_kg),
-              remainingKg: Math.max(0, Number(nextTier.min_quantity_kg) - committed),
-              remainingBags: null as number | null,
-              nextPricePerKg: Number(nextTier.price_per_kg),
-            }
-          : {
-              label: "Best tier reached",
-              targetKg: committed,
-              remainingKg: 0,
-              remainingBags: null as number | null,
-              nextPricePerKg: null as number | null,
-            };
+        : {
+            label: "Best tier reached",
+            targetKg: committed,
+            remainingKg: 0,
+            remainingBags: null as number | null,
+            nextPricePerKg: null as number | null,
+          };
 
-    const milestoneTargets = [minCommitment, ...tiers.map((t: any) => Number(t.min_quantity_kg))]
-      .filter((v) => Number.isFinite(v) && v > 0)
-      .sort((a, b) => a - b);
+    // Progress bar scale: bag-aware lots use bag thresholds; legacy use kg.
+    const milestoneTargets = isBagAware
+      ? [minBagsToSucceed, ...progress.sortedTiers.map((t) => t.min_bags ?? 0)]
+          .filter((v) => Number.isFinite(v) && v > 0)
+          .sort((a, b) => a - b)
+      : [minCommitment, ...progress.sortedTiers.map((t) => t.threshold_kg)]
+          .filter((v) => Number.isFinite(v) && v > 0)
+          .sort((a, b) => a - b);
     const uniqueTargets = Array.from(new Set(milestoneTargets));
-    const nextTarget = uniqueTargets.find((target) => committed < target) || null;
+    const currentValue = isBagAware ? completedBags : committed;
+    const nextTarget = uniqueTargets.find((target) => currentValue < target) || null;
     const previousTarget =
       uniqueTargets
-        .filter((target) => target <= committed)
+        .filter((target) => target <= currentValue)
         .sort((a, b) => b - a)[0] || 0;
 
     const progressPct = nextTarget
@@ -251,7 +256,7 @@ export default async function BuyerOverview({
           0,
           Math.min(
             100,
-            Math.round(((committed - previousTarget) / (nextTarget - previousTarget)) * 100)
+            Math.round(((currentValue - previousTarget) / (nextTarget - previousTarget)) * 100)
           )
         )
       : 100;
@@ -265,9 +270,10 @@ export default async function BuyerOverview({
       lowestPrice,
       nextMilestone,
       progressPct,
-      progressTextTarget: nextTarget || previousTarget,
+      progressCurrent: currentValue,
+      progressTarget: nextTarget || previousTarget,
       isBagAware,
-      bagSizeKg,
+      bagSizeKg: bagSize,
       completedBags,
       minBagsToSucceed,
       invested: investedLotIds.has(lot.id),
@@ -550,8 +556,16 @@ export default async function BuyerOverview({
                               Commitment Progress
                             </span>
                             <span style={{ color: "#7A6A50", fontSize: 11 }}>
-                              <UnitWeightText kg={Number(card.lot.committed_quantity_kg)} /> /{" "}
-                              <UnitWeightText kg={Number(card.progressTextTarget)} />
+                              {card.isBagAware ? (
+                                <>
+                                  {card.progressCurrent.toLocaleString()} / {Number(card.progressTarget).toLocaleString()} bags
+                                </>
+                              ) : (
+                                <>
+                                  <UnitWeightText kg={Number(card.lot.committed_quantity_kg)} /> /{" "}
+                                  <UnitWeightText kg={Number(card.progressTarget)} />
+                                </>
+                              )}
                             </span>
                           </div>
                           <div
@@ -604,7 +618,11 @@ export default async function BuyerOverview({
                               </span>
                             )}
                           </p>
-                          {card.nextMilestone.remainingKg > 0 ? (
+                          {card.isBagAware && card.nextMilestone.remainingBags !== null && card.nextMilestone.remainingBags > 0 ? (
+                            <p className="mt-1 text-xs" style={{ color: "#7A6A50" }}>
+                              {card.nextMilestone.remainingBags} bag{card.nextMilestone.remainingBags === 1 ? "" : "s"} needed
+                            </p>
+                          ) : !card.isBagAware && card.nextMilestone.remainingKg > 0 ? (
                             <p className="mt-1 text-xs" style={{ color: "#7A6A50" }}>
                               <UnitWeightText kg={card.nextMilestone.remainingKg} /> needed
                             </p>

--- a/app/dashboard/seller/commitments/[lotId]/page.tsx
+++ b/app/dashboard/seller/commitments/[lotId]/page.tsx
@@ -6,22 +6,7 @@ import { Card, CardContent } from "@merninos/ui";
 import { Badge } from "@merninos/ui";
 import { UnitWeightText, UnitPriceText } from "@/components/unit-value";
 import { SellerCampaignPreview } from "@/components/seller-campaign-preview";
-
-function getCurrentLotPrice(
-  lot: { committed_quantity_kg: number; price_per_kg: number },
-  tiers: { min_quantity_kg: number; price_per_kg: number }[]
-): number {
-  const basePrice = Number(lot.price_per_kg || 0);
-  if (tiers.length === 0) return basePrice;
-  const committedQty = Number(lot.committed_quantity_kg || 0);
-  const sortedDesc = [...tiers].sort(
-    (a, b) => Number(b.min_quantity_kg) - Number(a.min_quantity_kg)
-  );
-  for (const tier of sortedDesc) {
-    if (committedQty >= Number(tier.min_quantity_kg)) return Number(tier.price_per_kg);
-  }
-  return basePrice;
-}
+import { getTierProgress } from "@/lib/tier-progress";
 
 const statusBadge: Record<
   "Open / At Risk" | "Open / Guaranteed" | "Successful",
@@ -82,13 +67,23 @@ export default async function SellerLotCommitmentsPage({
       .maybeSingle(),
     supabase
       .from("pricing_tiers")
-      .select("lot_id, min_quantity_kg, price_per_kg")
-      .eq("lot_id", lotId)
-      .order("min_quantity_kg", { ascending: true }),
+      .select("lot_id, min_bags, min_quantity_kg, price_per_kg")
+      .eq("lot_id", lotId),
   ]);
 
   const tiers = pricingTiers || [];
-  const currentPricePerKg = getCurrentLotPrice(lot, tiers);
+  const currentPricePerKg = getTierProgress(
+    {
+      committed_quantity_kg: Number(lot.committed_quantity_kg || 0),
+      price_per_kg: Number(lot.price_per_kg || 0),
+      bag_size_kg: lot.bag_size_kg ?? null,
+    },
+    tiers.map((t) => ({
+      min_bags: t.min_bags ?? null,
+      min_quantity_kg: t.min_quantity_kg === null ? null : Number(t.min_quantity_kg),
+      price_per_kg: Number(t.price_per_kg),
+    }))
+  ).currentPricePerKg;
 
   let commitments: {
     id: string;

--- a/app/dashboard/seller/commitments/page.tsx
+++ b/app/dashboard/seller/commitments/page.tsx
@@ -1,22 +1,7 @@
 import { createClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
 import { SellerCommitmentsClient, type LotCampaignCard } from "@/components/seller-commitments-client";
-
-function getCurrentLotPrice(
-  lot: { committed_quantity_kg: number; price_per_kg: number },
-  tiers: { min_quantity_kg: number; price_per_kg: number }[]
-): number {
-  const basePrice = Number(lot.price_per_kg || 0);
-  if (tiers.length === 0) return basePrice;
-  const committedQty = Number(lot.committed_quantity_kg || 0);
-  const sortedDesc = [...tiers].sort(
-    (a, b) => Number(b.min_quantity_kg) - Number(a.min_quantity_kg)
-  );
-  for (const tier of sortedDesc) {
-    if (committedQty >= Number(tier.min_quantity_kg)) return Number(tier.price_per_kg);
-  }
-  return basePrice;
-}
+import { getTierProgress } from "@/lib/tier-progress";
 
 export default async function SellerCommitmentsPage() {
   const supabase = await createClient();
@@ -58,9 +43,8 @@ export default async function SellerCommitmentsPage() {
         : Promise.resolve({ data: [] }),
       supabase
         .from("pricing_tiers")
-        .select("lot_id, min_quantity_kg, price_per_kg")
-        .in("lot_id", lotIds)
-        .order("min_quantity_kg", { ascending: true }),
+        .select("lot_id, min_bags, min_quantity_kg, price_per_kg")
+        .in("lot_id", lotIds),
     ]);
 
     const commitmentsByCampaignId: Record<string, { quantity_kg: number }[]> = {};
@@ -70,10 +54,17 @@ export default async function SellerCommitmentsPage() {
       commitmentsByCampaignId[c.campaign_id].push(c);
     }
 
-    const tiersByLotId: Record<string, { min_quantity_kg: number; price_per_kg: number }[]> = {};
+    const tiersByLotId: Record<
+      string,
+      { min_bags: number | null; min_quantity_kg: number | null; price_per_kg: number }[]
+    > = {};
     for (const t of pricingTiers || []) {
       if (!tiersByLotId[t.lot_id]) tiersByLotId[t.lot_id] = [];
-      tiersByLotId[t.lot_id].push(t);
+      tiersByLotId[t.lot_id].push({
+        min_bags: t.min_bags ?? null,
+        min_quantity_kg: t.min_quantity_kg === null ? null : Number(t.min_quantity_kg),
+        price_per_kg: Number(t.price_per_kg),
+      });
     }
 
     // One card per campaign (one active/settled campaign per lot at a time)
@@ -90,7 +81,14 @@ export default async function SellerCommitmentsPage() {
       );
 
       const tiers = tiersByLotId[lot.id] || [];
-      const currentPricePerKg = getCurrentLotPrice(lot, tiers);
+      const currentPricePerKg = getTierProgress(
+        {
+          committed_quantity_kg: Number(lot.committed_quantity_kg || 0),
+          price_per_kg: Number(lot.price_per_kg || 0),
+          bag_size_kg: lot.bag_size_kg ?? null,
+        },
+        tiers
+      ).currentPricePerKg;
 
       const hub = (campaign.hub as unknown) as { id: string; name: string } | null;
 

--- a/app/dashboard/seller/lots/[id]/backfill-bag-config/page.tsx
+++ b/app/dashboard/seller/lots/[id]/backfill-bag-config/page.tsx
@@ -10,7 +10,7 @@ import {
 } from "@merninos/ui";
 import { Button } from "@merninos/ui";
 import { ArrowLeft } from "lucide-react";
-import type { Lot, PricingTier } from "@/lib/types";
+import type { Lot } from "@/lib/types";
 import { BackfillBagConfigForm } from "./backfill-bag-config-form";
 
 // Server component (Task 3.6): auth-gate the route, fetch the lot + tiers, and
@@ -142,13 +142,13 @@ export default async function BackfillBagConfigPage({
         existingMinBagsToSucceed={(lot as Lot).min_bags_to_succeed}
         hasActiveCampaign={Boolean(activeCampaign)}
         tiers={
-          (tiers ?? []).map((t) => ({
-            id: t.id,
-            min_quantity_kg: t.min_quantity_kg,
-            price_per_kg: t.price_per_kg,
-          })) as Array<
-            Pick<PricingTier, "id" | "min_quantity_kg" | "price_per_kg">
-          >
+          (tiers ?? [])
+            .filter((t) => t.min_quantity_kg !== null && t.min_quantity_kg !== undefined)
+            .map((t) => ({
+              id: t.id,
+              min_quantity_kg: Number(t.min_quantity_kg),
+              price_per_kg: t.price_per_kg,
+            }))
         }
       />
     </div>

--- a/components/buyer-commitments/buyer-commitments-board.tsx
+++ b/components/buyer-commitments/buyer-commitments-board.tsx
@@ -11,7 +11,10 @@ import type { PricingTier } from "@/lib/types";
 
 export interface BuyerCommitmentsBoardProps {
   buckets: BucketedGroups;
-  tiersByLotId: Record<string, Pick<PricingTier, "min_quantity_kg" | "price_per_kg">[]>;
+  tiersByLotId: Record<
+    string,
+    Pick<PricingTier, "min_bags" | "min_quantity_kg" | "price_per_kg">[]
+  >;
   landingKg: number;
   ytdSpend: number;
   /**
@@ -93,10 +96,10 @@ export function BuyerCommitmentsBoard({
   const openGroup = findGroup(openGroupKey);
   const openTiers = openGroup
     ? (tiersByLotId[openGroup.lotId] || []).map((t) => ({
-        id: `${openGroup.lotId}-${t.min_quantity_kg}`,
+        id: `${openGroup.lotId}-${t.min_bags ?? t.min_quantity_kg ?? "?"}`,
         lot_id: openGroup.lotId,
-        min_quantity_kg: t.min_quantity_kg,
-        min_bags: null,
+        min_quantity_kg: t.min_quantity_kg ?? null,
+        min_bags: t.min_bags ?? null,
         price_per_kg: t.price_per_kg,
         created_at: "",
       }))

--- a/components/buyer-commitments/commitment-drawer/__tests__/closed-body.test.tsx
+++ b/components/buyer-commitments/commitment-drawer/__tests__/closed-body.test.tsx
@@ -147,8 +147,8 @@ describe("ClosedDrawerBody — value mode", () => {
         group={group}
         mode="value"
         tiers={[
-          { min_quantity_kg: 500, price_per_kg: 10 },
-          { min_quantity_kg: 1000, price_per_kg: 9 },
+          { min_bags: null, min_quantity_kg: 500, price_per_kg: 10 },
+          { min_bags: null, min_quantity_kg: 1000, price_per_kg: 9 },
         ]}
       />
     );
@@ -166,7 +166,7 @@ describe("ClosedDrawerBody — value mode", () => {
       <ClosedDrawerBody
         group={group}
         mode="value"
-        tiers={[{ min_quantity_kg: 500, price_per_kg: 10 }]}
+        tiers={[{ min_bags: null, min_quantity_kg: 500, price_per_kg: 10 }]}
       />
     );
     expect(screen.queryByTestId("closed-tier-summary")).not.toBeInTheDocument();
@@ -224,7 +224,7 @@ describe("ClosedDrawerBody — refund mode", () => {
       <ClosedDrawerBody
         group={group}
         mode="refund"
-        tiers={[{ min_quantity_kg: 500, price_per_kg: 10 }]}
+        tiers={[{ min_bags: null, min_quantity_kg: 500, price_per_kg: 10 }]}
       />
     );
     const header = screen.getByTestId("closed-refund-header");

--- a/components/buyer-commitments/commitment-drawer/__tests__/raising-body.test.tsx
+++ b/components/buyer-commitments/commitment-drawer/__tests__/raising-body.test.tsx
@@ -128,9 +128,9 @@ describe("RaisingDrawerBody", () => {
       <RaisingDrawerBody
         group={makeGroup()}
         tiers={[
-          { min_quantity_kg: 500, price_per_kg: 10 },
-          { min_quantity_kg: 1000, price_per_kg: 9 },
-          { min_quantity_kg: 2000, price_per_kg: 8 },
+          { min_bags: null, min_quantity_kg: 500, price_per_kg: 10 },
+          { min_bags: null, min_quantity_kg: 1000, price_per_kg: 9 },
+          { min_bags: null, min_quantity_kg: 2000, price_per_kg: 8 },
         ]}
       />
     );
@@ -172,9 +172,9 @@ describe("RaisingDrawerBody", () => {
           commitments: [makeCommit({ quantity_kg: 50 })],
         })}
         tiers={[
-          { min_quantity_kg: 500, price_per_kg: 10 },
-          { min_quantity_kg: 1000, price_per_kg: 9 },
-          { min_quantity_kg: 2000, price_per_kg: 8 },
+          { min_bags: null, min_quantity_kg: 500, price_per_kg: 10 },
+          { min_bags: null, min_quantity_kg: 1000, price_per_kg: 9 },
+          { min_bags: null, min_quantity_kg: 2000, price_per_kg: 8 },
         ]}
       />
     );

--- a/components/buyer-commitments/commitment-drawer/closed-body.tsx
+++ b/components/buyer-commitments/commitment-drawer/closed-body.tsx
@@ -1,5 +1,6 @@
 import { addPlatformFee } from "@/lib/pricing";
 import { UnitPriceText, UnitWeightText } from "@/components/unit-value";
+import { getTierProgress } from "@/lib/tier-progress";
 import { ContributionsTable } from "./contributions-table";
 import { BagBreakdown } from "./bag-breakdown";
 import { refundDollarsFor } from "./refund-amount";
@@ -12,7 +13,15 @@ export interface ClosedDrawerBodyProps {
    * "refund" — minimum_not_met. Lead with refund total, suppress savings/CTA.
    */
   mode: "value" | "refund";
-  tiers?: { min_quantity_kg: number; price_per_kg: number }[];
+  /**
+   * Pricing tiers fetched for this lot. Bag-aware tiers carry a non-null
+   * `min_bags`; legacy tiers carry only `min_quantity_kg`.
+   */
+  tiers?: {
+    min_bags: number | null;
+    min_quantity_kg: number | null;
+    price_per_kg: number;
+  }[];
 }
 
 const fmtMoney = (n: number) =>
@@ -95,17 +104,20 @@ export function ClosedDrawerBody({
   const saved = Math.max(0, baselinePaid - paid);
 
   // Find which tier the campaign settled at — the highest one whose threshold
-  // was met by the final committed quantity.
+  // was met by the final committed quantity. `getTierProgress` mirrors the
+  // bag-aware settlement rule for display.
   const finalCommitted = Number(lot?.committed_quantity_kg || 0);
-  const sortedTiers = [...tiers].sort(
-    (a, b) => Number(a.min_quantity_kg) - Number(b.min_quantity_kg)
+  const settledProgress = getTierProgress(
+    {
+      committed_quantity_kg: finalCommitted,
+      price_per_kg: Number(lot?.price_per_kg || 0),
+      bag_size_kg: lot?.bag_size_kg ?? null,
+    },
+    tiers
   );
-  const unlockedTiers = sortedTiers.filter(
-    (t) => finalCommitted >= Number(t.min_quantity_kg)
-  );
-  const settledTier = unlockedTiers[unlockedTiers.length - 1] ?? null;
+  const settledTier = settledProgress.currentTier;
   const finalBuyerPrice = settledTier
-    ? addPlatformFee(Number(settledTier.price_per_kg))
+    ? addPlatformFee(settledTier.price_per_kg)
     : null;
 
   return (
@@ -155,15 +167,19 @@ export function ClosedDrawerBody({
             data-testid="closed-tier-threshold"
           >
             <span className="font-bold tabular-nums">
-              <UnitWeightText
-                kg={Number(settledTier.min_quantity_kg)}
-                maximumFractionDigits={0}
-              />
+              {settledProgress.isBagAware && settledTier.min_bags !== null ? (
+                <>{settledTier.min_bags} bag{settledTier.min_bags === 1 ? "" : "s"}</>
+              ) : (
+                <UnitWeightText
+                  kg={settledTier.threshold_kg}
+                  maximumFractionDigits={0}
+                />
+              )}
             </span>{" "}
             tier · final price{" "}
             <span className="font-bold tabular-nums">
               <UnitPriceText
-                pricePerKg={Number(settledTier.price_per_kg)}
+                pricePerKg={settledTier.price_per_kg}
                 currency="USD"
                 includePlatformFee
               />

--- a/components/buyer-commitments/commitment-drawer/raising-body.tsx
+++ b/components/buyer-commitments/commitment-drawer/raising-body.tsx
@@ -4,13 +4,21 @@ import Link from "next/link";
 import { Button } from "@merninos/ui";
 import { addPlatformFee } from "@/lib/pricing";
 import { UnitPriceText, UnitWeightText } from "@/components/unit-value";
+import { getTierProgress } from "@/lib/tier-progress";
 import { ContributionsTable } from "./contributions-table";
 import type { CommitmentGroup } from "../bucket-by-lifecycle";
 
 export interface RaisingDrawerBodyProps {
   group: CommitmentGroup;
-  /** Sorted ascending by min_quantity_kg from the page query. */
-  tiers: { min_quantity_kg: number; price_per_kg: number }[];
+  /**
+   * Pricing tiers fetched for this lot. Bag-aware tiers carry a non-null
+   * `min_bags`; legacy tiers carry only `min_quantity_kg`.
+   */
+  tiers: {
+    min_bags: number | null;
+    min_quantity_kg: number | null;
+    price_per_kg: number;
+  }[];
 }
 
 const fmtMoney = (n: number) =>
@@ -51,17 +59,18 @@ export function RaisingDrawerBody({ group, tiers }: RaisingDrawerBodyProps) {
 
   // The current tier is the highest one whose threshold has been met. If
   // none yet, fall back to the lot's base price (which is what the buyer
-  // is currently committed at).
-  const sortedTiers = [...tiers].sort(
-    (a, b) => Number(a.min_quantity_kg) - Number(b.min_quantity_kg)
+  // is currently committed at). `getTierProgress` handles bag-aware and
+  // legacy tiers uniformly.
+  const progress = getTierProgress(
+    {
+      committed_quantity_kg: campaignTotal,
+      price_per_kg: Number(lot?.price_per_kg || 0),
+      bag_size_kg: lot?.bag_size_kg ?? null,
+    },
+    tiers
   );
-  const unlockedTiers = sortedTiers.filter(
-    (t) => campaignTotal >= Number(t.min_quantity_kg)
-  );
-  const currentTier = unlockedTiers[unlockedTiers.length - 1] ?? null;
-  const currentBuyerPrice = addPlatformFee(
-    Number(currentTier?.price_per_kg ?? lot?.price_per_kg ?? 0)
-  );
+  const sortedTiers = progress.sortedTiers;
+  const currentBuyerPrice = addPlatformFee(progress.currentPricePerKg);
 
   const deadline = group.campaign?.deadline ?? lot?.commitment_deadline ?? null;
   const commitMoreHref = `/dashboard/buyer/lot/${group.lotId}${
@@ -158,17 +167,19 @@ export function RaisingDrawerBody({ group, tiers }: RaisingDrawerBodyProps) {
           </div>
           <div className="flex flex-col gap-1.5">
             {sortedTiers.map((t) => {
-              const tierThreshold = Number(t.min_quantity_kg);
-              const tierBuyerPrice = addPlatformFee(Number(t.price_per_kg));
-              const tierSellerPrice = Number(t.price_per_kg);
-              const unlocked = campaignTotal >= tierThreshold;
+              const tierThreshold = t.threshold_kg;
+              const tierBuyerPrice = addPlatformFee(t.price_per_kg);
+              const tierSellerPrice = t.price_per_kg;
+              const unlocked = progress.isBagAware && t.min_bags !== null
+                ? progress.completedBags >= t.min_bags
+                : campaignTotal >= tierThreshold;
               const personalDelta = unlocked
                 ? 0
                 : Math.max(0, (currentBuyerPrice - tierBuyerPrice) * myKg);
               return (
                 <div
-                  key={tierThreshold}
-                  data-testid={`raising-tier-${tierThreshold}`}
+                  key={`${t.min_bags ?? "kg"}-${tierThreshold}`}
+                  data-testid={`raising-tier-${t.min_bags ?? tierThreshold}`}
                   data-unlocked={unlocked ? "true" : "false"}
                   className={`flex items-center justify-between gap-3 rounded-md border-2 px-3 py-2 ${
                     unlocked
@@ -178,7 +189,11 @@ export function RaisingDrawerBody({ group, tiers }: RaisingDrawerBodyProps) {
                 >
                   <div className="flex items-center gap-3">
                     <span className="font-headline text-sm font-extrabold tabular-nums text-espresso">
-                      <UnitWeightText kg={tierThreshold} maximumFractionDigits={0} />
+                      {progress.isBagAware && t.min_bags !== null ? (
+                        <>{t.min_bags} bag{t.min_bags === 1 ? "" : "s"}</>
+                      ) : (
+                        <UnitWeightText kg={tierThreshold} maximumFractionDigits={0} />
+                      )}
                     </span>
                     <span className="font-body text-sm text-espresso/70 tabular-nums">
                       <UnitPriceText
@@ -198,7 +213,7 @@ export function RaisingDrawerBody({ group, tiers }: RaisingDrawerBodyProps) {
                         {personalDelta > 0 && myKg > 0 && (
                           <span
                             className="font-body text-xs font-bold text-tomato tabular-nums"
-                            data-testid={`raising-tier-delta-${tierThreshold}`}
+                            data-testid={`raising-tier-delta-${t.min_bags ?? tierThreshold}`}
                           >
                             +{fmtMoney(personalDelta)} if reached
                           </span>

--- a/components/buyer-commitments/raising-lot-card.tsx
+++ b/components/buyer-commitments/raising-lot-card.tsx
@@ -9,12 +9,21 @@ import { addPlatformFee } from "@/lib/pricing";
 import { UnitPriceText, UnitWeightText } from "@/components/unit-value";
 import { useUnitPreference } from "@/components/unit-provider";
 import { formatUnitPrice, toDisplayWeight } from "@/lib/units";
+import { getTierProgress } from "@/lib/tier-progress";
 import type { CommitmentGroup } from "./bucket-by-lifecycle";
 
 export interface RaisingLotCardProps {
   group: CommitmentGroup;
-  /** Sorted ascending by min_quantity_kg from the page query. */
-  pricingTiers: { min_quantity_kg: number; price_per_kg: number }[];
+  /**
+   * Pricing tiers fetched for this lot. Bag-aware tiers carry a non-null
+   * `min_bags`; legacy tiers carry only `min_quantity_kg`. The card resolves
+   * both modes via `getTierProgress`.
+   */
+  pricingTiers: {
+    min_bags: number | null;
+    min_quantity_kg: number | null;
+    price_per_kg: number;
+  }[];
   /** Fired when the buyer wants to open the per-lot drawer. */
   onSelect?: () => void;
   /** Forwarded to the chevron button so the parent can return focus on close. */
@@ -58,18 +67,27 @@ export function RaisingLotCard({ group, pricingTiers, onSelect, triggerRef }: Ra
   const lotCommittedKg = Number(lot?.committed_quantity_kg || 0);
   const committedKg = lotCommittedKg > 0 ? lotCommittedKg : myKg;
   const targetKg = Number(lot?.total_quantity_kg || 0);
-  const tierMaxes = pricingTiers.map((t) => Number(t.min_quantity_kg));
+  const progress = getTierProgress(
+    {
+      committed_quantity_kg: committedKg,
+      price_per_kg: Number(lot?.price_per_kg || 0),
+      bag_size_kg: lot?.bag_size_kg ?? null,
+    },
+    pricingTiers
+  );
+  const tierMaxes = progress.sortedTiers.map((t) => t.threshold_kg);
   const maxKg = Math.max(targetKg, ...tierMaxes, committedKg, 1);
   const committedDisplay = toDisplayWeight(committedKg, unit);
   const maxBarUnits = toDisplayWeight(maxKg, unit);
-  const ticks: TierBarTick[] = pricingTiers
-    .filter((t) => Number(t.min_quantity_kg) > 0)
+  const ticks: TierBarTick[] = progress.sortedTiers
+    .filter((t) => t.threshold_kg > 0)
     .map((t) => ({
-      position: toDisplayWeight(Number(t.min_quantity_kg), unit),
-      sub: `${formatUnitPrice(addPlatformFee(Number(t.price_per_kg)), unit, "USD")}/${unit}`,
+      position: toDisplayWeight(t.threshold_kg, unit),
+      sub: `${formatUnitPrice(addPlatformFee(t.price_per_kg), unit, "USD")}/${unit}`,
     }));
 
-  const nextTier = pricingTiers.find((t) => Number(t.min_quantity_kg) > committedKg);
+  const nextTier = progress.nextTier;
+  const bagsToNext = progress.bagsToNext;
   const deadline = group.campaign?.deadline ?? lot?.commitment_deadline ?? null;
   const { label: countdownLabel, goingFast } = fmtCountdown(deadline, now);
   const photoUrl = lot?.images?.[0] || null;
@@ -145,9 +163,17 @@ export function RaisingLotCard({ group, pricingTiers, onSelect, triggerRef }: Ra
               <span className="font-extrabold tracking-[0.06em]">NEXT TIER</span>
               <span className="opacity-70">·</span>
               <span>
-                <UnitWeightText kg={Number(nextTier.min_quantity_kg) - committedKg} maximumFractionDigits={0} /> to{" "}
+                {progress.isBagAware ? (
+                  <>
+                    {bagsToNext} bag{bagsToNext === 1 ? "" : "s"} to{" "}
+                  </>
+                ) : (
+                  <>
+                    <UnitWeightText kg={nextTier.threshold_kg - committedKg} maximumFractionDigits={0} /> to{" "}
+                  </>
+                )}
                 <b>
-                  <UnitPriceText pricePerKg={Number(nextTier.price_per_kg)} currency="usd" includePlatformFee />
+                  <UnitPriceText pricePerKg={nextTier.price_per_kg} currency="usd" includePlatformFee />
                 </b>
               </span>
             </>

--- a/components/campaign/CampaignPage.tsx
+++ b/components/campaign/CampaignPage.tsx
@@ -213,6 +213,7 @@ function AuthenticatedView({
     stretchKg,
     committedKg,
     kgToNext,
+    bagsToNext,
     nextTier,
     nextIsStretch,
     activePrice,
@@ -413,7 +414,7 @@ function AuthenticatedView({
             pricingTiers={pricingTiers}
           >
             <div style={{ flex: '1 1 320px', minWidth: 0 }}>
-              <InvitePoke kgToNext={kgToNext} onOpen={openModal} />
+              <InvitePoke kgToNext={kgToNext} bagsToNext={bagsToNext} onOpen={openModal} />
             </div>
           </BagGridProgress>
         </div>
@@ -435,7 +436,7 @@ function AuthenticatedView({
 
       {/* MARQUEE strip */}
       <Marquee
-        items={buildMarqueeItems(socialProof, kgToNext, nextTier.name, unit)}
+        items={buildMarqueeItems(socialProof, kgToNext, bagsToNext, nextTier.name, unit)}
         inverted
         duration={36}
       />
@@ -456,6 +457,7 @@ function AuthenticatedView({
         <div style={{ maxWidth: 1100, margin: '0 auto' }}>
           <InviteBanner
             kgToNext={kgToNext}
+            bagsToNext={bagsToNext}
             nextTierName={nextTier.name}
             nextIsStretch={nextIsStretch}
             onOpen={openModal}
@@ -580,6 +582,13 @@ type TierContext = {
   stretchKg: number
   committedKg: number
   kgToNext: number
+  /**
+   * Bags remaining to the next tier. Non-null only when the lot is bag-aware
+   * (has bag_size_kg). UI copy switches to "X bags to drop the price" then.
+   */
+  bagsToNext: number | null
+  /** True when the lot's bag config is set. Mirrors settlement's bag-aware mode. */
+  isBagAware: boolean
   nextTier: CampaignTier
   nextIsStretch: boolean
   /** Price per kg at the active tier (used by the commit form). */
@@ -671,6 +680,18 @@ function buildTierContext(lot: Lot, pricingTiers: PricingTier[]): TierContext {
   const kgToNext = Math.max(0, kgAtTier(nextTier) - committedKg)
   const nextIsStretch = nextTier.id === stretchTier.id
 
+  // Bag-aware copy switches the marquee / invite messaging to bag units. We
+  // ceil so a partial bag still counts as "1 more bag" to drop the price —
+  // settlement only credits a fully completed bag, so rounding down here
+  // would show 0 bags while the price hasn't actually moved yet.
+  const isBagAware = bagSizeKg !== null
+  const bagsToNext =
+    isBagAware && bagSizeKg !== null && kgToNext > 0
+      ? Math.ceil(kgToNext / bagSizeKg)
+      : isBagAware
+        ? 0
+        : null
+
   // Active price = price of the highest tier whose threshold has been reached.
   const reached = [...tiers].reverse().find((t) => committedKg >= kgAtTier(t)) ?? tiers[0]
   const activePrice = reached.priceKg
@@ -680,6 +701,8 @@ function buildTierContext(lot: Lot, pricingTiers: PricingTier[]): TierContext {
     stretchKg,
     committedKg,
     kgToNext,
+    bagsToNext,
+    isBagAware,
     nextTier,
     nextIsStretch,
     activePrice,
@@ -690,6 +713,7 @@ function buildTierContext(lot: Lot, pricingTiers: PricingTier[]): TierContext {
 function buildMarqueeItems(
   socialProof: CampaignSocialProof | undefined,
   kgToNext: number,
+  bagsToNext: number | null,
   nextTierName: string,
   unit: 'kg' | 'lb'
 ): string[] {
@@ -701,7 +725,11 @@ function buildMarqueeItems(
       )
     }
   }
-  if (kgToNext > 0) {
+  if (bagsToNext !== null) {
+    if (bagsToNext > 0) {
+      out.push(`${bagsToNext.toLocaleString()} bag${bagsToNext === 1 ? '' : 's'} to ${nextTierName}`)
+    }
+  } else if (kgToNext > 0) {
     out.push(`${formatUnitWeight(kgToNext, unit, 0)} ${unit} to ${nextTierName}`)
   }
   out.push('Bring a roaster · drop the price')

--- a/components/campaign/InviteBanner.tsx
+++ b/components/campaign/InviteBanner.tsx
@@ -7,8 +7,13 @@ import { formatUnitWeight } from '@/lib/units'
 import { REFERRAL_CREDIT_AMOUNT_CENTS } from '@/lib/referrals/settle-attribution'
 
 interface InviteBannerProps {
-  /** Quantity remaining to the next tier, in kg. */
+  /** Quantity remaining to the next tier, in kg. Used for legacy weight-based lots. */
   kgToNext: number
+  /**
+   * Bags remaining to the next tier. Non-null for bag-aware lots, in which
+   * case the headline switches to "X bags to drop the price".
+   */
+  bagsToNext?: number | null
   /** Name of the next tier — used in the headline/body. */
   nextTierName: string
   /** Whether the next tier is the stretch goal — flips body copy. */
@@ -22,6 +27,7 @@ interface InviteBannerProps {
 // and hardcoded city/hub → useInviteData substitutions.
 export function InviteBanner({
   kgToNext,
+  bagsToNext,
   nextTierName,
   nextIsStretch,
   onOpen,
@@ -33,7 +39,11 @@ export function InviteBanner({
   const credit = REFERRAL_CREDIT_AMOUNT_CENTS / 100
   const city = data.hubCity ?? null
   const hubName = data.hubName
-  const displayQty = formatUnitWeight(kgToNext, unit, 0)
+  const isBagAware = bagsToNext !== null && bagsToNext !== undefined
+  const remaining = isBagAware ? bagsToNext! : kgToNext
+  const remainingLabel = isBagAware
+    ? `${remaining.toLocaleString()} bag${remaining === 1 ? '' : 's'}`
+    : `${formatUnitWeight(kgToNext, unit, 0)} ${unit}`
 
   return (
     <div
@@ -135,7 +145,7 @@ export function InviteBanner({
               margin: 0,
             }}
           >
-            {kgToNext > 0 ? (
+            {remaining > 0 ? (
               <>
                 Bring your{' '}
                 {city && (
@@ -145,7 +155,7 @@ export function InviteBanner({
                 )}
                 roast crew.
                 <br />
-                {displayQty} {unit} to drop the price.
+                {remainingLabel} to drop the price.
               </>
             ) : nextIsStretch ? (
               <>

--- a/components/campaign/InvitePoke.tsx
+++ b/components/campaign/InvitePoke.tsx
@@ -7,8 +7,13 @@ import { formatUnitWeight } from '@/lib/units'
 import { REFERRAL_CREDIT_AMOUNT_CENTS } from '@/lib/referrals/settle-attribution'
 
 interface InvitePokeProps {
-  /** Quantity remaining to the next tier, in kg. */
+  /** Quantity remaining to the next tier, in kg. Used for legacy weight-based lots. */
   kgToNext: number
+  /**
+   * Bags remaining to the next tier. Non-null for bag-aware lots, in which
+   * case the copy switches to "X bags to next tier" regardless of unit pref.
+   */
+  bagsToNext?: number | null
   onOpen: () => void
 }
 
@@ -16,14 +21,22 @@ interface InvitePokeProps {
 // design/project/campaign/Invite.jsx (InvitePoke). Returns null when the
 // buyer has no hub or while invite data is loading — same render gate
 // as every other CTA on the page.
-export function InvitePoke({ kgToNext, onOpen }: InvitePokeProps) {
+export function InvitePoke({ kgToNext, bagsToNext, onOpen }: InvitePokeProps) {
   const { status, data } = useInviteData()
   const { unit } = useUnitPreference()
   if (status !== 'ready' || !data) return null
 
   const credit = REFERRAL_CREDIT_AMOUNT_CENTS / 100
   const cityCopy = data.hubCity ? `local ${data.hubCity} roasters` : 'local roasters'
-  const displayQty = formatUnitWeight(kgToNext, unit, 0)
+  const isBagAware = bagsToNext !== null && bagsToNext !== undefined
+  const remaining = isBagAware ? bagsToNext! : kgToNext
+  const headline = isBagAware
+    ? remaining > 0
+      ? `${remaining.toLocaleString()} bag${remaining === 1 ? '' : 's'} to next tier`
+      : 'Push the stretch goal'
+    : kgToNext > 0
+      ? `${formatUnitWeight(kgToNext, unit, 0)} ${unit} to next tier`
+      : 'Push the stretch goal'
 
   return (
     <button
@@ -74,7 +87,7 @@ export function InvitePoke({ kgToNext, onOpen }: InvitePokeProps) {
             color: 'var(--color-espresso)',
           }}
         >
-          {kgToNext > 0 ? `${displayQty} ${unit} to next tier` : 'Push the stretch goal'}
+          {headline}
         </div>
         <div
           style={{

--- a/components/campaign/locked-filling-pill.tsx
+++ b/components/campaign/locked-filling-pill.tsx
@@ -136,7 +136,7 @@ export function LockedFillingPill({
           values are zero — keeps the buyer dashboard layout stable. */}
       {!hasLocked && !hasFilling && (
         <span
-          aria-label="No kg pledged"
+          aria-label="Nothing pledged yet"
           style={{
             display: "inline-flex",
             alignItems: "center",

--- a/components/featured-roast-hero.tsx
+++ b/components/featured-roast-hero.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import type { Lot, PricingTier } from "@/lib/types";
 import { addPlatformFee } from "@/lib/pricing";
+import { getTierProgress } from "@/lib/tier-progress";
 import { CountdownTimer } from "./countdown-timer";
 import { UnitWeightText } from "./unit-value";
 import { HeroPrice, HeroCommitLabel } from "./hero-price";
@@ -9,25 +10,41 @@ interface FeaturedRoastHeroProps {
   lot: Lot & { campaign_deadline?: string | null } | null;
   campaignId?: string | null;
   hubId?: string | null;
-  tiers?: Pick<PricingTier, "min_quantity_kg" | "price_per_kg">[];
+  tiers?: Pick<PricingTier, "min_bags" | "min_quantity_kg" | "price_per_kg">[];
 }
 
 export function FeaturedRoastHero({ lot, campaignId, hubId, tiers = [] }: FeaturedRoastHeroProps) {
   if (!lot) return null;
 
-  const commitPct =
-    lot.total_quantity_kg > 0
+  // Total-progress denominator: bag-aware lots count completed bags out of
+  // total-quantity bags so the bar matches the unit the campaign settles in.
+  const bagSizeKg = lot.bag_size_kg && lot.bag_size_kg > 0 ? Number(lot.bag_size_kg) : null;
+  const totalBags = bagSizeKg ? Math.floor(Number(lot.total_quantity_kg) / bagSizeKg) : 0;
+  const completedBags = bagSizeKg
+    ? Math.floor(Number(lot.committed_quantity_kg) / bagSizeKg)
+    : 0;
+  const isBagAware = bagSizeKg !== null && tiers.some((t) => t.min_bags !== null);
+  const commitPct = isBagAware
+    ? totalBags > 0
+      ? Math.round((completedBags / totalBags) * 100)
+      : 0
+    : lot.total_quantity_kg > 0
       ? Math.round((lot.committed_quantity_kg / lot.total_quantity_kg) * 100)
       : 0;
 
   // Resolve the live tier price based on how much has been committed.
-  const activeSellerPricePerKg = (() => {
-    const sortedDesc = [...tiers].sort((a, b) => b.min_quantity_kg - a.min_quantity_kg);
-    for (const tier of sortedDesc) {
-      if (lot.committed_quantity_kg >= tier.min_quantity_kg) return tier.price_per_kg;
-    }
-    return lot.price_per_kg;
-  })();
+  const activeSellerPricePerKg = getTierProgress(
+    {
+      committed_quantity_kg: Number(lot.committed_quantity_kg),
+      price_per_kg: Number(lot.price_per_kg),
+      bag_size_kg: bagSizeKg,
+    },
+    tiers.map((t) => ({
+      min_bags: t.min_bags ?? null,
+      min_quantity_kg: t.min_quantity_kg ?? null,
+      price_per_kg: Number(t.price_per_kg),
+    }))
+  ).currentPricePerKg;
 
   const altitudeLabel =
     lot.altitude_min && lot.altitude_max
@@ -331,9 +348,15 @@ export function FeaturedRoastHero({ lot, campaignId, hubId, tiers = [] }: Featur
               <div style={{ marginBottom: 2 }}>
                 <div style={{ display: "flex", justifyContent: "space-between", fontFamily: "'Cal Sans', system-ui, sans-serif", fontSize: 10, fontWeight: 800, letterSpacing: "0.1em", textTransform: "uppercase", marginBottom: 6, opacity: 0.75, color: "#F5F0D8" }}>
                   <span>
-                    <UnitWeightText kg={lot.committed_quantity_kg} maximumFractionDigits={0} />
-                    {" / "}
-                    <UnitWeightText kg={lot.total_quantity_kg} maximumFractionDigits={0} />
+                    {isBagAware ? (
+                      <>{completedBags.toLocaleString()} / {totalBags.toLocaleString()} bags</>
+                    ) : (
+                      <>
+                        <UnitWeightText kg={lot.committed_quantity_kg} maximumFractionDigits={0} />
+                        {" / "}
+                        <UnitWeightText kg={lot.total_quantity_kg} maximumFractionDigits={0} />
+                      </>
+                    )}
                   </span>
                   <span style={{ color: "#F5C842" }}>{commitPct}%</span>
                 </div>

--- a/components/lot-detail-view.tsx
+++ b/components/lot-detail-view.tsx
@@ -37,6 +37,7 @@ import { useBagAssignment } from "@/hooks/use-bag-assignment";
 import { useUnitPreference } from "@/components/unit-provider";
 import { formatUnitPrice, formatUnitWeight } from "@/lib/units";
 import { addPlatformFee } from "@/lib/pricing";
+import { getTierProgress, type ResolvedTier } from "@/lib/tier-progress";
 
 interface LotDetailProps {
   lot: Lot;
@@ -75,54 +76,56 @@ export function LotDetailView({
   backLabel,
 }: LotDetailProps) {
   const { unit } = useUnitPreference();
-  const sortedTiers = [...pricingTiers].sort(
-    (a, b) => a.min_quantity_kg - b.min_quantity_kg
-  );
 
-  // Build full tier list: base + discount tiers
-  const allTiers = [
+  // Tier resolution: shared bag-aware helper. Bag-aware lots key on
+  // `min_bags`; legacy lots fall back to `min_quantity_kg`. Display labels
+  // below branch on `isBagAware` to surface bags or weight as appropriate.
+  const progress = getTierProgress(
     {
-      min_quantity_kg: lot.min_commitment_kg,
+      committed_quantity_kg: lot.committed_quantity_kg,
       price_per_kg: lot.price_per_kg,
-      label: "Minimum (trigger)",
+      bag_size_kg: lot.bag_size_kg ?? null,
     },
-    ...sortedTiers.map((t) => ({
-      min_quantity_kg: t.min_quantity_kg,
-      price_per_kg: t.price_per_kg,
-      label: `${formatUnitWeight(t.min_quantity_kg, unit)} ${unit}`,
-    })),
-  ];
-
-  // Current active price based on committed quantity
-  const getActivePrice = (committedQty: number) => {
-    let price = lot.price_per_kg;
-    for (const tier of [...sortedTiers].reverse()) {
-      if (committedQty >= tier.min_quantity_kg) {
-        price = tier.price_per_kg;
-        break;
-      }
-    }
-    return price;
-  };
-
-  const activePrice = getActivePrice(lot.committed_quantity_kg);
-  const nextTier = sortedTiers.find(
-    (t) => t.min_quantity_kg > lot.committed_quantity_kg
+    pricingTiers
   );
-
-  // Bag-aware progress: for lots with bag_size_kg set, the trigger metric
-  // is "completed bags toward min_bags_to_succeed". Legacy lots keep the
-  // kg-based math against min_commitment_kg.
-  const bagSizeKg =
-    lot.bag_size_kg != null && lot.bag_size_kg > 0 ? Number(lot.bag_size_kg) : null;
-  const isBagAware = bagSizeKg !== null;
+  const isBagAware = progress.isBagAware;
+  const bagSizeKg = progress.bagSize;
+  const completedBags = progress.completedBags;
   const minBagsToSucceed = Number(lot.min_bags_to_succeed || 0);
-  const completedBags = isBagAware
-    ? Math.floor(lot.committed_quantity_kg / bagSizeKg)
-    : 0;
-  const maxBags = isBagAware
+  const maxBags = isBagAware && bagSizeKg
     ? Math.floor(lot.total_quantity_kg / bagSizeKg)
     : 0;
+  const activePrice = progress.currentPricePerKg;
+  const nextTier = progress.nextTier;
+  const bagsToNext = progress.bagsToNext;
+  const sortedTiers = progress.sortedTiers;
+
+  // Build full tier list: base trigger + discount tiers. The threshold label
+  // shows bags for bag-aware lots and kg for legacy lots.
+  type TierRow = ResolvedTier & { label: string; isTrigger: boolean };
+  const triggerThresholdKg = isBagAware && bagSizeKg && minBagsToSucceed > 0
+    ? minBagsToSucceed * bagSizeKg
+    : lot.min_commitment_kg;
+  const triggerMinBags = isBagAware ? minBagsToSucceed : null;
+  const allTiers: TierRow[] = [
+    {
+      min_bags: triggerMinBags,
+      threshold_kg: triggerThresholdKg,
+      price_per_kg: lot.price_per_kg,
+      label: "Minimum (trigger)",
+      isTrigger: true,
+    },
+    ...sortedTiers.map<TierRow>((t) => ({
+      min_bags: t.min_bags,
+      threshold_kg: t.threshold_kg,
+      price_per_kg: t.price_per_kg,
+      label:
+        isBagAware && t.min_bags !== null
+          ? `${t.min_bags} bag${t.min_bags === 1 ? "" : "s"}`
+          : `${formatUnitWeight(t.threshold_kg, unit)} ${unit}`,
+      isTrigger: false,
+    })),
+  ];
 
   const triggerPercent = isBagAware
     ? minBagsToSucceed > 0
@@ -344,11 +347,17 @@ export function LotDetailView({
                     {" "}
                     Only{" "}
                     <span className="font-semibold text-foreground">
-                      {formatUnitWeight(
-                        nextTier.min_quantity_kg - lot.committed_quantity_kg,
-                        unit
-                      )}{" "}
-                      {unit}
+                      {isBagAware ? (
+                        <>{bagsToNext} bag{bagsToNext === 1 ? "" : "s"}</>
+                      ) : (
+                        <>
+                          {formatUnitWeight(
+                            nextTier.threshold_kg - lot.committed_quantity_kg,
+                            unit
+                          )}{" "}
+                          {unit}
+                        </>
+                      )}
                     </span>{" "}
                     more needed to unlock{" "}
                     {formatUnitPrice(addPlatformFee(nextTier.price_per_kg), unit, lot.currency || "USD")}/{unit}!
@@ -359,16 +368,22 @@ export function LotDetailView({
             <CardContent>
               <div className="space-y-3">
                 {allTiers.map((tier, idx) => {
-                  const isActive =
-                    tier.price_per_kg === activePrice &&
-                    lot.committed_quantity_kg >= tier.min_quantity_kg;
+                  // Reached-state: bag-aware lots compare bag count against
+                  // the tier's min_bags; legacy lots compare kg.
                   const isReached =
-                    lot.committed_quantity_kg >= tier.min_quantity_kg;
-                  const isNext =
-                    !isReached &&
-                    (idx === 0 ||
-                      lot.committed_quantity_kg >=
-                        allTiers[idx - 1].min_quantity_kg);
+                    isBagAware && tier.min_bags !== null
+                      ? completedBags >= tier.min_bags
+                      : lot.committed_quantity_kg >= tier.threshold_kg;
+                  const isActive =
+                    tier.price_per_kg === activePrice && isReached;
+                  const prevTier = allTiers[idx - 1];
+                  const prevReached =
+                    !prevTier
+                      ? true
+                      : isBagAware && prevTier.min_bags !== null
+                        ? completedBags >= prevTier.min_bags
+                        : lot.committed_quantity_kg >= prevTier.threshold_kg;
+                  const isNext = !isReached && (idx === 0 || prevReached);
                   const savings =
                     idx > 0
                       ? (
@@ -377,6 +392,10 @@ export function LotDetailView({
                           100
                         ).toFixed(0)
                       : null;
+                  const thresholdLabel =
+                    isBagAware && tier.min_bags !== null
+                      ? `${tier.min_bags} bag${tier.min_bags === 1 ? "" : "s"}`
+                      : `${formatUnitWeight(tier.threshold_kg, unit)} ${unit}`;
 
                   return (
                     <div
@@ -409,7 +428,7 @@ export function LotDetailView({
                           <p
                             className={`text-sm font-medium ${isActive ? "text-primary" : "text-foreground"}`}
                           >
-                            {formatUnitWeight(tier.min_quantity_kg, unit)} {unit}
+                            {thresholdLabel}
                           </p>
                           <p className="text-xs text-muted-foreground">
                             {tier.label}
@@ -434,7 +453,9 @@ export function LotDetailView({
                 })}
               </div>
 
-              {/* Tier progress visualization */}
+              {/* Tier progress visualization — markers use threshold_kg from
+                  the helper, which is min_bags * bag_size for bag-aware lots
+                  and min_quantity_kg for legacy lots. */}
               {sortedTiers.length > 0 && (
                 <div className="mt-4">
                   <div className="relative h-2 rounded-full bg-muted overflow-hidden">
@@ -442,13 +463,14 @@ export function LotDetailView({
                       className="absolute inset-y-0 left-0 rounded-full bg-primary transition-all"
                       style={{ width: `${capacityPercent}%` }}
                     />
-                    {/* Tier markers */}
                     {sortedTiers.map((tier) => {
                       const markerPct =
-                        (tier.min_quantity_kg / lot.total_quantity_kg) * 100;
+                        lot.total_quantity_kg > 0
+                          ? (tier.threshold_kg / lot.total_quantity_kg) * 100
+                          : 0;
                       return (
                         <div
-                          key={tier.id}
+                          key={`marker-${tier.min_bags ?? tier.threshold_kg}`}
                           className="absolute top-0 h-full w-0.5 bg-foreground/30"
                           style={{ left: `${markerPct}%` }}
                         />
@@ -456,8 +478,17 @@ export function LotDetailView({
                     })}
                   </div>
                   <div className="mt-1 flex items-center justify-between text-xs text-muted-foreground">
-                    <span>0 {unit}</span>
-                    <span>{formatUnitWeight(lot.total_quantity_kg, unit)} {unit}</span>
+                    {isBagAware ? (
+                      <>
+                        <span>0 bags</span>
+                        <span>{maxBags.toLocaleString()} bags</span>
+                      </>
+                    ) : (
+                      <>
+                        <span>0 {unit}</span>
+                        <span>{formatUnitWeight(lot.total_quantity_kg, unit)} {unit}</span>
+                      </>
+                    )}
                   </div>
                 </div>
               )}

--- a/lib/__tests__/tier-progress.test.ts
+++ b/lib/__tests__/tier-progress.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from "vitest";
+import {
+  getCompletedBags,
+  getTierProgress,
+  type TierInput,
+} from "@/lib/tier-progress";
+
+describe("getCompletedBags", () => {
+  it("floors committed kg by bag size", () => {
+    expect(getCompletedBags(187, 60)).toBe(3);
+    expect(getCompletedBags(180, 60)).toBe(3);
+    expect(getCompletedBags(59, 60)).toBe(0);
+  });
+
+  it("returns 0 when bag size is missing or zero", () => {
+    expect(getCompletedBags(187, null)).toBe(0);
+    expect(getCompletedBags(187, 0)).toBe(0);
+  });
+
+  it("returns 0 for non-positive committed kg", () => {
+    expect(getCompletedBags(0, 60)).toBe(0);
+    expect(getCompletedBags(-5, 60)).toBe(0);
+  });
+});
+
+describe("getTierProgress (bag-aware)", () => {
+  const tiers: TierInput[] = [
+    { min_bags: 1, min_quantity_kg: null, price_per_kg: 10 },
+    { min_bags: 3, min_quantity_kg: null, price_per_kg: 9 },
+    { min_bags: 6, min_quantity_kg: null, price_per_kg: 8.5 },
+  ];
+
+  it("resolves the largest qualifying tier by bag count", () => {
+    const p = getTierProgress(
+      { committed_quantity_kg: 187, price_per_kg: 11, bag_size_kg: 60 },
+      tiers
+    );
+    expect(p.isBagAware).toBe(true);
+    expect(p.completedBags).toBe(3);
+    expect(p.currentPricePerKg).toBe(9);
+    expect(p.currentTier?.min_bags).toBe(3);
+    expect(p.nextTier?.min_bags).toBe(6);
+    expect(p.bagsToNext).toBe(3);
+    expect(p.kgToNext).toBe(60 * 6 - 187);
+  });
+
+  it("falls back to base price when no tier qualifies", () => {
+    const p = getTierProgress(
+      { committed_quantity_kg: 30, price_per_kg: 11, bag_size_kg: 60 },
+      tiers
+    );
+    expect(p.completedBags).toBe(0);
+    expect(p.currentTier).toBeNull();
+    expect(p.currentPricePerKg).toBe(11);
+    expect(p.nextTier?.min_bags).toBe(1);
+    expect(p.bagsToNext).toBe(1);
+  });
+
+  it("returns null nextTier when top tier already unlocked", () => {
+    const p = getTierProgress(
+      { committed_quantity_kg: 600, price_per_kg: 11, bag_size_kg: 60 },
+      tiers
+    );
+    expect(p.completedBags).toBe(10);
+    expect(p.currentTier?.min_bags).toBe(6);
+    expect(p.nextTier).toBeNull();
+    expect(p.bagsToNext).toBe(0);
+  });
+
+  it("sorts unordered tier input", () => {
+    const unordered: TierInput[] = [
+      { min_bags: 6, min_quantity_kg: null, price_per_kg: 8.5 },
+      { min_bags: 1, min_quantity_kg: null, price_per_kg: 10 },
+      { min_bags: 3, min_quantity_kg: null, price_per_kg: 9 },
+    ];
+    const p = getTierProgress(
+      { committed_quantity_kg: 187, price_per_kg: 11, bag_size_kg: 60 },
+      unordered
+    );
+    expect(p.sortedTiers.map((t) => t.min_bags)).toEqual([1, 3, 6]);
+  });
+});
+
+describe("getTierProgress (legacy weight-based)", () => {
+  const tiers: TierInput[] = [
+    { min_bags: null, min_quantity_kg: 50, price_per_kg: 10 },
+    { min_bags: null, min_quantity_kg: 150, price_per_kg: 9 },
+    { min_bags: null, min_quantity_kg: 300, price_per_kg: 8 },
+  ];
+
+  it("uses kg comparison when no bag config present", () => {
+    const p = getTierProgress(
+      { committed_quantity_kg: 200, price_per_kg: 11, bag_size_kg: null },
+      tiers
+    );
+    expect(p.isBagAware).toBe(false);
+    expect(p.completedBags).toBe(0);
+    expect(p.currentTier?.threshold_kg).toBe(150);
+    expect(p.currentPricePerKg).toBe(9);
+    expect(p.nextTier?.threshold_kg).toBe(300);
+    expect(p.kgToNext).toBe(100);
+    expect(p.bagsToNext).toBe(0);
+  });
+
+  it("uses kg comparison when bag_size present but tiers are unconverted", () => {
+    const p = getTierProgress(
+      { committed_quantity_kg: 200, price_per_kg: 11, bag_size_kg: 60 },
+      tiers
+    );
+    expect(p.isBagAware).toBe(false);
+    expect(p.currentTier?.threshold_kg).toBe(150);
+  });
+});
+
+describe("getTierProgress (mixed)", () => {
+  it("prefers bag-aware path when any tier is converted, dropping legacy tiers", () => {
+    const mixed: TierInput[] = [
+      { min_bags: null, min_quantity_kg: 50, price_per_kg: 10 },
+      { min_bags: 3, min_quantity_kg: null, price_per_kg: 9 },
+    ];
+    const p = getTierProgress(
+      { committed_quantity_kg: 180, price_per_kg: 11, bag_size_kg: 60 },
+      mixed
+    );
+    expect(p.isBagAware).toBe(true);
+    expect(p.completedBags).toBe(3);
+    expect(p.currentTier?.min_bags).toBe(3);
+    expect(p.currentPricePerKg).toBe(9);
+  });
+});
+
+describe("getTierProgress (empty)", () => {
+  it("returns base price with no tiers", () => {
+    const p = getTierProgress(
+      { committed_quantity_kg: 100, price_per_kg: 11, bag_size_kg: 60 },
+      []
+    );
+    expect(p.sortedTiers).toEqual([]);
+    expect(p.currentTier).toBeNull();
+    expect(p.currentPricePerKg).toBe(11);
+    expect(p.nextTier).toBeNull();
+  });
+});

--- a/lib/tier-progress.ts
+++ b/lib/tier-progress.ts
@@ -1,0 +1,171 @@
+/**
+ * Shared bag-aware volume tier progress helper.
+ *
+ * Under the bag-aware model, a pricing tier unlocks when
+ *   completed_bags = floor(total_committed_kg / bag_size_kg)
+ * reaches the tier's `min_bags`. This module centralises the math so every
+ * buyer, seller, and hub surface resolves "current tier" and "next tier" the
+ * same way, without each page re-implementing the comparison.
+ *
+ * Bag-aware vs. legacy:
+ *  - A lot is "bag-aware" when `bag_size_kg > 0` AND at least one tier has
+ *    `min_bags !== null`. We then resolve tiers by bag count.
+ *  - Otherwise we fall back to legacy weight-based resolution against
+ *    `min_quantity_kg`. This covers lots that haven't been backfilled yet.
+ *
+ * The settlement code path in `lib/settle-bag-pricing.ts` is the authoritative
+ * pricing oracle at deadline; this module mirrors its tier-selection rule for
+ * read-only display purposes.
+ */
+
+export type TierInput = {
+  min_bags: number | null;
+  min_quantity_kg: number | null;
+  price_per_kg: number;
+};
+
+export type LotInput = {
+  committed_quantity_kg: number;
+  price_per_kg: number;
+  bag_size_kg: number | null;
+};
+
+/** A tier normalised so callers can read either `min_bags` or `threshold_kg`. */
+export type ResolvedTier = {
+  /** For bag-aware lots: tier.min_bags. For legacy lots: undefined. */
+  min_bags: number | null;
+  /** Weight equivalent. Always set so progress bars can position markers. */
+  threshold_kg: number;
+  price_per_kg: number;
+};
+
+export type TierProgress = {
+  /** The lot's bag size in kg, or null when not bag-configured. */
+  bagSize: number | null;
+  /**
+   * True when the lot has `bag_size_kg > 0` and at least one tier carries a
+   * non-null `min_bags`. UI should use bag-flavoured copy in this case.
+   */
+  isBagAware: boolean;
+  /** Whole completed bags. Zero for legacy lots or sub-bag totals. */
+  completedBags: number;
+  /** Echo of the lot's committed kg, coerced to Number. */
+  committedKg: number;
+  /** Ascending by threshold. Legacy and bag-aware tiers are normalised. */
+  sortedTiers: ResolvedTier[];
+  /** Highest qualifying tier, or null when none reached. */
+  currentTier: ResolvedTier | null;
+  /** Resolved per-kg price: current tier price, or the lot's base price. */
+  currentPricePerKg: number;
+  /** Next tier above current, or null when the top tier is already unlocked. */
+  nextTier: ResolvedTier | null;
+  /** Bags remaining until `nextTier` unlocks. Zero when not bag-aware or none. */
+  bagsToNext: number;
+  /** Kg remaining until `nextTier` unlocks. Useful for both modes. */
+  kgToNext: number;
+};
+
+/**
+ * Compute completed bag count. Returns 0 when the lot has no bag size or
+ * committed quantity is non-positive.
+ */
+export function getCompletedBags(
+  committedKg: number,
+  bagSizeKg: number | null
+): number {
+  if (!bagSizeKg || bagSizeKg <= 0) return 0;
+  if (!Number.isFinite(committedKg) || committedKg <= 0) return 0;
+  return Math.floor(committedKg / bagSizeKg);
+}
+
+/**
+ * Resolve a single tier into the normalised `ResolvedTier` shape. Returns
+ * null when neither bag nor kg threshold is usable for this lot.
+ */
+function resolveTier(tier: TierInput, bagSizeKg: number | null): ResolvedTier | null {
+  if (tier.min_bags !== null && bagSizeKg && bagSizeKg > 0) {
+    return {
+      min_bags: tier.min_bags,
+      threshold_kg: tier.min_bags * bagSizeKg,
+      price_per_kg: Number(tier.price_per_kg),
+    };
+  }
+  if (tier.min_quantity_kg !== null && tier.min_quantity_kg !== undefined) {
+    return {
+      min_bags: null,
+      threshold_kg: Number(tier.min_quantity_kg),
+      price_per_kg: Number(tier.price_per_kg),
+    };
+  }
+  return null;
+}
+
+/**
+ * Single entry point for tier progress on a lot. Pure: no I/O, no mutation
+ * of the input tier array.
+ */
+export function getTierProgress(lot: LotInput, tiers: TierInput[]): TierProgress {
+  const bagSize = lot.bag_size_kg && lot.bag_size_kg > 0 ? Number(lot.bag_size_kg) : null;
+  const committedKg = Number(lot.committed_quantity_kg) || 0;
+  const completedBags = getCompletedBags(committedKg, bagSize);
+  const basePricePerKg = Number(lot.price_per_kg);
+
+  const isBagAware = bagSize !== null && tiers.some((t) => t.min_bags !== null);
+
+  const resolved: ResolvedTier[] = [];
+  for (const t of tiers) {
+    const r = resolveTier(t, bagSize);
+    if (r !== null) resolved.push(r);
+  }
+  const sortedTiers = resolved.sort((a, b) => a.threshold_kg - b.threshold_kg);
+
+  let currentTier: ResolvedTier | null = null;
+  let nextTier: ResolvedTier | null = null;
+
+  if (isBagAware) {
+    for (const t of sortedTiers) {
+      if (t.min_bags === null) continue;
+      if (t.min_bags <= completedBags) {
+        currentTier = t;
+      } else if (nextTier === null) {
+        nextTier = t;
+        break;
+      }
+    }
+  } else {
+    for (const t of sortedTiers) {
+      if (t.threshold_kg <= committedKg) {
+        currentTier = t;
+      } else if (nextTier === null) {
+        nextTier = t;
+        break;
+      }
+    }
+  }
+
+  const currentPricePerKg = currentTier ? currentTier.price_per_kg : basePricePerKg;
+
+  let bagsToNext = 0;
+  let kgToNext = 0;
+  if (nextTier) {
+    if (isBagAware && nextTier.min_bags !== null && bagSize) {
+      bagsToNext = Math.max(0, nextTier.min_bags - completedBags);
+      kgToNext = Math.max(0, nextTier.threshold_kg - committedKg);
+    } else {
+      kgToNext = Math.max(0, nextTier.threshold_kg - committedKg);
+    }
+  }
+
+  return {
+    bagSize,
+    isBagAware,
+    completedBags,
+    committedKg,
+    sortedTiers,
+    currentTier,
+    currentPricePerKg,
+    nextTier,
+    bagsToNext,
+    kgToNext,
+  };
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -239,7 +239,15 @@ export interface Claim {
 export interface PricingTier {
   id: string;
   lot_id: string;
-  min_quantity_kg: number;
+  /**
+   * Legacy weight threshold in kg. Nullable post-migration #37 — bag-aware
+   * tiers store their threshold in `min_bags` and leave this null.
+   */
+  min_quantity_kg: number | null;
+  /**
+   * Bag count threshold. Non-null for bag-aware tiers; null for legacy
+   * unconverted tiers (which still key on `min_quantity_kg`).
+   */
   min_bags: number | null;
   price_per_kg: number;
   created_at: string;


### PR DESCRIPTION
Sellers list lots in bags now, so volume tier thresholds settle on
completed bag count — but most read paths still resolved tiers against
min_quantity_kg and rendered "X lbs/kg to next tier".

Centralise tier resolution in lib/tier-progress.ts (mirrors the
settlement rule in lib/settle-bag-pricing.ts) and route every buyer
campaign card, browse page, commitments drawer, the hub catalog
lot-detail view, and the seller commitments revenue summary through it.
Copy now reads "X bag(s) to next tier" / "X bags to drop the price"
when the lot has a bag config; legacy weight-based lots still fall back
to kg/lb. PricingTier.min_quantity_kg is now number | null to match
migration #37.