### PR TITLE
fix(webhook): stop clobbering stripe_payment_method_id with null on setup_intent.succeeded

### DIFF
--- a/app/api/stripe/webhook/__tests__/webhook-failure-events.test.ts
+++ b/app/api/stripe/webhook/__tests__/webhook-failure-events.test.ts
@@ -567,4 +567,112 @@ describe("Stripe webhook — failure events cancel commitments", () => {
     // Critically, status must NOT be set to 'cancelled' on the happy path.
     expect(updateCalls[0].payload.status).toBeUndefined();
   });
+
+  // -------------------------------------------------------------------------
+  // setup_intent.succeeded — PM-clobber regression
+  // -------------------------------------------------------------------------
+  // The bug this guards against: a setup_intent.succeeded event with a
+  // missing `payment_method` field used to write
+  // `stripe_payment_method_id: null` unconditionally. Stripe webhook
+  // ordering isn't guaranteed; the sibling checkout.session.completed
+  // handler may have already persisted a real PM. Clobbering it with NULL
+  // strands the commitment in `setup_complete` with no card, and the
+  // settlement charge worker then bails the bag charge with
+  // `missing_payment_method` (lib/charge-worker.ts:274).
+
+  it("setup_intent.succeeded writes payment_method when present", async () => {
+    const res = await POST(
+      makeRequest({
+        id: "evt_si_ok",
+        type: "setup_intent.succeeded",
+        data: {
+          object: {
+            id: "seti_ok",
+            payment_method: "pm_real",
+            customer: "cus_si_ok",
+            metadata: { commitment_id: "commit-si-ok" },
+          },
+        },
+      })
+    );
+
+    expect(res.status).toBe(200);
+    const mainUpdate = updateCalls.find(
+      (c) => c.payload.payment_status === "setup_complete"
+    );
+    expect(mainUpdate).toBeDefined();
+    expect(mainUpdate?.payload).toMatchObject({
+      payment_status: "setup_complete",
+      stripe_setup_intent_id: "seti_ok",
+      stripe_customer_id: "cus_si_ok",
+      stripe_payment_method_id: "pm_real",
+    });
+  });
+
+  it("setup_intent.succeeded does NOT clobber stripe_payment_method_id with null when payment_method is missing", async () => {
+    const res = await POST(
+      makeRequest({
+        id: "evt_si_no_pm",
+        type: "setup_intent.succeeded",
+        data: {
+          object: {
+            id: "seti_no_pm",
+            // payment_method intentionally omitted — simulates the production
+            // payload that produced our Sour Grape Thermal Shock orphan.
+            customer: "cus_si_no_pm",
+            metadata: { commitment_id: "commit-si-no-pm" },
+          },
+        },
+      })
+    );
+
+    expect(res.status).toBe(200);
+    const mainUpdate = updateCalls.find(
+      (c) => c.payload.payment_status === "setup_complete"
+    );
+    expect(mainUpdate).toBeDefined();
+    // The fix: the field must NOT be present in the payload at all (a present
+    // `null` would clobber a real PM written by a sibling webhook).
+    expect(
+      Object.prototype.hasOwnProperty.call(
+        mainUpdate?.payload ?? {},
+        "stripe_payment_method_id"
+      )
+    ).toBe(false);
+  });
+
+  it("setup_intent.succeeded with no payment_method also stamps payment_error (gated on existing-null PM)", async () => {
+    const res = await POST(
+      makeRequest({
+        id: "evt_si_no_pm_err",
+        type: "setup_intent.succeeded",
+        data: {
+          object: {
+            id: "seti_no_pm_err",
+            customer: "cus_x",
+            metadata: { commitment_id: "commit-si-no-pm-err" },
+          },
+        },
+      })
+    );
+
+    expect(res.status).toBe(200);
+    // A second UPDATE should have fired to set payment_error, scoped to
+    // rows where stripe_payment_method_id IS NULL so a sibling handler
+    // that already wrote a real PM isn't clobbered by the error stamp.
+    const errUpdate = updateCalls.find(
+      (c) => c.payload.payment_error === "Couldn't retrieve payment method after setup"
+    );
+    expect(errUpdate).toBeDefined();
+    expect(errUpdate?.filters).toContainEqual({
+      op: "is",
+      col: "stripe_payment_method_id",
+      val: null,
+    });
+    expect(errUpdate?.filters).toContainEqual({
+      op: "eq",
+      col: "id",
+      val: "commit-si-no-pm-err",
+    });
+  });
 });

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -283,15 +283,44 @@ export async function POST(request: Request) {
       if (setupIntent.metadata?.commitment_id) {
         const admin = createAdminClient();
 
+        // Mirror the defensive shape used by checkout.session.completed
+        // (mode=setup): never write `stripe_payment_method_id` as NULL.
+        // Stripe webhook ordering is not guaranteed, and a `setup_intent.
+        // succeeded` event with a missing `payment_method` would otherwise
+        // clobber a PM id already written by the sibling
+        // checkout.session.completed handler. The settlement gate at
+        // lib/charge-worker.ts:274 reads PM presence as the
+        // ready-to-charge signal — losing it strands the commitment in
+        // `setup_complete` with no card.
+        const updatePayload: Record<string, unknown> = {
+          payment_status: "setup_complete",
+          stripe_setup_intent_id: setupIntent.id,
+        };
+        if (setupIntent.customer) {
+          updatePayload.stripe_customer_id = setupIntent.customer;
+        }
+        if (setupIntent.payment_method) {
+          updatePayload.stripe_payment_method_id = setupIntent.payment_method;
+        }
         await admin
           .from("commitments")
-          .update({
-            payment_status: "setup_complete",
-            stripe_setup_intent_id: setupIntent.id,
-            stripe_payment_method_id: setupIntent.payment_method || null,
-            stripe_customer_id: setupIntent.customer || null,
-          })
+          .update(updatePayload)
           .eq("id", setupIntent.metadata.commitment_id);
+
+        // Defensive: if Stripe handed us a succeeded setup_intent with no
+        // payment_method AND the row doesn't already have one (sibling
+        // handler hasn't run / won't run), surface it via payment_error so
+        // the worker treats this row as not-ready-to-charge instead of
+        // marking the eventual bag charge as terminal `missing_payment_method`.
+        if (!setupIntent.payment_method) {
+          await admin
+            .from("commitments")
+            .update({
+              payment_error: "Couldn't retrieve payment method after setup",
+            })
+            .eq("id", setupIntent.metadata.commitment_id)
+            .is("stripe_payment_method_id", null);
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

The `setup_intent.succeeded` handler used to unconditionally write `stripe_payment_method_id: setupIntent.payment_method || null`. Stripe webhook delivery order isn't guaranteed, so a sibling `checkout.session.completed` (mode=setup) handler that had already persisted a real PM could be overwritten by a later `setup_intent.succeeded` with a missing `payment_method` field — leaving the commitment in `setup_complete` with no card.

The charge worker then sees `payment_error IS NULL` (the AC12 auth probe never ran for this code path) and `stripe_payment_method_id IS NULL`, takes the `missing_payment_method` branch at `lib/charge-worker.ts:274`, and marks the bag charge terminal `payment_failed`. **No payout fires because nothing was charged.**

Found via the Sour Grape Thermal Shock Coferment commitment (`770edf1d-...`) — `setup_complete` + null PM + null `payment_error` + a `commitment_bag_charges` row stuck at `payment_failed` / `missing_payment_method`. 1/1 commitments in the affected state at time of investigation.

## Fix

- Build the UPDATE payload conditionally — only include `stripe_payment_method_id` and `stripe_customer_id` when truthy, mirroring the defensive pattern at `route.ts:117` in the sibling `checkout.session.completed` handler.
- If the succeeded SI arrives without a `payment_method`, fire a second UPDATE that stamps `payment_error = "Couldn't retrieve payment method after setup"` so the worker's gate catches the row before it tries to charge. The error stamp is **scoped via `.is("stripe_payment_method_id", null)`** so a real PM previously written by a sibling handler isn't overwritten with the error.

Three regression tests added in `app/api/stripe/webhook/__tests__/webhook-failure-events.test.ts`:

1. Happy path — `payment_method` present → field is written.
2. No-clobber guarantee — `payment_method` missing → the `stripe_payment_method_id` key is **absent** from the UPDATE payload (so it can't overwrite a sibling-written PM).
3. Defensive stamp — missing PM also triggers the `payment_error` UPDATE, gated by `stripe_payment_method_id IS NULL`.

## Test plan

- [x] Existing `webhook-failure-events.test.ts` cases continue to pass.
- [x] New three-case regression block covers happy, no-clobber, and defensive-stamp paths.
- [ ] Sanity-check on staging: complete a fresh Stripe-hosted setup flow → both `checkout.session.completed` and `setup_intent.succeeded` fire → commitment lands with `payment_status='setup_complete'`, real `stripe_payment_method_id`, `payment_error IS NULL`.

## Related

Companion fix to #85 (`claude/fix-bag-transfers-hub-id`), which fixes a downstream `bag_transfers.hub_id NOT NULL` bug that this defect was masking — when every bag charge fails, the zero-charge branch of transfer-out runs, and that branch needed the hub_id fix to write its marker ledger row.

## Data remediation

The single affected commitment (`770edf1d-141e-4aea-8388-3f467b4699da`) was reset to `pending_setup` (Stripe fields cleared, `commitment_bag_charges` row deleted) so the buyer can re-run the setup flow once the fix lands. No money moved in either direction; no Stripe transfers had fired.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NLEJsqpZtVmEJZUCLNfNJ2)_