### PR TITLE
feat(buyer-commitments): card-update flow with auto-rearm of failed bag charges

### DIFF
--- a/app/api/commitments/[id]/restart-setup/route.ts
+++ b/app/api/commitments/[id]/restart-setup/route.ts
@@ -1,0 +1,169 @@
+/**
+ * Buyer-initiated card-update flow for the bag-aware lifecycle.
+ *
+ * Wired to the "Update payment" button on `NeedsAttentionCard` and to the
+ * `manageUrl` baked into the AC13 "Your card declined" email
+ * (lib/charge-worker.ts → sendPaymentUpdateRequiredEmail). The buyer hits
+ * this endpoint, we mint a fresh Stripe Checkout setup session attached
+ * to the existing commitment, and return the redirect URL. The buyer's
+ * subsequent webhook completion (a) writes the new PM onto the commit
+ * and (b) re-arms any terminal `payment_failed` bag charges via
+ * `lib/bag-charge-rearm.ts` so the charge worker retries them with the
+ * new card on the next cron tick.
+ *
+ * Auth model:
+ *   - Buyer must be authenticated (Supabase session) and OWN this commit.
+ *   - Commit must have at least one `payment_failed` bag row OR be in
+ *     legacy `charge_failed` state. The 400 on "nothing to retry" stops
+ *     the endpoint from rotating sessions on a healthy in-flight commit.
+ *   - Commit must have a `stripe_customer_id` already on file — re-using
+ *     it preserves the buyer's saved methods + history. A null customer
+ *     id means the commit never finished initial setup and the buyer
+ *     should re-run the commit flow from scratch, not this restart path.
+ */
+
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { createSetupCheckoutSession } from "@/lib/stripe";
+
+const APP_URL = process.env.NEXT_PUBLIC_APP_URL || "https://crowdroast.com";
+
+export async function POST(
+  _request: Request,
+  context: { params: Promise<{ id: string }> }
+) {
+  const { id: commitmentId } = await context.params;
+  if (!commitmentId) {
+    return NextResponse.json(
+      { error: "Missing commitment id" },
+      { status: 400 }
+    );
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+  if (authError || !user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // RLS-bound read scopes to the buyer's own rows. We additionally check
+  // buyer_id below as belt-and-suspenders so an RLS misconfiguration can't
+  // silently grant access.
+  const { data: commitment, error: readError } = await supabase
+    .from("commitments")
+    .select(
+      "id, buyer_id, lot_id, status, payment_status, stripe_customer_id, lot:lots(id, currency)"
+    )
+    .eq("id", commitmentId)
+    .maybeSingle();
+  if (readError) {
+    return NextResponse.json({ error: readError.message }, { status: 500 });
+  }
+  if (!commitment) {
+    return NextResponse.json({ error: "Commitment not found" }, { status: 404 });
+  }
+  if (commitment.buyer_id !== user.id) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  if (commitment.status === "cancelled") {
+    return NextResponse.json(
+      { error: "Cannot restart a cancelled commitment" },
+      { status: 400 }
+    );
+  }
+  if (!commitment.stripe_customer_id) {
+    // Means the commit never completed initial setup. Restart-setup
+    // re-attaches a PM to the EXISTING customer; without one we'd have to
+    // create a fresh customer and the buyer's saved methods elsewhere
+    // would be split. Send them back to the lot to re-commit cleanly.
+    return NextResponse.json(
+      {
+        error:
+          "This commitment has no payment customer on file yet. Re-commit from the lot page to set one up.",
+      },
+      { status: 400 }
+    );
+  }
+
+  // Guard: only restart when there's actually something to fix. Without
+  // this check the endpoint would rotate the buyer's session id on every
+  // call and orphan in-flight Stripe sessions.
+  const admin = createAdminClient();
+  const { data: failedBags, error: failedReadError } = await admin
+    .from("commitment_bag_charges")
+    .select("id")
+    .eq("commitment_id", commitmentId)
+    .eq("payment_status", "payment_failed")
+    .limit(1);
+  if (failedReadError) {
+    return NextResponse.json(
+      { error: failedReadError.message },
+      { status: 500 }
+    );
+  }
+  const hasFailedBags = !!(failedBags && failedBags.length > 0);
+  const legacyFailed = commitment.payment_status === "charge_failed";
+  if (!hasFailedBags && !legacyFailed) {
+    return NextResponse.json(
+      { error: "No failed charges to retry on this commitment" },
+      { status: 400 }
+    );
+  }
+
+  // PostgREST returns embeds as single objects or arrays depending on
+  // cardinality inference. The lots foreign key is one-to-one so we
+  // expect a single object — coerce defensively.
+  const lot = Array.isArray(commitment.lot)
+    ? (commitment.lot[0] as { id: string; currency: string | null } | undefined)
+    : (commitment.lot as { id: string; currency: string | null } | null);
+  if (!lot?.id) {
+    return NextResponse.json(
+      { error: "Commitment is missing its lot reference" },
+      { status: 500 }
+    );
+  }
+
+  // Mint the fresh setup session. The success/cancel URLs land back on
+  // the commitments dashboard with a banner key so the page can show a
+  // brief confirmation. The webhook's bag-charge re-arm will already have
+  // fired by the time the buyer lands here (Stripe fires both
+  // checkout.session.completed and setup_intent.succeeded synchronously
+  // with the redirect), so the page just needs to confirm "thanks, we
+  // queued the retry".
+  const session = await createSetupCheckoutSession({
+    customerId: commitment.stripe_customer_id,
+    successUrl: `${APP_URL}/dashboard/buyer/commitments?restart=success`,
+    cancelUrl: `${APP_URL}/dashboard/buyer/commitments?restart=cancelled`,
+    commitmentId: commitment.id,
+    lotId: lot.id,
+    currency: lot.currency || "USD",
+  });
+  if (!session.url) {
+    return NextResponse.json(
+      { error: "Stripe setup session returned no redirect URL" },
+      { status: 502 }
+    );
+  }
+
+  // Update the commit to point at the new session. We deliberately do
+  // NOT clear stripe_payment_method_id here — if the buyer abandons the
+  // restart flow, their old PM is still on file and the worker can keep
+  // retrying with it (per the retry ladder). The webhook will overwrite
+  // PM cleanly on completion.
+  await admin
+    .from("commitments")
+    .update({
+      payment_status: "pending_setup",
+      stripe_checkout_session_id: session.id,
+      stripe_setup_intent_id: null,
+      payment_error: null,
+      card_auth_failed_email_sent_at: null,
+    })
+    .eq("id", commitmentId);
+
+  return NextResponse.json({ url: session.url }, { status: 200 });
+}

--- a/app/api/stripe/webhook/__tests__/webhook-failure-events.test.ts
+++ b/app/api/stripe/webhook/__tests__/webhook-failure-events.test.ts
@@ -95,6 +95,18 @@ vi.mock("@/lib/email", () => ({
   sendCardAuthFailedEmail: (...args: unknown[]) => mockSendCardAuthFailedEmail(...args),
 }));
 
+// Tracks calls into the bag-charge-rearm helper. The webhook handlers
+// call this when a setup-mode session completes for an existing commit
+// that has terminal-failed bag rows. The mock surfaces the args so tests
+// can assert wiring + that the helper is NOT called on the auth-probe-
+// failed branch.
+const mockRearmFailedBagCharges = vi.fn();
+
+vi.mock("@/lib/bag-charge-rearm", () => ({
+  rearmFailedBagCharges: (...args: unknown[]) =>
+    mockRearmFailedBagCharges(...args),
+}));
+
 import { POST } from "@/app/api/stripe/webhook/route";
 
 function makeRequest(event: unknown): Request {
@@ -113,6 +125,11 @@ beforeEach(() => {
   mockGetSetupIntent.mockReset();
   mockSendCardAuthFailedEmail.mockReset();
   mockSendCardAuthFailedEmail.mockResolvedValue({ success: true });
+  mockRearmFailedBagCharges.mockReset();
+  mockRearmFailedBagCharges.mockResolvedValue({
+    status: "no_failed_rows",
+    rearmedRowIds: [],
+  });
   process.env.STRIPE_WEBHOOK_SECRET = "whsec_test";
 });
 
@@ -674,5 +691,124 @@ describe("Stripe webhook — failure events cancel commitments", () => {
       col: "id",
       val: "commit-si-no-pm-err",
     });
+  });
+
+  // -------------------------------------------------------------------------
+  // Bag-charge re-arm wiring (P3 — buyer card-update flow)
+  // -------------------------------------------------------------------------
+  // When a buyer completes a fresh Stripe Checkout setup session via the
+  // restart-setup flow, both setup-mode webhook handlers should call
+  // rearmFailedBagCharges with the commitment id + new setup_intent id so
+  // any terminal payment_failed bag rows flip back to awaiting_charge with
+  // a fresh idempotency key.
+
+  it("setup_intent.succeeded calls rearmFailedBagCharges when the SI carries a payment_method", async () => {
+    const res = await POST(
+      makeRequest({
+        id: "evt_si_rearm",
+        type: "setup_intent.succeeded",
+        data: {
+          object: {
+            id: "seti_rearm_1",
+            payment_method: "pm_rearm",
+            customer: "cus_rearm",
+            metadata: { commitment_id: "commit-rearm-1" },
+          },
+        },
+      })
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockRearmFailedBagCharges).toHaveBeenCalledTimes(1);
+    expect(mockRearmFailedBagCharges).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        commitmentId: "commit-rearm-1",
+        newSetupIntentId: "seti_rearm_1",
+      })
+    );
+  });
+
+  it("setup_intent.succeeded does NOT call rearmFailedBagCharges when payment_method is missing (no usable card to retry with)", async () => {
+    const res = await POST(
+      makeRequest({
+        id: "evt_si_norearm",
+        type: "setup_intent.succeeded",
+        data: {
+          object: {
+            id: "seti_norearm",
+            // No payment_method — bug-mode payload that PR #86 hardened against.
+            customer: "cus_n",
+            metadata: { commitment_id: "commit-norearm" },
+          },
+        },
+      })
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockRearmFailedBagCharges).not.toHaveBeenCalled();
+  });
+
+  it("checkout.session.completed (mode=setup) on probe.ok calls rearmFailedBagCharges", async () => {
+    commitmentLookup = {
+      id: "commit-rearm-cs",
+      lot: { id: "lot-1", title: "Lot", currency: "USD" },
+      buyer: { email: "buyer@example.com", contact_name: "Bo" },
+    };
+    mockProbeCardAuth.mockResolvedValue({ ok: true });
+
+    const res = await POST(
+      makeRequest({
+        id: "evt_cs_rearm",
+        type: "checkout.session.completed",
+        data: {
+          object: {
+            id: "cs_rearm",
+            mode: "setup",
+            setup_intent: "seti_cs_rearm",
+            customer: "cus_cs_rearm",
+            payment_method: "pm_cs_rearm",
+          },
+        },
+      })
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockRearmFailedBagCharges).toHaveBeenCalledTimes(1);
+    expect(mockRearmFailedBagCharges).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        commitmentId: "commit-rearm-cs",
+        newSetupIntentId: "seti_cs_rearm",
+      })
+    );
+  });
+
+  it("checkout.session.completed (mode=setup) on probe.fail does NOT call rearmFailedBagCharges (declined card mustn't unlock retries)", async () => {
+    commitmentLookup = {
+      id: "commit-norearm-cs",
+      lot: { id: "lot-1", title: "Lot", currency: "USD" },
+      buyer: { email: "buyer@example.com", contact_name: "Bo" },
+    };
+    mockProbeCardAuth.mockResolvedValue({ ok: false, reason: "card_declined" });
+
+    const res = await POST(
+      makeRequest({
+        id: "evt_cs_norearm",
+        type: "checkout.session.completed",
+        data: {
+          object: {
+            id: "cs_norearm",
+            mode: "setup",
+            setup_intent: "seti_cs_norearm",
+            customer: "cus_n",
+            payment_method: "pm_n",
+          },
+        },
+      })
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockRearmFailedBagCharges).not.toHaveBeenCalled();
   });
 });

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -6,6 +6,7 @@ import {
   verifyStripeWebhookSignature,
 } from "@/lib/stripe";
 import { insertReferralAttributionIfEligible } from "@/lib/referrals/insert-attribution";
+import { rearmFailedBagCharges } from "@/lib/bag-charge-rearm";
 import { sendCardAuthFailedEmail } from "@/lib/email";
 import { NextResponse } from "next/server";
 
@@ -161,6 +162,28 @@ export async function POST(request: Request) {
             currency,
           });
 
+          // Re-arm any terminal `payment_failed` bag charges for this
+          // commitment on the probe-OK path. Fires for first-time setups
+          // too — those have no failed bag rows, so the helper is a no-op.
+          // Only kicks in when the buyer came back via the restart-setup
+          // flow after a prior decline.
+          if (probe.ok && commitmentRow?.id && session.setup_intent) {
+            try {
+              await rearmFailedBagCharges(admin, {
+                commitmentId: commitmentRow.id,
+                newSetupIntentId: session.setup_intent,
+              });
+            } catch (rearmErr) {
+              // Best-effort: a re-arm failure must not 500 the webhook.
+              // Worst case the buyer is left with terminal rows and needs
+              // manual support — the dashboard still shows the right state.
+              console.warn(
+                "[webhook checkout.session.completed mode=setup] rearmFailedBagCharges failed",
+                rearmErr instanceof Error ? rearmErr.message : rearmErr
+              );
+            }
+          }
+
           if (!probe.ok) {
             // M4 idempotency stamp: Stripe delivers webhooks at-least-once,
             // and probeCardAuth is intentionally idempotent (deterministic
@@ -306,6 +329,25 @@ export async function POST(request: Request) {
           .from("commitments")
           .update(updatePayload)
           .eq("id", setupIntent.metadata.commitment_id);
+
+        // Re-arm any terminal `payment_failed` bag charges so the worker
+        // retries them with the buyer's freshly-attached card on the next
+        // tick. Mirrors the call from the sibling checkout.session.completed
+        // handler — both webhooks fire on the same setup completion, so
+        // whichever lands first wins the claim; the second is a no-op.
+        if (setupIntent.payment_method) {
+          try {
+            await rearmFailedBagCharges(admin, {
+              commitmentId: setupIntent.metadata.commitment_id,
+              newSetupIntentId: setupIntent.id,
+            });
+          } catch (rearmErr) {
+            console.warn(
+              "[webhook setup_intent.succeeded] rearmFailedBagCharges failed",
+              rearmErr instanceof Error ? rearmErr.message : rearmErr
+            );
+          }
+        }
 
         // Defensive: if Stripe handed us a succeeded setup_intent with no
         // payment_method AND the row doesn't already have one (sibling

--- a/app/dashboard/buyer/commitments/[id]/page.tsx
+++ b/app/dashboard/buyer/commitments/[id]/page.tsx
@@ -1,0 +1,19 @@
+import { redirect } from "next/navigation";
+
+/**
+ * The AC13 "Your card declined" email links each buyer to
+ * `${APP_URL}/dashboard/buyer/commitments/{commitment_id}` (lib/charge-worker.ts).
+ * The full commitments dashboard already renders every buyer commit with
+ * its lifecycle + needs-attention state, so this page is just a redirect
+ * shim that forwards there with the commit id pinned as a hash — the
+ * dashboard's existing drawer-open-on-load behavior surfaces the right
+ * group automatically. Without this shim the email's URL 404s.
+ */
+export default async function CommitmentRedirectPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  redirect(`/dashboard/buyer/commitments#${id}`);
+}

--- a/components/buyer-commitments/__tests__/bucket-by-lifecycle.test.ts
+++ b/components/buyer-commitments/__tests__/bucket-by-lifecycle.test.ts
@@ -18,6 +18,7 @@ import {
   effectiveChargeState,
   effectiveChargedCents,
   effectiveChargedKg,
+  deriveNeedsAttentionDisplay,
   type CommitmentGroup,
 } from "../bucket-by-lifecycle";
 import type { BagChargeRow } from "../commitment-drawer/bag-breakdown";
@@ -737,5 +738,93 @@ describe("derivePortfolioStats — bag-aware paths", () => {
     });
     const s = derivePortfolioStats([g], NOOP_FEE);
     expect(s.savedVsBase).toBeCloseTo(70, 2);
+  });
+});
+
+describe("deriveNeedsAttentionDisplay", () => {
+  it("returns hasAny=false for a group with no failed commits", () => {
+    const g = mkGroup({ commitments: [mkCommit({ payment_status: "charge_succeeded" })] });
+    const d = deriveNeedsAttentionDisplay(g);
+    expect(d.hasAny).toBe(false);
+    expect(d.failedKg).toBe(0);
+  });
+
+  it("legacy: sums quantity_kg and surfaces payment_error", () => {
+    const g = mkGroup({
+      commitments: [
+        mkCommit({
+          payment_status: "charge_failed",
+          quantity_kg: 50,
+          payment_error: "Your card was declined.",
+        }),
+      ],
+    });
+    const d = deriveNeedsAttentionDisplay(g);
+    expect(d.hasAny).toBe(true);
+    expect(d.failedKg).toBe(50);
+    expect(d.reason).toBe("Your card was declined.");
+  });
+
+  it("legacy: falls back to generic message when payment_error is null", () => {
+    const g = mkGroup({
+      commitments: [mkCommit({ payment_status: "charge_failed", quantity_kg: 25, payment_error: null })],
+    });
+    const d = deriveNeedsAttentionDisplay(g);
+    expect(d.reason).toBe("Your card was declined");
+  });
+
+  it("bag-aware: counts only the failed bags' kg toward failedKg (regression: legacy code returned 0)", () => {
+    const g = mkGroup({
+      commitments: [
+        mkCommit({
+          id: "c-bx",
+          payment_status: "setup_complete",
+          quantity_kg: 58,
+          charge_amount_cents: null,
+        }),
+      ],
+      bagChargesByCommitmentId: {
+        "c-bx": [
+          mkBag({ commitment_id: "c-bx", kg: 29, payment_status: "charged" }),
+          mkBag({ commitment_id: "c-bx", kg: 29, payment_status: "payment_failed" }),
+        ],
+      },
+    });
+    const d = deriveNeedsAttentionDisplay(g);
+    expect(d.hasAny).toBe(true);
+    expect(d.failedKg).toBe(29);
+    expect(d.reason).toBe("Your card couldn't be charged for 1 of 2 bags");
+  });
+
+  it("bag-aware: 'any of the bags' phrasing when every bag failed", () => {
+    const g = mkGroup({
+      commitments: [
+        mkCommit({ id: "c-by", payment_status: "setup_complete", quantity_kg: 58 }),
+      ],
+      bagChargesByCommitmentId: {
+        "c-by": [
+          mkBag({ commitment_id: "c-by", kg: 29, payment_status: "payment_failed" }),
+          mkBag({ commitment_id: "c-by", kg: 29, payment_status: "payment_failed" }),
+        ],
+      },
+    });
+    const d = deriveNeedsAttentionDisplay(g);
+    expect(d.failedKg).toBe(58);
+    expect(d.reason).toBe("Your card couldn't be charged for any of the bags");
+  });
+
+  it("bag-aware in-flight commits (no failures yet) are NOT surfaced", () => {
+    const g = mkGroup({
+      commitments: [mkCommit({ id: "c-bz", payment_status: "setup_complete" })],
+      bagChargesByCommitmentId: {
+        "c-bz": [
+          mkBag({ commitment_id: "c-bz", payment_status: "charged" }),
+          mkBag({ commitment_id: "c-bz", payment_status: "awaiting_charge" }),
+        ],
+      },
+    });
+    const d = deriveNeedsAttentionDisplay(g);
+    expect(d.hasAny).toBe(false);
+    expect(d.failedKg).toBe(0);
   });
 });

--- a/components/buyer-commitments/bucket-by-lifecycle.ts
+++ b/components/buyer-commitments/bucket-by-lifecycle.ts
@@ -205,6 +205,77 @@ function hasChargeFailed(group: CommitmentGroup): boolean {
 }
 
 /**
+ * Inputs the `NeedsAttentionCard` renders. Pure derivation so the card
+ * component itself stays a thin shell — and so the bag-aware "X of Y bags
+ * couldn't be charged" messaging can be tested without spinning up React.
+ *
+ * Returns:
+ *   • `failedKg`  — total kg the buyer LOST (sum of failed bag rows for
+ *                   bag-aware commits; commitment.quantity_kg for legacy
+ *                   charge_failed rows).
+ *   • `reason`    — buyer-facing failure blurb. Bag-aware: a count-based
+ *                   message ("X of Y bags couldn't be charged") since the
+ *                   raw `failed_reason` codes (`missing_payment_method`,
+ *                   `auth_probe_failed`) aren't buyer-meaningful. Legacy:
+ *                   the commitment's `payment_error` if set, else a
+ *                   generic "card was declined" line.
+ *   • `hasAny`    — true when at least one commit in the group is in the
+ *                   `failed` effective state. Card consumers can short-
+ *                   circuit on false.
+ */
+export interface NeedsAttentionDisplay {
+  failedKg: number;
+  reason: string;
+  hasAny: boolean;
+}
+
+export function deriveNeedsAttentionDisplay(
+  group: CommitmentGroup
+): NeedsAttentionDisplay {
+  let failedKg = 0;
+  let failedBags = 0;
+  let totalBags = 0;
+  let legacyReason: string | null = null;
+  let anyFailed = false;
+
+  for (const c of group.commitments) {
+    const bags = group.bagChargesByCommitmentId?.[c.id];
+    const state = effectiveChargeState(c, bags);
+    if (state !== "failed") continue;
+    anyFailed = true;
+
+    if (bags && bags.length > 0) {
+      // Bag-aware: sum kg of failed rows and accumulate the failed/total
+      // counts so the message can read "X of Y bags …".
+      totalBags += bags.length;
+      for (const b of bags) {
+        if (b.payment_status === "payment_failed") {
+          failedKg += Number(b.kg || 0);
+          failedBags += 1;
+        }
+      }
+    } else {
+      // Legacy: the whole commitment is failed. Use quantity_kg as the
+      // lost weight and pick up payment_error if we have it.
+      failedKg += Number(c.quantity_kg || 0);
+      if (!legacyReason && c.payment_error) legacyReason = c.payment_error;
+    }
+  }
+
+  let reason: string;
+  if (failedBags > 0 && totalBags > 0) {
+    reason =
+      failedBags === totalBags
+        ? "Your card couldn't be charged for any of the bags"
+        : `Your card couldn't be charged for ${failedBags} of ${totalBags} bags`;
+  } else {
+    reason = legacyReason || "Your card was declined";
+  }
+
+  return { failedKg, reason, hasAny: anyFailed };
+}
+
+/**
  * Map a (lot × campaign) group to its lifecycle stage.
  *
  * Whenever a `campaign` is present, the campaign's own status is the

--- a/components/buyer-commitments/needs-attention-card.tsx
+++ b/components/buyer-commitments/needs-attention-card.tsx
@@ -1,7 +1,6 @@
-import Link from "next/link";
-import { Button } from "@merninos/ui";
 import { UnitWeightText } from "@/components/unit-value";
-import { deriveNeedsAttentionDisplay, type CommitmentGroup } from "./bucket-by-lifecycle";
+import { effectiveChargeState, deriveNeedsAttentionDisplay, type CommitmentGroup } from "./bucket-by-lifecycle";
+import { UpdatePaymentButton } from "./update-payment-button";
 
 export interface NeedsAttentionCardProps {
   group: CommitmentGroup;
@@ -21,6 +20,19 @@ export interface NeedsAttentionCardProps {
  */
 export function NeedsAttentionCard({ group }: NeedsAttentionCardProps) {
   const { failedKg, reason } = deriveNeedsAttentionDisplay(group);
+
+  // The card-update flow has to target one commitment id (Stripe Checkout
+  // sessions are 1:1 with a commitment). When the group has multiple
+  // failed commits — rare; would require the same buyer to commit twice
+  // on the same campaign — pick the first failed one and let the button
+  // restart that. The buyer can repeat the action for any remaining
+  // failed commits on subsequent dashboard visits.
+  const failedCommitId =
+    group.commitments.find(
+      (c) =>
+        effectiveChargeState(c, group.bagChargesByCommitmentId?.[c.id]) ===
+        "failed"
+    )?.id ?? null;
 
   return (
     <div
@@ -43,13 +55,7 @@ export function NeedsAttentionCard({ group }: NeedsAttentionCardProps) {
           </div>
         </div>
       </div>
-      <Button asChild size="sm" variant="default" className="self-stretch sm:self-auto">
-        <Link
-          href={`/dashboard/buyer/lot/${group.lotId}${group.hubId ? `?hub=${group.hubId}` : ""}`}
-        >
-          Update payment →
-        </Link>
-      </Button>
+      {failedCommitId ? <UpdatePaymentButton commitmentId={failedCommitId} /> : null}
     </div>
   );
 }

--- a/components/buyer-commitments/needs-attention-card.tsx
+++ b/components/buyer-commitments/needs-attention-card.tsx
@@ -1,20 +1,26 @@
 import Link from "next/link";
 import { Button } from "@merninos/ui";
 import { UnitWeightText } from "@/components/unit-value";
-import type { CommitmentGroup } from "./bucket-by-lifecycle";
+import { deriveNeedsAttentionDisplay, type CommitmentGroup } from "./bucket-by-lifecycle";
 
 export interface NeedsAttentionCardProps {
   group: CommitmentGroup;
 }
 
 /**
- * Surfaces a commitment whose payment has failed (`payment_status = 'charge_failed'`).
+ * Surfaces a commitment whose payment has failed.
+ *
+ * "Failed" is read via `deriveNeedsAttentionDisplay`, which considers both
+ * legacy `commitment.payment_status === 'charge_failed'` AND bag-aware
+ * `commitment_bag_charges.payment_status === 'payment_failed'`. Without
+ * that derivation a bag-aware commit with every bag dead would render as
+ * `0 kg · Charge failed — retrying` because the legacy commitment-level
+ * field stays parked at `setup_complete`.
+ *
  * Excluded from cycle math; the user's only action is to fix payment.
  */
 export function NeedsAttentionCard({ group }: NeedsAttentionCardProps) {
-  const failed = group.commitments.filter((c) => c.payment_status === "charge_failed");
-  const failedKg = failed.reduce((s, c) => s + Number(c.quantity_kg || 0), 0);
-  const reason = failed.find((c) => c.payment_error)?.payment_error || "Charge failed — retrying";
+  const { failedKg, reason } = deriveNeedsAttentionDisplay(group);
 
   return (
     <div

--- a/components/buyer-commitments/update-payment-button.tsx
+++ b/components/buyer-commitments/update-payment-button.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@merninos/ui";
+
+export interface UpdatePaymentButtonProps {
+  commitmentId: string;
+}
+
+/**
+ * Client-side "Update payment" affordance for the bag-aware needs-attention
+ * surface. POSTs to `/api/commitments/[id]/restart-setup`, then redirects
+ * the buyer to the Stripe-hosted setup session returned by the route.
+ * When the buyer completes setup, the Stripe webhook (a) writes the new PM
+ * onto the commit and (b) re-arms any terminal `payment_failed` bag rows
+ * via `lib/bag-charge-rearm.ts` — the worker then retries them with the
+ * new card on the next cron tick.
+ *
+ * Embedded inside the otherwise server-rendered `NeedsAttentionCard` so
+ * the surrounding layout stays a server component.
+ */
+export function UpdatePaymentButton({ commitmentId }: UpdatePaymentButtonProps) {
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleClick() {
+    if (pending) return;
+    setPending(true);
+    setError(null);
+    try {
+      const res = await fetch(
+        `/api/commitments/${commitmentId}/restart-setup`,
+        { method: "POST" }
+      );
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error || `Couldn't start the update (${res.status})`);
+      }
+      const { url } = (await res.json()) as { url: string };
+      // Stripe-hosted Checkout — full-page redirect so cookies/session
+      // round-trip cleanly. `window.location.href` is the documented
+      // pattern in Stripe's docs for this flow.
+      window.location.href = url;
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : "Something went sideways. Try again in a sec."
+      );
+      setPending(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-1 self-stretch sm:self-auto">
+      <Button
+        type="button"
+        size="sm"
+        variant="default"
+        onClick={handleClick}
+        disabled={pending}
+        aria-busy={pending}
+      >
+        {pending ? "Opening Stripe…" : "Update payment →"}
+      </Button>
+      {error ? (
+        <span
+          className="font-headline text-[11px] font-bold text-tomato"
+          role="alert"
+        >
+          {error}
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/lib/__tests__/bag-charge-rearm.test.ts
+++ b/lib/__tests__/bag-charge-rearm.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Tests for `rearmFailedBagCharges` — the helper that flips terminal
+ * `payment_failed` bag rows back to `awaiting_charge` after a buyer
+ * completes a fresh Stripe setup session via the restart-setup flow.
+ *
+ * Failure cases this guards:
+ * - Re-arming a row without rotating `stripe_idempotency_key` (Stripe's
+ *   cache would replay the previous decline).
+ * - Re-arming rows that aren't `payment_failed` (would clobber a worker
+ *   tick that's already mid-charge).
+ * - Wiping non-bag-aware commits or other commits' bag rows.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { rearmFailedBagCharges } from "../bag-charge-rearm";
+
+// Captured calls — one entry per .from(...).update(...) chain that
+// resolves a .then(). Mirrors the shape used by the webhook tests so
+// assertions read consistently.
+const updateCalls: Array<{
+  table: string;
+  payload: Record<string, unknown>;
+  filters: Array<{ op: string; col: string; val: unknown }>;
+}> = [];
+
+// Configurable shape for the SELECT call. Tests override this in their
+// arrange step.
+let selectRows: Array<{ id: string; bag_number: number }> | null = [];
+let selectError: { message: string } | null = null;
+
+// Per-row update errors keyed by row id. Default: success on every row.
+let updateErrorsByRowId: Record<string, { message: string } | undefined> = {};
+
+function makeChain(table: string) {
+  let mode: "select" | "update" | null = null;
+  let pendingUpdatePayload: Record<string, unknown> | null = null;
+  const filters: Array<{ op: string; col: string; val: unknown }> = [];
+
+  const chain: Record<string, unknown> = {
+    select: vi.fn(() => {
+      mode = "select";
+      return chain;
+    }),
+    update: vi.fn((payload: Record<string, unknown>) => {
+      mode = "update";
+      pendingUpdatePayload = payload;
+      return chain;
+    }),
+    eq: vi.fn((col: string, val: unknown) => {
+      filters.push({ op: "eq", col, val });
+      return chain;
+    }),
+    then: (resolve: (v: unknown) => void) => {
+      if (mode === "select") {
+        return Promise.resolve({ data: selectRows, error: selectError }).then(
+          resolve
+        );
+      }
+      if (mode === "update" && pendingUpdatePayload) {
+        updateCalls.push({
+          table,
+          payload: pendingUpdatePayload,
+          filters: [...filters],
+        });
+        // Look up a configured per-row error using the .eq("id", rowId) we
+        // captured. Falls back to null (success) for any row that isn't
+        // overridden.
+        const idFilter = filters.find(
+          (f) => f.op === "eq" && f.col === "id"
+        );
+        const rowId = (idFilter?.val as string) || "";
+        const err = updateErrorsByRowId[rowId] ?? null;
+        return Promise.resolve({ data: null, error: err }).then(resolve);
+      }
+      return Promise.resolve({ data: null, error: null }).then(resolve);
+    },
+  };
+  return chain;
+}
+
+const supabase = {
+  from: (table: string) => makeChain(table),
+} as unknown as Parameters<typeof rearmFailedBagCharges>[0];
+
+beforeEach(() => {
+  updateCalls.length = 0;
+  selectRows = [];
+  selectError = null;
+  updateErrorsByRowId = {};
+});
+
+describe("rearmFailedBagCharges", () => {
+  it("returns no_failed_rows when the commitment has no payment_failed bags (happy-no-op path)", async () => {
+    selectRows = [];
+    const result = await rearmFailedBagCharges(supabase, {
+      commitmentId: "c-1",
+      newSetupIntentId: "seti_new_1",
+    });
+    expect(result.status).toBe("no_failed_rows");
+    expect(result.rearmedRowIds).toEqual([]);
+    // No UPDATE chain should have resolved.
+    expect(updateCalls).toEqual([]);
+  });
+
+  it("flips a single payment_failed row to awaiting_charge with a fresh idempotency key", async () => {
+    selectRows = [{ id: "bc-7", bag_number: 1 }];
+
+    const result = await rearmFailedBagCharges(supabase, {
+      commitmentId: "c-1",
+      newSetupIntentId: "seti_new_1",
+    });
+
+    expect(result.status).toBe("rearmed");
+    expect(result.rearmedRowIds).toEqual(["bc-7"]);
+
+    expect(updateCalls).toHaveLength(1);
+    const call = updateCalls[0];
+    expect(call.table).toBe("commitment_bag_charges");
+    expect(call.payload).toMatchObject({
+      payment_status: "awaiting_charge",
+      attempt_count: 0,
+      failed_reason: null,
+      next_attempt_at: null,
+      stripe_payment_intent_id: null,
+      payment_update_email_sent_at: null,
+      // Key MUST be different from the row's original deterministic
+      // settlement key — encodes the new setup_intent so Stripe's
+      // idempotency cache no longer replays the prior decline.
+      stripe_idempotency_key: "retry:seti_new_1:bag:1",
+    });
+    // Scope guard: only flip rows still in payment_failed (prevents racing
+    // with a worker tick that may have re-claimed the row).
+    expect(call.filters).toContainEqual({
+      op: "eq",
+      col: "payment_status",
+      val: "payment_failed",
+    });
+    expect(call.filters).toContainEqual({ op: "eq", col: "id", val: "bc-7" });
+  });
+
+  it("processes every failed row and uses each row's bag_number in its new idempotency key", async () => {
+    selectRows = [
+      { id: "bc-1", bag_number: 1 },
+      { id: "bc-2", bag_number: 2 },
+      { id: "bc-3", bag_number: 3 },
+    ];
+
+    const result = await rearmFailedBagCharges(supabase, {
+      commitmentId: "c-multi",
+      newSetupIntentId: "seti_xyz",
+    });
+
+    expect(result.status).toBe("rearmed");
+    expect(result.rearmedRowIds.sort()).toEqual(["bc-1", "bc-2", "bc-3"]);
+    expect(updateCalls).toHaveLength(3);
+    expect(
+      updateCalls.map((c) => c.payload.stripe_idempotency_key).sort()
+    ).toEqual([
+      "retry:seti_xyz:bag:1",
+      "retry:seti_xyz:bag:2",
+      "retry:seti_xyz:bag:3",
+    ]);
+  });
+
+  it("treats a failed UPDATE on one row as that row not being re-armed; other rows still go through", async () => {
+    selectRows = [
+      { id: "bc-good", bag_number: 1 },
+      { id: "bc-raced", bag_number: 2 },
+    ];
+    updateErrorsByRowId = {
+      "bc-raced": { message: "concurrent worker claimed the row" },
+    };
+
+    const result = await rearmFailedBagCharges(supabase, {
+      commitmentId: "c-race",
+      newSetupIntentId: "seti_race",
+    });
+
+    expect(result.status).toBe("rearmed");
+    expect(result.rearmedRowIds).toEqual(["bc-good"]);
+    expect(updateCalls).toHaveLength(2); // both attempted
+  });
+
+  it("throws when the initial SELECT errors out (callers should not silently proceed)", async () => {
+    selectError = { message: "db connection reset" };
+    await expect(
+      rearmFailedBagCharges(supabase, {
+        commitmentId: "c-x",
+        newSetupIntentId: "seti_x",
+      })
+    ).rejects.toThrow(/db connection reset/);
+  });
+
+  it("is idempotent when the SELECT returns no rows on a second delivery (Stripe webhook retry pattern)", async () => {
+    // First delivery: a row is flipped.
+    selectRows = [{ id: "bc-1", bag_number: 1 }];
+    const first = await rearmFailedBagCharges(supabase, {
+      commitmentId: "c-idem",
+      newSetupIntentId: "seti_idem",
+    });
+    expect(first.status).toBe("rearmed");
+
+    // Second delivery (Stripe's at-least-once redelivery of the same
+    // setup_intent.succeeded event): the row is now `awaiting_charge`,
+    // so SELECT returns []; the helper short-circuits as no_failed_rows.
+    selectRows = [];
+    updateCalls.length = 0;
+    const second = await rearmFailedBagCharges(supabase, {
+      commitmentId: "c-idem",
+      newSetupIntentId: "seti_idem",
+    });
+    expect(second.status).toBe("no_failed_rows");
+    expect(updateCalls).toEqual([]);
+  });
+});

--- a/lib/bag-charge-rearm.ts
+++ b/lib/bag-charge-rearm.ts
@@ -1,0 +1,97 @@
+/**
+ * Bag-aware charge re-arm.
+ *
+ * Fired from the Stripe-webhook setup-mode handlers when a buyer completes
+ * a fresh Stripe Checkout setup session attached to an existing commitment
+ * with at least one terminal `payment_failed` bag row. Flips those rows
+ * back to `awaiting_charge` with a fresh idempotency key so the charge
+ * worker picks them up on the next tick using the buyer's newly-attached
+ * payment method.
+ *
+ * Idempotency:
+ * - Reading `payment_status = 'payment_failed'` and updating with the same
+ *   WHERE clause means a second webhook delivery is a guaranteed no-op:
+ *   the first delivery flipped the row to `awaiting_charge`, the second
+ *   delivery's WHERE clause excludes it.
+ * - The new `stripe_idempotency_key` is derived from the new setup_intent
+ *   id so Stripe webhook retries reuse the same key (no UNIQUE collision)
+ *   but a separate restart-setup flow produces a different key (which is
+ *   what we want — the previous key is stuck in Stripe's idempotency cache
+ *   pointing at the failed PaymentIntent and would replay the decline).
+ *
+ * Race with the worker:
+ * - The worker uses a 5-minute lease (`payment_status = 'charging'`).
+ * - Re-arm scopes its UPDATE by `payment_status = 'payment_failed'`, so a
+ *   row already claimed by a concurrent worker tick is left alone.
+ * - The worker only flips a row to `charging` from `awaiting_charge` /
+ *   `retry_scheduled` / `charging` (lease re-claim), so it cannot move a
+ *   `payment_failed` row into `charging` without the re-arm running
+ *   first.
+ */
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export interface RearmFailedBagChargesArgs {
+  commitmentId: string;
+  /**
+   * The new setup_intent id from the buyer's just-completed Checkout
+   * setup session. Used as the suffix on the row's `stripe_idempotency_key`
+   * so the worker's next Stripe call doesn't hit a cached failed outcome.
+   */
+  newSetupIntentId: string;
+}
+
+export interface RearmFailedBagChargesResult {
+  status: "rearmed" | "no_failed_rows";
+  /** Ids of rows the UPDATE actually changed. Useful for tests + logs. */
+  rearmedRowIds: string[];
+}
+
+export async function rearmFailedBagCharges(
+  supabase: SupabaseClient,
+  args: RearmFailedBagChargesArgs
+): Promise<RearmFailedBagChargesResult> {
+  const { data: failed, error: readError } = await supabase
+    .from("commitment_bag_charges")
+    .select("id, bag_number")
+    .eq("commitment_id", args.commitmentId)
+    .eq("payment_status", "payment_failed");
+
+  if (readError) {
+    throw new Error(
+      `rearmFailedBagCharges read failed: ${readError.message}`
+    );
+  }
+  if (!failed || failed.length === 0) {
+    return { status: "no_failed_rows", rearmedRowIds: [] };
+  }
+
+  const rearmedRowIds: string[] = [];
+  for (const row of failed as Array<{ id: string; bag_number: number }>) {
+    const { error: updateError } = await supabase
+      .from("commitment_bag_charges")
+      .update({
+        payment_status: "awaiting_charge",
+        attempt_count: 0,
+        failed_reason: null,
+        next_attempt_at: null,
+        stripe_payment_intent_id: null,
+        stripe_idempotency_key: `retry:${args.newSetupIntentId}:bag:${row.bag_number}`,
+        // AC13 idempotency stamp — clearing lets the worker re-send the
+        // "card declined" email on a fresh failure with the new card.
+        payment_update_email_sent_at: null,
+      })
+      .eq("id", row.id)
+      // Defensive scope: only flip rows that are still `payment_failed`.
+      // Prevents a race with the charge worker (which might have already
+      // claimed the row from a parallel path) or with a concurrent
+      // re-arm call from a duplicate webhook delivery.
+      .eq("payment_status", "payment_failed");
+    if (!updateError) rearmedRowIds.push(row.id);
+  }
+
+  return {
+    status: rearmedRowIds.length > 0 ? "rearmed" : "no_failed_rows",
+    rearmedRowIds,
+  };
+}


### PR DESCRIPTION
## Summary

Closes the loop on the bag-aware "Needs Attention" surface. After this PR, a buyer who sees a "Charge issue" card on the dashboard can click one button, replace their card on Stripe-hosted Checkout, and have the previously-failed bag charges automatically retried with the new payment method on the next worker tick.

Bundles two commits:

**Commit 1 — Display fix.** `NeedsAttentionCard` was filtering on `commitment.payment_status === 'charge_failed'` which never matches for bag-aware commits (that field stays at `'setup_complete'`). Renders `0 kg · Charge failed — retrying` regardless of how many bags actually died. Replaced with a new `deriveNeedsAttentionDisplay(group)` helper that sums failed-bag kg and builds a count-based message (`"X of Y bags couldn't be charged"`).

**Commit 2 — Full card-update flow.**

| File | Purpose |
|---|---|
| `lib/bag-charge-rearm.ts` | Pure helper. Flips `payment_failed` bag rows back to `awaiting_charge` with a fresh `stripe_idempotency_key` derived from the new setup_intent id. |
| `lib/__tests__/bag-charge-rearm.test.ts` | 7-case test suite. |
| `app/api/commitments/[id]/restart-setup/route.ts` | New POST endpoint. Validates ownership + "something to retry" guard, mints a fresh Stripe Checkout setup session re-using the existing `stripe_customer_id`, returns the redirect URL. |
| `app/api/stripe/webhook/route.ts` | Both setup-mode handlers (`checkout.session.completed` + `setup_intent.succeeded`) now call `rearmFailedBagCharges` on completion. Gated on `probe.ok` (CS path) / `payment_method` present (SI path) so a declined card can't unlock retries. |
| `components/buyer-commitments/update-payment-button.tsx` | New client component. POSTs to the restart-setup endpoint, redirects to Stripe on success, surfaces errors inline. |
| `components/buyer-commitments/needs-attention-card.tsx` | Now embeds the button; passes the failed commit's id. |
| `app/dashboard/buyer/commitments/[id]/page.tsx` | Redirect shim — the AC13 "Your card declined" email links to this URL but it previously 404'd. |

## Idempotency / safety

- **Webhook retry safe**: re-arm's UPDATE is scoped by `payment_status = 'payment_failed'`, so a second Stripe webhook delivery is a guaranteed no-op (the row is already `awaiting_charge`).
- **Stripe idempotency cache**: the new key is `retry:<seti_id>:bag:<N>`. Reuses the same key on webhook retries (no UNIQUE collision) but generates a different key on a separate restart attempt (avoids replaying a cached decline).
- **Worker race**: the per-row UPDATE filters by `payment_status = 'payment_failed'` so a row already claimed by a concurrent worker tick (`'charging'`) isn't overwritten.
- **Declined card guard**: `checkout.session.completed` only calls re-arm when `probe.ok === true`. `setup_intent.succeeded` only calls re-arm when the SI carries a real `payment_method`.
- **First-time setup**: no failed bag rows exist yet, so the helper short-circuits as `no_failed_rows`. Safe to call from every setup completion.

## Test plan

- [x] 7-case `rearmFailedBagCharges` suite: happy single-row, multi-row key derivation, no-failed-rows short-circuit, per-row error isolation, SELECT error propagation, webhook-retry idempotency, scoped update filter.
- [x] 6 `deriveNeedsAttentionDisplay` cases (no failures, legacy with/without payment_error, bag-aware partial/total failure, bag-aware in-flight).
- [x] 4 new webhook regression cases: SI w/ pm → rearm fires; SI w/o pm → no rearm; CS probe.ok → rearm fires; CS probe.fail → no rearm.
- [x] All eleven existing bucket / portfolio tests untouched.
- [ ] Verify on staging: dashboard shows the right card text, clicking the button redirects to Stripe, completing setup re-arms the bag rows, next worker tick charges with the new card.

## Depends on

#87 (bag-aware bucket + portfolio stats refactor). This branch is built on top of #87 — please merge #87 first or rebase as needed.