### PR TITLE
fix(bag-transfer-out): populate bag_transfers.hub_id on insert

### DIFF
--- a/lib/__tests__/bag-transfer-out.test.ts
+++ b/lib/__tests__/bag-transfer-out.test.ts
@@ -94,6 +94,7 @@ function defaultCommitmentJoin(overrides: Record<string, unknown> = {}) {
   return {
     lot_id: "lot-1",
     campaign_id: "camp-1",
+    hub_id: "hub-1",
     lot: {
       id: "lot-1",
       seller_id: "seller-1",
@@ -105,6 +106,7 @@ function defaultCommitmentJoin(overrides: Record<string, unknown> = {}) {
     },
     campaign: {
       id: "camp-1",
+      hub_id: "hub-1",
       hub: {
         owner_profile: { stripe_connect_account_id: "acct_hub_1" },
       },
@@ -270,6 +272,7 @@ describe("transferOutBagIfReady", () => {
     expect(insert).toBeDefined();
     expect(insert?.payload).toMatchObject({
       lot_id: "lot-1",
+      hub_id: "hub-1",
       bag_number: 1,
       currency: "USD",
       seller_amount_cents: 20000,
@@ -404,6 +407,7 @@ describe("transferOutBagIfReady", () => {
     expect(transferMock).not.toHaveBeenCalled();
     expect(insertCaptured[0]?.payload).toMatchObject({
       lot_id: "lot-1",
+      hub_id: "hub-1",
       bag_number: 1,
       seller_amount_cents: 0,
       hub_amount_cents: 0,
@@ -411,5 +415,36 @@ describe("transferOutBagIfReady", () => {
       seller_transfer_id: null,
       hub_transfer_id: null,
     });
+  });
+
+  // ------------------------------------------------------------------
+  // 7. skipped: hub_id unresolved (bag_transfers.hub_id NOT NULL guard)
+  // ------------------------------------------------------------------
+  it("returns 'skipped' when neither campaign.hub_id nor commitment.hub_id is resolvable", async () => {
+    enqueue("commitments", {
+      data: defaultCommitmentJoin({
+        hub_id: null,
+        campaign: {
+          id: "camp-1",
+          hub_id: null,
+          hub: {
+            owner_profile: { stripe_connect_account_id: "acct_hub_1" },
+          },
+        },
+      }),
+      error: null,
+    });
+
+    const transferMock = vi.fn();
+    const result = await transferOutBagIfReady(
+      makeSupabase(),
+      { commitmentId: "commit-1", bagNumber: 1 },
+      makeDeps(transferMock)
+    );
+
+    expect(result.status).toBe("skipped");
+    expect(result.reason).toBe("hub_id_unresolved_on_commitment");
+    expect(transferMock).not.toHaveBeenCalled();
+    expect(insertCaptured).toHaveLength(0);
   });
 });

--- a/lib/bag-transfer-out.ts
+++ b/lib/bag-transfer-out.ts
@@ -99,6 +99,14 @@ export interface TransferOutBagDeps {
 interface CommitmentJoin {
   lot_id: string;
   campaign_id: string | null;
+  /**
+   * Commitment-row `hub_id`. Migration #42 added `bag_transfers.hub_id NOT NULL`
+   * and noted that the insert call must populate it. The campaign's hub_id
+   * is the authoritative source (see migration header re: relisted lots),
+   * but commitments are routed at create time and carry their own hub_id
+   * column as a fallback for legacy commitments missing `campaign_id`.
+   */
+  hub_id: string | null;
   lot: {
     id: string;
     seller_id: string;
@@ -109,6 +117,7 @@ interface CommitmentJoin {
   } | null;
   campaign: {
     id: string;
+    hub_id: string | null;
     hub: {
       owner_profile: {
         stripe_connect_account_id: string | null;
@@ -159,7 +168,7 @@ export async function transferOutBagIfReady(
   const { data: commitmentJoin, error: commitmentError } = await supabase
     .from("commitments")
     .select(
-      "lot_id, campaign_id, lot:lot_id(id, seller_id, currency, seller_profile:seller_id(stripe_connect_account_id)), campaign:campaign_id(id, hub:hub_id(owner_profile:owner_id(stripe_connect_account_id)))"
+      "lot_id, campaign_id, hub_id, lot:lot_id(id, seller_id, currency, seller_profile:seller_id(stripe_connect_account_id)), campaign:campaign_id(id, hub_id, hub:hub_id(owner_profile:owner_id(stripe_connect_account_id)))"
     )
     .eq("id", args.commitmentId)
     .single();
@@ -184,6 +193,12 @@ export async function transferOutBagIfReady(
     normalized.lot.seller_profile?.stripe_connect_account_id || null;
   const hubAccountId =
     normalized.campaign?.hub?.owner_profile?.stripe_connect_account_id || null;
+  // Hub id for the ledger row. Prefer the campaign's hub_id so a relisted
+  // lot can't backfill prior-hub transfers under a new hub (migration #42's
+  // M1 fix). Fall back to commitment.hub_id for legacy rows without
+  // campaign_id. Required by `bag_transfers.hub_id NOT NULL`.
+  const hubId =
+    normalized.campaign?.hub_id || normalized.hub_id || null;
   const currency = (normalized.lot.currency || "USD").toLowerCase();
 
   if (!sellerAccountId) {
@@ -191,6 +206,9 @@ export async function transferOutBagIfReady(
   }
   if (!hubAccountId) {
     return { status: "skipped", reason: "hub_missing_connect_account" };
+  }
+  if (!hubId) {
+    return { status: "skipped", reason: "hub_id_unresolved_on_commitment" };
   }
 
   // ---------------------------------------------------------------------
@@ -267,6 +285,7 @@ export async function transferOutBagIfReady(
       .from("bag_transfers")
       .insert({
         lot_id: lotId,
+        hub_id: hubId,
         bag_number: args.bagNumber,
         currency: (currency || "usd").toUpperCase(),
         seller_amount_cents: 0,
@@ -393,6 +412,7 @@ export async function transferOutBagIfReady(
     .from("bag_transfers")
     .insert({
       lot_id: lotId,
+      hub_id: hubId,
       bag_number: args.bagNumber,
       currency: currency.toUpperCase(),
       seller_amount_cents: split.sellerAmount,
@@ -451,6 +471,7 @@ function normalizeCommitmentJoin(raw: unknown): CommitmentJoin {
   return {
     lot_id: (obj.lot_id as string) || "",
     campaign_id: (obj.campaign_id as string | null) || null,
+    hub_id: (obj.hub_id as string | null) || null,
     lot: normalizeLotEmbed(obj.lot),
     campaign: normalizeCampaignEmbed(obj.campaign),
   };
@@ -485,6 +506,9 @@ function normalizeCampaignEmbed(raw: unknown): CommitmentJoin["campaign"] {
     : null;
   return {
     id: String((campaignObj as Record<string, unknown>).id || ""),
+    hub_id:
+      ((campaignObj as Record<string, unknown>).hub_id as string | null) ??
+      null,
     hub: hub
       ? {
           owner_profile: ownerProfile


### PR DESCRIPTION
## Summary

`bag_transfers.hub_id` is `NOT NULL` (migration #42's M1 fix — prevents a relisted lot from being silently backfilled under a new hub), but `lib/bag-transfer-out.ts` never populated the column on its two `bag_transfers.insert(...)` call sites. Result: **every** bag transfer-out attempt — including the zero-charge marker path — fails with `null value in column "hub_id" violates not-null constraint`, and the bag is left without a ledger row so `transferOutBagIfReady` will keep re-evaluating it on every subsequent worker tick.

This surfaces in production logs as:

```
[charge-worker] transferOutBagIfReady skipped
  reason: 'bag_transfers_insert_failed_zero: null value in column "hub_id" of relation "bag_transfers"...'
```

after a campaign settles.

## Fix

- Add `hub_id` to the commitment join select alongside `campaign.hub_id`.
- Resolve the hub_id at runtime: prefer `campaign.hub_id` (authoritative per the migration's M1 rationale), fall back to `commitment.hub_id` for legacy rows that pre-date the campaigns table.
- Guard with a `skipped: hub_id_unresolved_on_commitment` outcome so a missing hub_id is surfaced explicitly rather than crashing the NOT NULL.
- Include `hub_id` in both insert payloads (the zero-charge marker at line ~285 and the real-transfer ledger row at line ~412).
- Update `normalizeCommitmentJoin` / `normalizeCampaignEmbed` to carry the new field through PostgREST's single-vs-array embed normalization.

## Test plan

- [x] Existing `lib/__tests__/bag-transfer-out.test.ts` cases continue to pass with the new field threaded through the commitment join.
- [x] New regression case covering the `hub_id` insert + `hub_id_unresolved_on_commitment` skip outcome.
- [ ] Verify on staging: settle a campaign whose every bag charge succeeded → `bag_transfers` row lands with the correct `hub_id` and seller/hub transfers fire.
- [ ] Verify the zero-charge branch (e.g. campaign where every bag charge ended `payment_failed`) writes a `hub_id`-populated marker row instead of looping the worker.

## Related

Companion fix to `claude/fix-setup-intent-pm-clobber`, which closes the upstream defect that caused all bag charges to fail with `missing_payment_method` and exposed this hub_id bug in the zero-charge branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NLEJsqpZtVmEJZUCLNfNJ2)_