### PR TITLE
fix(buyer-commitments): fetch SI to resolve PM in syncPendingSetupCommitments

### DIFF
--- a/app/dashboard/buyer/commitments/page.tsx
+++ b/app/dashboard/buyer/commitments/page.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { ShoppingCart } from "lucide-react";
 import { Button } from "@merninos/ui";
 import type { Commitment, ShipmentStatus } from "@/lib/types";
-import { getCheckoutSession, getPaymentIntent } from "@/lib/stripe";
+import { getCheckoutSession, getPaymentIntent, getSetupIntent } from "@/lib/stripe";
 import { addPlatformFee } from "@/lib/pricing";
 import {
   bucketByLifecycle,
@@ -61,16 +61,44 @@ async function syncPendingSetupCommitments(
             .eq("buyer_id", buyerId);
         }
       } else {
+        // Mode=setup. For Checkout Sessions in setup mode, Stripe documents
+        // that `session.payment_method` is NULL — the real PM is attached
+        // to the resulting SetupIntent. Without the fetch-fallback below
+        // we'd write null to `stripe_payment_method_id` and strand the
+        // commit at settlement with `missing_payment_method`. Same pattern
+        // the webhook handler at app/api/stripe/webhook/route.ts:99-110
+        // uses; mirrored here so this fallback sync path matches.
         const setupIntentId = session.setup_intent || null;
-        if (setupIntentId || session.payment_method) {
+        let paymentMethodId: string | null = session.payment_method || null;
+        if (!paymentMethodId && setupIntentId) {
+          try {
+            const setupIntent = await getSetupIntent(setupIntentId);
+            paymentMethodId = setupIntent.payment_method || null;
+          } catch {
+            paymentMethodId = null;
+          }
+        }
+
+        if (setupIntentId || paymentMethodId) {
+          // Defensive payload shape: only include fields we have non-null
+          // values for. The OLD code wrote `stripe_payment_method_id: null`
+          // and `stripe_customer_id: null` unconditionally, which would
+          // overwrite a real PM written by a concurrent webhook delivery.
+          // PR #86 fixed this same clobber pattern in the webhook handler;
+          // applying it here closes the parallel write path.
+          const updatePayload: Record<string, unknown> = {
+            payment_status: "setup_complete",
+            stripe_setup_intent_id: setupIntentId,
+          };
+          if (paymentMethodId) {
+            updatePayload.stripe_payment_method_id = paymentMethodId;
+          }
+          if (session.customer) {
+            updatePayload.stripe_customer_id = session.customer;
+          }
           await supabase
             .from("commitments")
-            .update({
-              payment_status: "setup_complete",
-              stripe_setup_intent_id: setupIntentId,
-              stripe_payment_method_id: session.payment_method || null,
-              stripe_customer_id: session.customer || null,
-            })
+            .update(updatePayload)
             .eq("id", commitment.id)
             .eq("buyer_id", buyerId);
         }


### PR DESCRIPTION
For Stripe Checkout Sessions in mode=setup, `session.payment_method` is
documented to be NULL — the real payment method is attached to the
resulting SetupIntent, not the session. The webhook handler at
app/api/stripe/webhook/route.ts:99-110 already accounts for this with a
follow-up `getSetupIntent` call. The page-render sync function did NOT,
and was writing `stripe_payment_method_id: session.payment_method || null`
on every redirect-back from Stripe.

Effect on the bag-aware flow:

- Every commit that came back via the page-render path (the operative
  path when the webhook isn't reaching the server) ended up at
  `setup_complete` with `stripe_payment_method_id = NULL`.
- At settlement, the charge worker's missing-PM gate fired:
  `lib/charge-worker.ts:274 → markPaymentFailed('missing_payment_method')`.
- Database evidence: 0 of 37 commitments in this DB have ever had a PM
  saved; 20 succeeded via legacy payment-mode (immediate charge), 1
  bag-aware commit got `stripe_setup_intent_id` written but no PM.

PR #86 fixed the same `|| null` clobber in the webhook's
`setup_intent.succeeded` handler. This file was a parallel write path
that PR #86 didn't touch.

Fix:

- Add a follow-up `getSetupIntent` call when the session doesn't have a
  PM, mirroring the webhook handler's pattern.
- Build the UPDATE payload conditionally — only include fields we have
  non-null values for. The old code wrote `stripe_payment_method_id: null`
  and `stripe_customer_id: null` unconditionally, which could overwrite
  a real PM written by a concurrent webhook delivery in the rare ordering
  where the webhook lands first.

Race / ordering notes:

- The page-render sync SELECT filters on `payment_status='pending_setup'`,
  so a successful webhook write to `setup_complete` first means the sync
  skips the row entirely. No race in that ordering.
- If the page-render sync runs first (typical: Stripe redirect lands on
  our server faster than the webhook delivery), we now write the real
  PM via the SI fetch. A subsequent webhook delivery's defensive write
  (PR #86) won't clobber because both code paths only write PM when
  truthy.
- If the SI fetch fails (network glitch), we skip the PM write — the row
  stays at `setup_complete` without a PM, and the webhook is the only
  thing that can rescue it. The orphan-cancel branch in settle-deadlines
  picks up the row at deadline if no PM ever lands.

Separate concern: the webhook isn't successfully running in this
environment (Stripe webhook delivery logs / signature config). This fix
makes the page-render sync a reliable fallback so commits don't strand
at settlement even when the webhook path is broken.