### PR TITLE
fix(settle-deadlines + dashboards): finalize bag-aware campaigns + show settled kg

### DIFF
--- a/app/api/payments/settle-deadlines/__tests__/bag-aware-lifecycle.integration.test.ts
+++ b/app/api/payments/settle-deadlines/__tests__/bag-aware-lifecycle.integration.test.ts
@@ -485,11 +485,15 @@ describe("settle-deadlines bag-aware lifecycle integration (Task 4.15)", () => {
       error: null,
       count: 3,
     });
-    // Three kg_locked_at_settlement stamps — order matches the Map's
-    // insertion order which mirrors the portion expansion: A → B → C.
+    // Three kg_locked_at_settlement (+ status='confirmed') stamps — order
+    // matches the Map's insertion order which mirrors the portion expansion:
+    // A → B → C.
     enqueueRoute("commitments", { data: null, error: null });
     enqueueRoute("commitments", { data: null, error: null });
     enqueueRoute("commitments", { data: null, error: null });
+    // Unallocated-commits SELECT: all 3 commits got bags so the response is
+    // empty (no rows to cancel as "didn't fill a bag").
+    enqueueRoute("commitments", { data: [], error: null });
 
     const res = await POST(makeReq());
     expect(res.status).toBe(200);
@@ -500,14 +504,43 @@ describe("settle-deadlines bag-aware lifecycle integration (Task 4.15)", () => {
     expect(body.results[0]).toMatchObject({
       campaign_id: "camp-1",
       lot_id: "lot-1",
-      outcome: "bag_charges_created",
+      // After the finalize wiring, the outcome flips from
+      // 'bag_charges_created' (interim staging-only state) to 'settled'.
+      // The interim state is now only used as a fallback when
+      // finalize_campaign itself fails.
+      outcome: "settled",
       bag_size_kg: 60,
       completed_bags: 2,
       price_per_kg: 10,
       bag_charges_planned: 3,
       bag_charges_inserted: 3,
       commitments_stamped: 3,
+      unallocated_cancelled: 0,
     });
+
+    // The route MUST call finalize_campaign to move the campaign out of
+    // 'active' once the bag-charge plan is durable. Without this call the
+    // campaign stays 'active' forever and the seller never sees "ship it."
+    expect(rpcCalls).toContainEqual({
+      fn: "finalize_campaign",
+      args: { p_campaign_id: "camp-1", p_outcome: "settled" },
+    });
+
+    // Per-commit stamp must set both kg_locked AND status='confirmed' so the
+    // orphan-cancel pass on a re-entrant run skips them and the seller +
+    // buyer dashboards bucket them as locked-in.
+    const stamps = routeUpdates.filter(
+      (u) =>
+        u.table === "commitments" &&
+        u.payload.kg_locked_at_settlement !== undefined
+    );
+    expect(stamps).toHaveLength(3);
+    for (const stamp of stamps) {
+      expect(stamp.payload).toMatchObject({
+        status: "confirmed",
+        payment_error: null,
+      });
+    }
 
     // Exactly one upsert into commitment_bag_charges with 3 rows.
     const bagChargesUpserts = routeUpserts.filter(

--- a/app/api/payments/settle-deadlines/__tests__/bag-aware-orphan-filter.test.ts
+++ b/app/api/payments/settle-deadlines/__tests__/bag-aware-orphan-filter.test.ts
@@ -257,9 +257,11 @@ describe("settle-deadlines — bag-aware orphan filter regression", () => {
       error: null,
       count: 2,
     });
-    // 7-8) kg_locked_at_settlement stamps
+    // 7-8) kg_locked_at_settlement (+ status='confirmed') stamps
     enqueue("commitments", { data: null, error: null });
     enqueue("commitments", { data: null, error: null });
+    // Unallocated-commits SELECT — both commits got bags, no rows to cancel.
+    enqueue("commitments", { data: [], error: null });
 
     const res = await POST(makeReq());
     expect(res.status).toBe(200);
@@ -273,7 +275,7 @@ describe("settle-deadlines — bag-aware orphan filter regression", () => {
     expect(body.results[0]).toMatchObject({
       campaign_id: "camp-1",
       lot_id: "lot-1",
-      outcome: "bag_charges_created",
+      outcome: "settled",
       completed_bags: 2,
       bag_charges_planned: 2,
       bag_charges_inserted: 2,

--- a/app/api/payments/settle-deadlines/__tests__/bag-aware-skips-legacy-min-kg-gate.test.ts
+++ b/app/api/payments/settle-deadlines/__tests__/bag-aware-skips-legacy-min-kg-gate.test.ts
@@ -20,9 +20,9 @@
  *   3 ≥ 3      → AC7 passes; this is a SUCCESSFUL bag-aware close.
  *
  * Asserts the route takes the bag-aware-success branch:
- *   • result.outcome === 'bag_charges_created'
+ *   • result.outcome === 'settled'
  *   • 3 commitment_bag_charges rows upserted
- *   • finalize_campaign NOT called as 'failed'
+ *   • finalize_campaign called as 'settled' (NOT 'failed')
  *   • createRefund NOT called (legacy refund path never entered)
  *
  * Mocking style mirrors `bag-aware-below-min-bags.test.ts` and the
@@ -283,10 +283,12 @@ describe("settle-deadlines — M9: bag-aware lots skip the legacy kg-minimum gat
       error: null,
       count: 3,
     });
-    // Three kg_locked_at_settlement stamps — one per commit.
+    // Three kg_locked_at_settlement (+ status='confirmed') stamps — one per commit.
     enqueue("commitments", { data: null, error: null });
     enqueue("commitments", { data: null, error: null });
     enqueue("commitments", { data: null, error: null });
+    // Unallocated-commits SELECT — all 3 commits got bags, nothing to cancel.
+    enqueue("commitments", { data: [], error: null });
 
     const res = await POST(makeReq());
     expect(res.status).toBe(200);
@@ -295,11 +297,13 @@ describe("settle-deadlines — M9: bag-aware lots skip the legacy kg-minimum gat
     // 1. Route reports bag-aware SUCCESS — not 'failed', not
     //    'minimum_not_met'. This is the load-bearing assertion: pre-fix it
     //    would be 'minimum_not_met' (or 'failed' after refund processing).
+    //    The outcome string updated from 'bag_charges_created' (interim
+    //    label) to 'settled' once finalize_campaign was wired in.
     expect(body.processed_campaigns).toBe(1);
     expect(body.results[0]).toMatchObject({
       campaign_id: "camp-m9",
       lot_id: "lot-m9",
-      outcome: "bag_charges_created",
+      outcome: "settled",
       bag_size_kg: 60,
       completed_bags: 3,
       bag_charges_planned: 3,

--- a/app/api/payments/settle-deadlines/route.ts
+++ b/app/api/payments/settle-deadlines/route.ts
@@ -895,21 +895,100 @@ async function settleDeadlines(request: Request) {
       // Stamp kg_locked_at_settlement on each commit even on retry — the
       // value is derived from the (deterministic) bag assignment, so
       // re-writing it is safe and lets a retry self-heal a missed update.
+      // Also flip status → 'confirmed' so the orphan-cancel pass on a
+      // re-entrant run skips these (the filter excludes 'confirmed' rows),
+      // and so seller/buyer dashboards bucket them as locked-in rather than
+      // pending.
       let commitmentsStamped = 0;
       if (!debug && !bagChargesInsertError) {
         for (const [commitmentId, lockedKg] of lockedKgByCommitment) {
           const { error: updateError } = await admin
             .from("commitments")
-            .update({ kg_locked_at_settlement: lockedKg })
+            .update({
+              kg_locked_at_settlement: lockedKg,
+              status: "confirmed",
+              payment_error: null,
+            })
             .eq("id", commitmentId);
           if (!updateError) commitmentsStamped += 1;
+        }
+      }
+
+      // Cancel commits that finished setup but didn't get any bag at
+      // allocation (their leftover kg didn't fill a bag, or the bag count
+      // ran out before reaching them). Without this they'd stay at
+      // status='pending' forever — neither confirmed (because no bag) nor
+      // cancelled. The buyer's card was never charged so there's no
+      // refund to issue.
+      let unallocatedCancelled = 0;
+      if (!debug && !bagChargesInsertError) {
+        const allocatedIds = Array.from(lockedKgByCommitment.keys());
+        const { data: unallocated } = allocatedIds.length > 0
+          ? await admin
+              .from("commitments")
+              .select("id")
+              .eq("campaign_id", campaign.id)
+              .eq("payment_status", "setup_complete")
+              .neq("status", "cancelled")
+              .neq("status", "confirmed")
+              .not("id", "in", `(${allocatedIds.join(",")})`)
+          : await admin
+              .from("commitments")
+              .select("id")
+              .eq("campaign_id", campaign.id)
+              .eq("payment_status", "setup_complete")
+              .neq("status", "cancelled")
+              .neq("status", "confirmed");
+        for (const row of unallocated || []) {
+          const { error } = await admin
+            .from("commitments")
+            .update({
+              status: "cancelled",
+              payment_status: "cancelled",
+              payment_error:
+                "Didn't fill a bag at settlement — no charge issued",
+            })
+            .eq("id", row.id);
+          if (!error) unallocatedCancelled += 1;
+        }
+      }
+
+      // Atomically transition the campaign to 'settled' + recycle the lot.
+      // Mirrors the legacy path at the bottom of this file. Bag-aware
+      // money movement is deferred to the charge worker, but the campaign
+      // itself is "done collecting" at this point — sellers need to ship,
+      // buyers need to see Funds Held on the dashboard. Without this call
+      // the campaign sits at 'active' forever even though the bag plan is
+      // written.
+      let finalizeError: string | null = null;
+      if (!debug && !bagChargesInsertError) {
+        const finalizeResult = await finalizeCampaign(
+          admin,
+          campaign.id,
+          "settled"
+        );
+        if (!finalizeResult.ok) {
+          finalizeError = finalizeResult.error;
+          console.error(
+            `settle-deadlines: finalize_campaign failed for bag-aware settled campaign ${campaign.id}`,
+            finalizeResult.error
+          );
+          finalizeFailures.push({
+            campaign_id: campaign.id,
+            outcome: "settled",
+            error: finalizeResult.error,
+          });
         }
       }
 
       results.push({
         campaign_id: campaign.id,
         lot_id: lot.id,
-        outcome: bagChargesInsertError ? "failed" : "bag_charges_created",
+        outcome: bagChargesInsertError
+          ? "failed"
+          : finalizeError
+            ? "bag_charges_created"
+            : "settled",
         bag_size_kg: lotBagSizeKg,
         completed_bags: bagPricing.completed_bags,
         price_per_kg: pricePerKg,
@@ -917,8 +996,10 @@ async function settleDeadlines(request: Request) {
         bag_charges_planned: chargeRows.length,
         bag_charges_inserted: bagChargesInserted,
         commitments_stamped: commitmentsStamped,
+        unallocated_cancelled: unallocatedCancelled,
         orphans_cancelled: orphansCancelled,
         ...(bagChargesInsertError ? { error: bagChargesInsertError } : {}),
+        ...(finalizeError ? { finalize_error: finalizeError } : {}),
         ...(debug
           ? {
               debug_charge_rows: chargeRows,
@@ -927,10 +1008,26 @@ async function settleDeadlines(request: Request) {
           : {}),
       });
 
-      // Bag-aware lots skip transfer-out, success emails, shipment creation,
-      // finalize_campaign, and the legacy refund path. Those land in
-      // Task 4.6 (fees) / 4.8 (charge worker) / 4.11 (transfer-out) /
-      // 4.7 (min-bags failure mode + finalize wiring).
+      // Fire success notifications + create the shipment row so the seller
+      // sees the shipment task and the buyer sees something queued on the
+      // lifecycle track. Fire-and-forget — a notification failure must not
+      // block the cron from acknowledging the settled campaign.
+      // Gated on a clean finalize so a stuck-active campaign doesn't get
+      // duplicate emails on the next retry tick.
+      if (
+        !debug &&
+        !bagChargesInsertError &&
+        !finalizeError &&
+        commitmentsStamped > 0
+      ) {
+        backgroundTasks.push(
+          sendLotSuccessNotifications(admin, lot.id, campaign.hub_id)
+        );
+        backgroundTasks.push(
+          createShipmentForLot(lot.id, campaign.hub_id, campaign.id)
+        );
+      }
+
       continue;
     }
 

--- a/app/dashboard/seller/commitments/[lotId]/page.tsx
+++ b/app/dashboard/seller/commitments/[lotId]/page.tsx
@@ -7,6 +7,7 @@ import { Badge } from "@merninos/ui";
 import { UnitWeightText, UnitPriceText } from "@/components/unit-value";
 import { SellerCampaignPreview } from "@/components/seller-campaign-preview";
 import { getTierProgress } from "@/lib/tier-progress";
+import { commitmentDisplayKg } from "@/lib/commitment-kg";
 
 const statusBadge: Record<
   "Open / At Risk" | "Open / Guaranteed" | "Successful",
@@ -72,9 +73,46 @@ export default async function SellerLotCommitmentsPage({
   ]);
 
   const tiers = pricingTiers || [];
+  // Tier resolution + status math source the kg total from commits, not
+  // `lot.committed_quantity_kg` — finalize_campaign resets that to 0 the
+  // moment a campaign settles (the lot is recycled), so reading it here
+  // would render a settled campaign at tier 0 / "At Risk".
+  // We compute it after the commitments fetch below.
+
+  let commitments: {
+    id: string;
+    quantity_kg: number;
+    kg_locked_at_settlement: number | null;
+    created_at: string;
+    buyer: { company_name: string | null; contact_name: string | null } | null;
+  }[] = [];
+
+  if (campaign) {
+    const { data } = await supabase
+      .from("commitments")
+      .select(
+        "id, quantity_kg, kg_locked_at_settlement, created_at, buyer:profiles!commitments_buyer_id_fkey(company_name, contact_name)"
+      )
+      .eq("campaign_id", campaign.id)
+      .neq("status", "cancelled")
+      .order("created_at", { ascending: false });
+    commitments = (data || []) as unknown as typeof commitments;
+  }
+
+  const hub = (campaign?.hub as unknown) as { id: string; name: string } | null;
+
+  // Source of truth for the lot total: sum of commits' display kg.
+  // - Pre-settle: matches lot.committed_quantity_kg (sum of buyer pledges).
+  // - Post-settle: sums kg_locked_at_settlement, since finalize_campaign
+  //   has reset lot.committed_quantity_kg to 0.
+  const totalCommittedKg = commitments.reduce(
+    (sum, c) => sum + commitmentDisplayKg(c),
+    0
+  );
+
   const currentPricePerKg = getTierProgress(
     {
-      committed_quantity_kg: Number(lot.committed_quantity_kg || 0),
+      committed_quantity_kg: totalCommittedKg,
       price_per_kg: Number(lot.price_per_kg || 0),
       bag_size_kg: lot.bag_size_kg ?? null,
     },
@@ -85,36 +123,16 @@ export default async function SellerLotCommitmentsPage({
     }))
   ).currentPricePerKg;
 
-  let commitments: {
-    id: string;
-    quantity_kg: number;
-    created_at: string;
-    buyer: { company_name: string | null; contact_name: string | null } | null;
-  }[] = [];
-
-  if (campaign) {
-    const { data } = await supabase
-      .from("commitments")
-      .select(
-        "id, quantity_kg, created_at, buyer:profiles!commitments_buyer_id_fkey(company_name, contact_name)"
-      )
-      .eq("campaign_id", campaign.id)
-      .neq("status", "cancelled")
-      .order("created_at", { ascending: false });
-    commitments = (data || []) as unknown as typeof commitments;
-  }
-
-  const hub = (campaign?.hub as unknown) as { id: string; name: string } | null;
-
   // Bag-aware status: "Guaranteed" when completed_bags >= min_bags_to_succeed.
-  // Legacy lots keep the kg threshold check.
+  // Legacy lots keep the kg threshold check. Both use the commit-sourced total
+  // so a settled campaign keeps showing the right status label after recycle.
   const lotBagSizeKg =
     lot.bag_size_kg != null && Number(lot.bag_size_kg) > 0
       ? Number(lot.bag_size_kg)
       : null;
   const isLotBagAware = lotBagSizeKg !== null;
   const completedBagsForStatus = isLotBagAware
-    ? Math.floor(Number(lot.committed_quantity_kg) / lotBagSizeKg)
+    ? Math.floor(totalCommittedKg / lotBagSizeKg)
     : 0;
   const minBagsForStatus = Number(lot.min_bags_to_succeed || 0);
 
@@ -125,7 +143,7 @@ export default async function SellerLotCommitmentsPage({
     } else if (
       isLotBagAware
         ? completedBagsForStatus >= minBagsForStatus
-        : Number(lot.committed_quantity_kg) >= Number(lot.min_commitment_kg)
+        : totalCommittedKg >= Number(lot.min_commitment_kg)
     ) {
       statusLabel = "Open / Guaranteed";
     } else {
@@ -133,10 +151,6 @@ export default async function SellerLotCommitmentsPage({
     }
   }
 
-  const totalCommittedKg = commitments.reduce(
-    (sum, c) => sum + Number(c.quantity_kg || 0),
-    0
-  );
   const projectedRevenue = totalCommittedKg * currentPricePerKg;
 
   const badge = statusLabel ? statusBadge[statusLabel] : null;
@@ -179,10 +193,13 @@ export default async function SellerLotCommitmentsPage({
 
       {/* Live bag-aware campaign preview — headline status for the seller.
           When bag_size_kg is null (legacy, pre-backfill lot), the component
-          renders its own "bag size missing" prompt. */}
+          renders its own "bag size missing" prompt.
+          Pass the commit-sourced total so the preview keeps showing the
+          right bag count and "If campaign closed now" value even after
+          finalize_campaign has reset lot.committed_quantity_kg to 0. */}
       <div className="mb-6">
         <SellerCampaignPreview
-          total_pledged_kg={Number(lot.committed_quantity_kg) || 0}
+          total_pledged_kg={totalCommittedKg}
           bag_size_kg={Number(lot.bag_size_kg) || 0}
           min_bags_to_succeed={Number(lot.min_bags_to_succeed) || 1}
         />
@@ -248,7 +265,14 @@ export default async function SellerLotCommitmentsPage({
           {commitments.map((c) => {
             const buyerName =
               c.buyer?.company_name || c.buyer?.contact_name || "Unknown Buyer";
-            const sellerAmount = Number(c.quantity_kg || 0) * currentPricePerKg;
+            // Per-commit weight + revenue uses the locked amount once the
+            // campaign settles (bag allocation rounds the buyer's pledge
+            // down to whole bags). Pre-settle it falls back to the pledge.
+            const displayKg = commitmentDisplayKg(c);
+            const sellerAmount = displayKg * currentPricePerKg;
+            const hasPartialFill =
+              c.kg_locked_at_settlement != null &&
+              Number(c.kg_locked_at_settlement) < Number(c.quantity_kg || 0);
             return (
               <Card key={c.id} className="shadow-sm">
                 <CardContent className="p-4">
@@ -264,10 +288,17 @@ export default async function SellerLotCommitmentsPage({
                   </div>
                   <div className="mt-3 grid grid-cols-2 gap-3 text-sm">
                     <div>
-                      <p className="text-xs text-muted-foreground">Weight</p>
-                      <p className="font-medium text-foreground">
-                        <UnitWeightText kg={Number(c.quantity_kg)} />
+                      <p className="text-xs text-muted-foreground">
+                        {hasPartialFill ? "Weight settled" : "Weight"}
                       </p>
+                      <p className="font-medium text-foreground">
+                        <UnitWeightText kg={displayKg} />
+                      </p>
+                      {hasPartialFill && (
+                        <p className="mt-0.5 text-xs text-muted-foreground">
+                          Pledged <UnitWeightText kg={Number(c.quantity_kg)} /> · leftover didn&apos;t fill a bag
+                        </p>
+                      )}
                     </div>
                     <div>
                       <p className="text-xs text-muted-foreground">Your Amount</p>

--- a/app/dashboard/seller/commitments/page.tsx
+++ b/app/dashboard/seller/commitments/page.tsx
@@ -2,6 +2,7 @@ import { createClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
 import { SellerCommitmentsClient, type LotCampaignCard } from "@/components/seller-commitments-client";
 import { getTierProgress } from "@/lib/tier-progress";
+import { commitmentDisplayKg } from "@/lib/commitment-kg";
 
 export default async function SellerCommitmentsPage() {
   const supabase = await createClient();
@@ -37,7 +38,7 @@ export default async function SellerCommitmentsPage() {
       campaignIds.length > 0
         ? supabase
             .from("commitments")
-            .select("id, campaign_id, lot_id, quantity_kg")
+            .select("id, campaign_id, lot_id, quantity_kg, kg_locked_at_settlement")
             .in("campaign_id", campaignIds)
             .neq("status", "cancelled")
         : Promise.resolve({ data: [] }),
@@ -47,7 +48,10 @@ export default async function SellerCommitmentsPage() {
         .in("lot_id", lotIds),
     ]);
 
-    const commitmentsByCampaignId: Record<string, { quantity_kg: number }[]> = {};
+    const commitmentsByCampaignId: Record<
+      string,
+      { quantity_kg: number; kg_locked_at_settlement: number | null }[]
+    > = {};
     for (const c of commitments || []) {
       if (!c.campaign_id) continue;
       if (!commitmentsByCampaignId[c.campaign_id]) commitmentsByCampaignId[c.campaign_id] = [];
@@ -75,15 +79,23 @@ export default async function SellerCommitmentsPage() {
       const lotCommitments = commitmentsByCampaignId[campaign.id] || [];
       if (lotCommitments.length === 0) continue;
 
+      // Total kg the seller should plan to ship. Pre-settle: sum of buyer
+      // pledges (matches lot.committed_quantity_kg). Post-settle: sum of
+      // `kg_locked_at_settlement` — finalize_campaign resets
+      // lot.committed_quantity_kg to 0, so we MUST source from commits to
+      // show the right total once the campaign settles.
       const totalCommittedKg = lotCommitments.reduce(
-        (sum, c) => sum + Number(c.quantity_kg || 0),
+        (sum, c) => sum + commitmentDisplayKg(c),
         0
       );
 
       const tiers = tiersByLotId[lot.id] || [];
       const currentPricePerKg = getTierProgress(
         {
-          committed_quantity_kg: Number(lot.committed_quantity_kg || 0),
+          // Same source-of-truth principle for tier resolution: locked total
+          // post-settle, lot.committed_quantity_kg pre-settle. The legacy
+          // value would resolve to tier 0 once the lot is recycled.
+          committed_quantity_kg: totalCommittedKg,
           price_per_kg: Number(lot.price_per_kg || 0),
           bag_size_kg: lot.bag_size_kg ?? null,
         },
@@ -100,7 +112,7 @@ export default async function SellerCommitmentsPage() {
           : null;
       const isLotBagAware = lotBagSizeKg !== null;
       const completedBags = isLotBagAware
-        ? Math.floor(Number(lot.committed_quantity_kg) / lotBagSizeKg)
+        ? Math.floor(totalCommittedKg / lotBagSizeKg)
         : 0;
       const minBags = Number(lot.min_bags_to_succeed || 0);
 
@@ -110,7 +122,7 @@ export default async function SellerCommitmentsPage() {
       } else if (
         isLotBagAware
           ? completedBags >= minBags
-          : Number(lot.committed_quantity_kg) >= Number(lot.min_commitment_kg)
+          : totalCommittedKg >= Number(lot.min_commitment_kg)
       ) {
         statusLabel = "Open / Guaranteed";
       } else {

--- a/components/buyer-commitments/closed-lots-table.tsx
+++ b/components/buyer-commitments/closed-lots-table.tsx
@@ -1,7 +1,14 @@
 import Link from "next/link";
 import { ChevronRight } from "lucide-react";
 import { UnitPriceText, UnitWeightText } from "@/components/unit-value";
-import { stageOfGroup, STAGE_META, type CommitmentGroup, type StageColor } from "./bucket-by-lifecycle";
+import {
+  effectiveChargedCents,
+  stageOfGroup,
+  STAGE_META,
+  type CommitmentGroup,
+  type StageColor,
+} from "./bucket-by-lifecycle";
+import { commitmentDisplayKg } from "@/lib/commitment-kg";
 
 export interface ClosedLotsTableProps {
   groups: CommitmentGroup[];
@@ -42,13 +49,20 @@ function rowDate(g: CommitmentGroup): string | null {
 
 function buildRow(g: CommitmentGroup) {
   const stage = stageOfGroup(g);
-  const succeeded = g.commitments.filter((c) => c.payment_status === "charge_succeeded");
-  const securedKg = succeeded.reduce((s, c) => s + Number(c.quantity_kg || 0), 0);
-  const paid = succeeded.reduce(
-    (s, c) => s + (c.charge_amount_cents != null ? c.charge_amount_cents / 100 : Number(c.total_price || 0)),
+  // Surface non-cancelled commits; "secured" comes from the settlement
+  // allocation (`kg_locked_at_settlement` for bag-aware, `quantity_kg`
+  // pre-settle), not from the legacy `charge_succeeded` filter which
+  // misses every bag-aware commit.
+  const live = g.commitments.filter((c) => c.status !== "cancelled");
+  const securedKg = live.reduce((s, c) => s + commitmentDisplayKg(c), 0);
+  // "Paid" sums cents that actually moved on Stripe — bag-charge `charged`
+  // rows for bag-aware, legacy `charge_amount_cents` for payment-mode.
+  const paidCents = live.reduce(
+    (s, c) => s + effectiveChargedCents(c, g.bagChargesByCommitmentId?.[c.id]),
     0
   );
-  const billed = succeeded.reduce((s, c) => s + Number(c.total_price || 0), 0);
+  const paid = paidCents / 100;
+  const billed = live.reduce((s, c) => s + Number(c.total_price || 0), 0);
   const refunded = Math.max(0, billed - paid);
   const avg = securedKg > 0 ? paid / securedKg : Number(g.lot?.price_per_kg || 0);
   const totalCell = stage === "minimum_not_met" ? `−${fmtMoney(refunded)}` : fmtMoney(paid);

--- a/components/buyer-commitments/commitment-drawer/closed-body.tsx
+++ b/components/buyer-commitments/commitment-drawer/closed-body.tsx
@@ -4,7 +4,11 @@ import { getTierProgress } from "@/lib/tier-progress";
 import { ContributionsTable } from "./contributions-table";
 import { BagBreakdown } from "./bag-breakdown";
 import { refundDollarsFor } from "./refund-amount";
-import type { CommitmentGroup } from "../bucket-by-lifecycle";
+import {
+  effectiveChargedCents,
+  type CommitmentGroup,
+} from "../bucket-by-lifecycle";
+import { commitmentDisplayKg } from "@/lib/commitment-kg";
 
 export interface ClosedDrawerBodyProps {
   group: CommitmentGroup;
@@ -38,18 +42,18 @@ export function ClosedDrawerBody({
 }: ClosedDrawerBodyProps) {
   const lot = group.lot;
 
-  const succeeded = group.commitments.filter(
-    (c) => c.payment_status === "charge_succeeded" && c.status !== "cancelled"
-  );
-  const totalKg = succeeded.reduce((s, c) => s + Number(c.quantity_kg || 0), 0);
-  const paid = succeeded.reduce(
-    (s, c) =>
-      s +
-      (c.charge_amount_cents != null
-        ? c.charge_amount_cents / 100
-        : Number(c.total_price || 0)),
+  // Non-cancelled commits in this group are the "settled" set. Bag-aware
+  // commits stay at `setup_complete` even after picking up, so the legacy
+  // `charge_succeeded` filter would render an empty drawer for them. Read
+  // `kg_locked_at_settlement` via `commitmentDisplayKg` for per-commit kg
+  // so partial-fill rounding shows up correctly.
+  const succeeded = group.commitments.filter((c) => c.status !== "cancelled");
+  const totalKg = succeeded.reduce((s, c) => s + commitmentDisplayKg(c), 0);
+  const paidCents = succeeded.reduce(
+    (s, c) => s + effectiveChargedCents(c, group.bagChargesByCommitmentId?.[c.id]),
     0
   );
+  const paid = paidCents / 100;
   const totalRefund = group.commitments.reduce(
     (s, c) => s + refundDollarsFor(c),
     0
@@ -94,11 +98,14 @@ export function ClosedDrawerBody({
     );
   }
 
-  // Value mode — picked_up | done
+  // Value mode — picked_up | done. The kg axis here must match `paid` so a
+  // partial-fill commit doesn't overstate "saved" by including unsettled kg
+  // in the baseline calculation. `commitmentDisplayKg` returns the locked
+  // amount post-settle and the pledge pre-settle.
   const basePrice = Number(lot?.price_per_kg || 0);
   const baseWithFee = basePrice > 0 ? addPlatformFee(basePrice) : 0;
   const baselinePaid = succeeded.reduce(
-    (s, c) => s + baseWithFee * Number(c.quantity_kg || 0),
+    (s, c) => s + baseWithFee * commitmentDisplayKg(c),
     0
   );
   const saved = Math.max(0, baselinePaid - paid);

--- a/components/buyer-commitments/commitment-drawer/contributions-table.tsx
+++ b/components/buyer-commitments/commitment-drawer/contributions-table.tsx
@@ -1,6 +1,7 @@
 import { Fragment } from "react";
 import type { Commitment } from "@/lib/types";
 import { UnitWeightText } from "@/components/unit-value";
+import { commitmentDisplayKg } from "@/lib/commitment-kg";
 import { refundDollarsFor } from "./refund-amount";
 
 export interface ContributionsTableProps {
@@ -96,7 +97,7 @@ export function ContributionsTable({ commitments }: ContributionsTableProps) {
                   <td className="px-3 py-2.5 align-top">{fmtDate(c.created_at)}</td>
                   <td className="px-3 py-2.5 text-right align-top tabular-nums">
                     <UnitWeightText
-                      kg={Number(c.quantity_kg || 0)}
+                      kg={commitmentDisplayKg(c)}
                       maximumFractionDigits={1}
                     />
                   </td>

--- a/components/buyer-commitments/commitment-drawer/in-motion-body.tsx
+++ b/components/buyer-commitments/commitment-drawer/in-motion-body.tsx
@@ -3,11 +3,13 @@ import { addPlatformFee } from "@/lib/pricing";
 import { UnitWeightText } from "@/components/unit-value";
 import { ContributionsTable } from "./contributions-table";
 import {
+  effectiveChargedCents,
   STAGE_META,
   stageOfGroup,
   type CommitmentGroup,
   type StageColor,
 } from "../bucket-by-lifecycle";
+import { commitmentDisplayKg } from "@/lib/commitment-kg";
 
 export interface InMotionDrawerBodyProps {
   group: CommitmentGroup;
@@ -35,26 +37,30 @@ export function InMotionDrawerBody({ group }: InMotionDrawerBodyProps) {
   const stage = stageOfGroup(group);
   const stageMeta = STAGE_META[stage];
 
-  const succeeded = group.commitments.filter(
-    (c) => c.payment_status === "charge_succeeded" && c.status !== "cancelled"
-  );
-  const settledKg = succeeded.reduce(
-    (s, c) => s + Number(c.quantity_kg || 0),
+  // "Settled" = non-cancelled commits in this group. For bag-aware commits
+  // the per-commit settled weight is `kg_locked_at_settlement` (set by
+  // settle-deadlines once the campaign settles), not the original pledge.
+  // Reading via `commitmentDisplayKg` makes a partial-fill commit show
+  // the actually-locked kg, not the over-pledged amount.
+  const settled = group.commitments.filter((c) => c.status !== "cancelled");
+  const settledKg = settled.reduce(
+    (s, c) => s + commitmentDisplayKg(c),
     0
   );
-  const paid = succeeded.reduce(
-    (s, c) =>
-      s +
-      (c.charge_amount_cents != null
-        ? c.charge_amount_cents / 100
-        : Number(c.total_price || 0)),
+  // Paid = cents that actually moved. Bag-aware: sum of `charged` bag rows.
+  // Legacy: commitment.charge_amount_cents (net of refunds).
+  const paidCents = settled.reduce(
+    (s, c) => s + effectiveChargedCents(c, group.bagChargesByCommitmentId?.[c.id]),
     0
   );
-  // Saved versus base = (base_price_with_fee × kg) − actually paid, summed.
+  const paid = paidCents / 100;
+  // Saved versus base = (base_price_with_fee × kg actually settled) − actually paid.
+  // The kg axis must match `paid` — locked kg post-settle, pledge pre-settle —
+  // otherwise a partial-fill commit overstates "saved" by including unsettled kg.
   const basePrice = Number(lot?.price_per_kg || 0);
   const baseWithFee = basePrice > 0 ? addPlatformFee(basePrice) : 0;
-  const baselinePaid = succeeded.reduce(
-    (s, c) => s + baseWithFee * Number(c.quantity_kg || 0),
+  const baselinePaid = settled.reduce(
+    (s, c) => s + baseWithFee * commitmentDisplayKg(c),
     0
   );
   const saved = Math.max(0, baselinePaid - paid);

--- a/components/buyer-commitments/in-motion-lot-card.tsx
+++ b/components/buyer-commitments/in-motion-lot-card.tsx
@@ -2,7 +2,13 @@ import { ChevronRight } from "lucide-react";
 import { CommitmentPickupButton } from "@/components/commitment-pickup-button";
 import { UnitWeightText } from "@/components/unit-value";
 import { LifecycleTrack } from "./lifecycle-track";
-import { stageOfGroup, type CommitmentGroup } from "./bucket-by-lifecycle";
+import {
+  effectiveChargeState,
+  effectiveChargedCents,
+  stageOfGroup,
+  type CommitmentGroup,
+} from "./bucket-by-lifecycle";
+import { commitmentDisplayKg } from "@/lib/commitment-kg";
 
 export interface InMotionLotCardProps {
   group: CommitmentGroup;
@@ -25,18 +31,41 @@ function fmtRelDays(iso: string | null | undefined): string | null {
 export function InMotionLotCard({ group, onSelect, triggerRef }: InMotionLotCardProps) {
   const lot = group.lot;
   const stage = stageOfGroup(group);
-  const succeeded = group.commitments.filter((c) => c.payment_status === "charge_succeeded");
-  const myKg = succeeded.reduce((s, c) => s + Number(c.quantity_kg || 0), 0);
-  const paid = succeeded.reduce(
-    (s, c) => s + (c.charge_amount_cents != null ? c.charge_amount_cents / 100 : Number(c.total_price || 0)),
+  // Surface every non-cancelled commit, not just legacy `charge_succeeded`
+  // rows. Bag-aware commits stay at `setup_complete` even after settlement
+  // and through "in motion" — the truth of "is this commitment locked in"
+  // lives on `kg_locked_at_settlement` (set by settle-deadlines once the
+  // campaign settles).
+  const live = group.commitments.filter((c) => c.status !== "cancelled");
+  // "My weight" is what was AGREED — quantity_kg pre-settle, the actual
+  // allocated kg_locked_at_settlement post-settle. Reads via
+  // `commitmentDisplayKg` so the bag-aware-rounded amount shows up
+  // correctly when the buyer's pledge didn't fill a whole bag.
+  const myKg = live.reduce((s, c) => s + commitmentDisplayKg(c), 0);
+  // Paid = cents that actually moved on Stripe. Sums bag charges for
+  // bag-aware commits; falls back to legacy `charge_amount_cents` for
+  // payment-mode commits. Same semantics as `effectiveChargedCents` in
+  // the portfolio strip math.
+  const paidCents = live.reduce(
+    (s, c) => s + effectiveChargedCents(c, group.bagChargesByCommitmentId?.[c.id]),
     0
   );
-  const billed = succeeded.reduce((s, c) => s + Number(c.total_price || 0), 0);
+  const paid = paidCents / 100;
+  // Billed = gross before refunds. For bag-aware this is locked_kg × price
+  // before any failed-bag credit; for legacy it's the commitment.total_price.
+  const billed = live.reduce((s, c) => s + Number(c.total_price || 0), 0);
   const refunded = Math.max(0, billed - paid);
   const settlementFailed = lot?.settlement_status === "failed";
 
-  // Use the most-recent at-hub-stage commitment for the pickup button (any one will do — the API marks per-commitment)
-  const pickupCommitmentId = succeeded[0]?.id ?? group.commitments[0]?.id;
+  // Pickup button targets any commit at the at-hub stage. Prefer one that's
+  // confirmed-and-paid (effective state succeeded) since those are the
+  // commits eligible to pick up; fall back to the first live one.
+  const pickupCommitmentId =
+    live.find(
+      (c) =>
+        effectiveChargeState(c, group.bagChargesByCommitmentId?.[c.id]) ===
+        "succeeded"
+    )?.id ?? live[0]?.id ?? group.commitments[0]?.id;
 
   let nextEvent: string | null = null;
   if (stage === "in_transit") {

--- a/lib/__tests__/commitment-kg.test.ts
+++ b/lib/__tests__/commitment-kg.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Unit tests for `commitmentDisplayKg` — the helper that powers seller and
+ * buyer "how much of this commit is real" displays.
+ *
+ * Failure cases this guards:
+ * - A settled bag-aware commit displaying the pre-settle pledge (regression
+ *   user reported: "shows the total amount in weight the user committed to,
+ *   not the total amount that settled").
+ * - A pre-settle commit displaying 0 because `kg_locked_at_settlement` is
+ *   null (the bag-aware allocation hasn't run yet).
+ * - A 0-locked commit (allocated nothing — leftover didn't fill a bag)
+ *   falling back to the pledge by mistake.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  commitmentDisplayKg,
+  totalCommitmentDisplayKg,
+} from "../commitment-kg";
+
+describe("commitmentDisplayKg", () => {
+  it("returns kg_locked_at_settlement when the campaign has settled", () => {
+    expect(
+      commitmentDisplayKg({ quantity_kg: 72, kg_locked_at_settlement: 63 })
+    ).toBe(63);
+  });
+
+  it("returns quantity_kg pre-settle (kg_locked is null)", () => {
+    expect(
+      commitmentDisplayKg({ quantity_kg: 72, kg_locked_at_settlement: null })
+    ).toBe(72);
+  });
+
+  it("treats kg_locked_at_settlement === 0 as 'no bag allocated' and falls back to pledge", () => {
+    // A buyer who pledged 25 kg but the bag-allocator gave them 0 bags
+    // (their kg didn't fill a bag) ends up with kg_locked = 0. The display
+    // should still show the pledge so the buyer sees the original commit;
+    // the dropped-kg surface elsewhere narrates "you didn't get any bags."
+    expect(
+      commitmentDisplayKg({ quantity_kg: 25, kg_locked_at_settlement: 0 })
+    ).toBe(25);
+  });
+
+  it("treats kg_locked_at_settlement equal to quantity_kg as a clean fill (multi-bag commit)", () => {
+    expect(
+      commitmentDisplayKg({ quantity_kg: 120, kg_locked_at_settlement: 120 })
+    ).toBe(120);
+  });
+
+  it("coerces numeric strings (Supabase decimal columns arrive as strings via JSON)", () => {
+    expect(
+      commitmentDisplayKg({
+        quantity_kg: "72.07583" as unknown as number,
+        kg_locked_at_settlement: "63" as unknown as number,
+      })
+    ).toBe(63);
+  });
+
+  it("returns 0 when both fields are null/missing (shouldn't happen in prod but stays defensive)", () => {
+    expect(
+      commitmentDisplayKg({
+        quantity_kg: 0,
+        kg_locked_at_settlement: null,
+      })
+    ).toBe(0);
+  });
+});
+
+describe("totalCommitmentDisplayKg", () => {
+  it("sums display kg across mixed pre-settle / post-settle commits in the same campaign", () => {
+    // Realistic post-settle shape: every commit has kg_locked set. The
+    // total should match `completed_bags × bag_size_kg`.
+    const out = totalCommitmentDisplayKg([
+      { quantity_kg: 72.07583, kg_locked_at_settlement: 63 },
+      { quantity_kg: 90, kg_locked_at_settlement: 63 },
+      // Edge case: a commit that didn't get any bag at allocation.
+      { quantity_kg: 8, kg_locked_at_settlement: 0 },
+    ]);
+    // 63 + 63 + 8 (the 0-locked falls back to pledge per the helper rule)
+    expect(out).toBe(134);
+  });
+
+  it("returns 0 for an empty list", () => {
+    expect(totalCommitmentDisplayKg([])).toBe(0);
+  });
+});

--- a/lib/commitment-kg.ts
+++ b/lib/commitment-kg.ts
@@ -1,0 +1,38 @@
+import type { Commitment } from "@/lib/types";
+
+/**
+ * Effective kg for "this is my commitment" displays — the unit-side analog
+ * of "what was agreed to."
+ *
+ * Pre-settlement (campaign still active or just past deadline): the buyer's
+ * pledged `quantity_kg`. They wanted N kg, they pledged for N kg.
+ *
+ * Post-settlement (bag-aware): `kg_locked_at_settlement`, the actual weight
+ * allocated to bags for this commit. Bag-aware allocation rounds down to a
+ * whole multiple of `bag_size_kg`, so the locked amount is always ≤ the
+ * pledge. The leftover (`quantity_kg − kg_locked_at_settlement`) is the
+ * fractional bag that didn't fill — those kg never ship and were never
+ * charged.
+ *
+ * For charged-vs-failed accounting (Landing Soon / YTD Spend / etc.), use
+ * `effectiveChargedKg` in `bucket-by-lifecycle.ts` instead — that sums the
+ * `charged` bag rows, which can be less than the locked amount when some
+ * bags failed.
+ */
+export function commitmentDisplayKg(
+  c: Pick<Commitment, "quantity_kg" | "kg_locked_at_settlement">
+): number {
+  const locked = c.kg_locked_at_settlement;
+  if (locked != null && Number(locked) > 0) return Number(locked);
+  return Number(c.quantity_kg || 0);
+}
+
+/**
+ * Sum of `commitmentDisplayKg` across a list. Handy for the seller's
+ * "total settled" line and the buyer's per-group totals.
+ */
+export function totalCommitmentDisplayKg(
+  commitments: Array<Pick<Commitment, "quantity_kg" | "kg_locked_at_settlement">>
+): number {
+  return commitments.reduce((sum, c) => sum + commitmentDisplayKg(c), 0);
+}


### PR DESCRIPTION
## Summary

Three intertwined bugs that surfaced once bag-aware charging started working in production. They all stem from the same missing piece: the bag-aware branch of `settle-deadlines` wrote the bag-charge plan but never moved the campaign out of `active`, and downstream UI was still reading legacy pre-settle data.

Production evidence: campaign `314bf1fc-…` had its bag successfully charged (`bag_transfers` row with seller + hub Stripe transfer ids) but `campaigns.status` was still `active` two hours later. The charge worker did its job; the route just never closed the campaign.

## Three fixes in one PR

### 1. `settle-deadlines` bag-aware branch now finalizes the campaign

In `app/api/payments/settle-deadlines/route.ts`, after the bag-charge upsert + `kg_locked_at_settlement` stamp:

- Per-commit status flip → `'confirmed'` (clears `payment_error`).
- Cancel commits that didn't get any bag at allocation (leftover kg < bag_size_kg, or bag count ran out). Stamps `"Didn't fill a bag at settlement — no charge issued"`.
- Call `finalizeCampaign(admin, campaign.id, 'settled')` — same RPC the legacy branch uses. Flips campaign to `settled`, recycles the lot, clears `hub_lots`.
- Fire `sendLotSuccessNotifications` + `createShipmentForLot` as background tasks (gated on `commitmentsStamped > 0`).
- Result outcome flips from interim `'bag_charges_created'` to `'settled'` (the interim label is now only used when the finalize RPC itself fails — next cron tick retries safely because the bag-charge upsert is idempotent).

### 2. Seller commitments pages show settled bags, not pledged kg

`app/dashboard/seller/commitments/page.tsx` + `…/[lotId]/page.tsx`:

- Fetch `kg_locked_at_settlement` alongside `quantity_kg`.
- Compute totals by summing `commitmentDisplayKg(c)` across commits — never from `lot.committed_quantity_kg`. Right both pre-settle (sum of pledges) and post-settle (sum of locked kg, since `finalize_campaign` resets the lot value to 0).
- Pass the commit-sourced total to `SellerCampaignPreview` and `getTierProgress`.
- Per-commit row shows **"Weight settled"** with the pledge as secondary text when there's a partial fill (e.g. pledged 72.07583 kg → settled 63 kg, leftover 9 kg didn't fill a bag).

### 3. Buyer commitments components show settled bags, not pledged kg

Same legacy-only bug in five components:

- `in-motion-lot-card.tsx` · `closed-lots-table.tsx`
- `commitment-drawer/in-motion-body.tsx` · `closed-body.tsx` · `contributions-table.tsx`

All previously filtered on `payment_status === 'charge_succeeded'` (excluded every bag-aware commit) and summed `Number(c.quantity_kg)` (overstating partial-fill).

Now they filter on `status !== 'cancelled'` (so bag-aware commits surface) and sum `commitmentDisplayKg(c)`. "Paid" sums use `effectiveChargedCents` from PR #87 so bag-aware partial-success commits credit only the bags whose money actually moved.

## New helper — `lib/commitment-kg.ts`

```ts
commitmentDisplayKg(c): number
//   kg_locked_at_settlement when set (> 0) → locked kg
//   else                                   → quantity_kg
```

Plus `totalCommitmentDisplayKg(commits)` for list sums.

## Test plan

- [x] Updated `bag-aware-lifecycle.integration.test.ts`, `bag-aware-orphan-filter.test.ts`, `bag-aware-skips-legacy-min-kg-gate.test.ts` for the new `'settled'` outcome + the additional `commitments` SELECT for unallocated cancellation. Added an explicit assertion that `finalize_campaign` is RPC-called with the right args.
- [x] Six new unit tests for the kg helper in `lib/__tests__/commitment-kg.test.ts`.
- [x] Existing drawer body tests use legacy-shaped fixtures (`kg_locked_at_settlement: null`), so the helper falls back to `quantity_kg` and assertions don't change.
- [ ] Verify on staging: a fresh bag-aware campaign settles → campaign flips to `settled`, seller dashboard says "Successful" with the right total kg, buyer dashboard moves the group to In Motion.
- [ ] Verify the stuck campaign `314bf1fc-…` heals on the next cron tick (upsert is idempotent — existing bag-charge row is skipped; finalize fires).

## Remediation for the in-flight stuck campaign

The next `settle-deadlines` cron tick after this deploys will pick up campaign `314bf1fc-…` (still in scope: deadline past, `status='active'`), re-run the bag-aware branch (existing bag-charge row is skipped by `ON CONFLICT DO NOTHING`), stamp `kg_locked_at_settlement + status='confirmed'` on the commit, and call `finalize_campaign`. **No manual DB intervention needed.**

---
_Generated by [Claude Code](https://claude.ai/code/session_01NLEJsqpZtVmEJZUCLNfNJ2)_