### PR TITLE
fix(contributions-table): show settled total + dropped sub-row for partial fills

### DIFF
--- a/components/buyer-commitments/commitment-drawer/__tests__/contributions-table.test.tsx
+++ b/components/buyer-commitments/commitment-drawer/__tests__/contributions-table.test.tsx
@@ -87,17 +87,197 @@ describe("ContributionsTable", () => {
     expect(screen.queryByTestId("commitment-refund-c-none")).not.toBeInTheDocument();
   });
 
-  it("falls back to total_price when charge_amount_cents is null", () => {
+  it("shows $0 when no money has actually moved (charge_amount_cents null + no bag rows)", () => {
+    // Pre-fix this fell back to total_price (the buyer's pre-settle PLEDGE)
+    // even though the card was never charged — overstated what the buyer
+    // had paid. Now reflects actual money moved on Stripe via
+    // effectiveChargedCents, which returns 0 in this anomalous state.
     const commitments: Commitment[] = [
       makeCommitment({
-        id: "c-fallback",
+        id: "c-no-cents",
         charge_amount_cents: null,
         total_price: 99,
+        payment_status: "setup_complete",
       }),
     ];
     render(<ContributionsTable commitments={commitments} />);
-    const row = screen.getByTestId("commitment-row-c-fallback");
-    expect(row.textContent).toContain("$99.00");
+    const row = screen.getByTestId("commitment-row-c-no-cents");
+    expect(row.textContent).toContain("$0.00");
+  });
+
+  it("shows $0 for cancelled commits (never charged the card)", () => {
+    const commitments: Commitment[] = [
+      makeCommitment({
+        id: "c-cancelled",
+        status: "cancelled",
+        payment_status: "cancelled",
+        charge_amount_cents: null,
+        total_price: 132,
+      }),
+    ];
+    render(<ContributionsTable commitments={commitments} />);
+    const row = screen.getByTestId("commitment-row-c-cancelled");
+    expect(row.textContent).toContain("$0.00");
+  });
+
+  // -------------------------------------------------------------------------
+  // Bag-aware partial-fill scenarios (the user-reported bug)
+  // -------------------------------------------------------------------------
+  // A buyer pledged 72 kg against a 63-kg bag; settlement locked 1 bag
+  // (63 kg) and dropped the leftover 9 kg. The table should now show:
+  //   parent row: 63 kg @ $880  (Paid)
+  //   dropped row: 9 kg @ $0    (Not charged)
+  // so the math reads cleanly. Pre-fix, the parent row showed 63 kg but
+  // the buyer's pledged total_price as the dollar amount — that math
+  // didn't add up.
+
+  it("renders a separate 'Not charged' sub-row for the kg that didn't fill a bag", () => {
+    const commitments: Commitment[] = [
+      makeCommitment({
+        id: "c-partial",
+        payment_status: "setup_complete",
+        charge_amount_cents: null,
+        quantity_kg: 72,
+        kg_locked_at_settlement: 63,
+        total_price: 832,
+      }),
+    ];
+    const bagChargesByCommitmentId = {
+      "c-partial": [
+        {
+          id: "bc-1",
+          commitment_id: "c-partial",
+          bag_number: 1,
+          kg: 63,
+          amount_cents: 88000, // $880
+          payment_status: "charged" as const,
+          updated_at: "2026-04-20T00:00:00Z",
+        },
+      ],
+    };
+    render(
+      <ContributionsTable
+        commitments={commitments}
+        bagChargesByCommitmentId={bagChargesByCommitmentId}
+      />
+    );
+    // Parent row reflects the actually-charged amount ($880), not the
+    // buyer's pre-settle pledge ($832 for 72 kg).
+    const parent = screen.getByTestId("commitment-row-c-partial");
+    expect(parent.textContent).toContain("$880.00");
+
+    // Dropped sub-row exists with the leftover kg and $0.
+    const dropped = screen.getByTestId("commitment-dropped-c-partial");
+    expect(dropped).toBeInTheDocument();
+    expect(dropped.textContent).toContain("9");
+    expect(dropped.textContent).toContain("$0.00");
+    expect(dropped.textContent).toMatch(/Not charged/i);
+  });
+
+  it("does NOT render a dropped sub-row when the commit filled cleanly", () => {
+    // 60 kg pledged, 60 kg locked = clean fill; no leftover.
+    const commitments: Commitment[] = [
+      makeCommitment({
+        id: "c-clean",
+        payment_status: "setup_complete",
+        charge_amount_cents: null,
+        quantity_kg: 60,
+        kg_locked_at_settlement: 60,
+      }),
+    ];
+    const bagChargesByCommitmentId = {
+      "c-clean": [
+        {
+          id: "bc-1",
+          commitment_id: "c-clean",
+          bag_number: 1,
+          kg: 60,
+          amount_cents: 60000,
+          payment_status: "charged" as const,
+          updated_at: "2026-04-20T00:00:00Z",
+        },
+      ],
+    };
+    render(
+      <ContributionsTable
+        commitments={commitments}
+        bagChargesByCommitmentId={bagChargesByCommitmentId}
+      />
+    );
+    expect(screen.queryByTestId("commitment-dropped-c-clean")).not.toBeInTheDocument();
+  });
+
+  it("does NOT render a dropped sub-row pre-settle (kg_locked_at_settlement still null)", () => {
+    // The buyer is still on the active campaign — settlement hasn't run, so
+    // nothing has been "dropped" yet. Showing a dropped row here would be
+    // confusing.
+    const commitments: Commitment[] = [
+      makeCommitment({
+        id: "c-raising",
+        payment_status: "setup_complete",
+        charge_amount_cents: null,
+        quantity_kg: 72,
+        kg_locked_at_settlement: null,
+      }),
+    ];
+    render(<ContributionsTable commitments={commitments} />);
+    expect(screen.queryByTestId("commitment-dropped-c-raising")).not.toBeInTheDocument();
+  });
+
+  it("sums multiple charged bag rows for the parent total (multi-bag commit)", () => {
+    const commitments: Commitment[] = [
+      makeCommitment({
+        id: "c-multibag",
+        payment_status: "setup_complete",
+        charge_amount_cents: null,
+        quantity_kg: 120,
+        kg_locked_at_settlement: 120,
+      }),
+    ];
+    const bagChargesByCommitmentId = {
+      "c-multibag": [
+        { id: "bc-1", commitment_id: "c-multibag", bag_number: 1, kg: 60, amount_cents: 60000, payment_status: "charged" as const, updated_at: "2026-04-20T00:00:00Z" },
+        { id: "bc-2", commitment_id: "c-multibag", bag_number: 2, kg: 60, amount_cents: 60000, payment_status: "charged" as const, updated_at: "2026-04-20T00:00:00Z" },
+      ],
+    };
+    render(
+      <ContributionsTable
+        commitments={commitments}
+        bagChargesByCommitmentId={bagChargesByCommitmentId}
+      />
+    );
+    const row = screen.getByTestId("commitment-row-c-multibag");
+    // $600 + $600 = $1,200 — sums charged bag amount_cents, not commitment.total_price.
+    expect(row.textContent).toContain("$1,200.00");
+  });
+
+  it("only credits CHARGED bag rows in the parent total — failed bags don't inflate it", () => {
+    // 2 bags total: 1 charged ($600), 1 payment_failed. Parent total should
+    // be $600 ONLY. The user's bug was that the total reflected the
+    // buyer's pre-settle pledge even when some bags failed.
+    const commitments: Commitment[] = [
+      makeCommitment({
+        id: "c-partial-fail",
+        payment_status: "setup_complete",
+        charge_amount_cents: null,
+        quantity_kg: 120,
+        kg_locked_at_settlement: 120,
+      }),
+    ];
+    const bagChargesByCommitmentId = {
+      "c-partial-fail": [
+        { id: "bc-1", commitment_id: "c-partial-fail", bag_number: 1, kg: 60, amount_cents: 60000, payment_status: "charged" as const, updated_at: "2026-04-20T00:00:00Z" },
+        { id: "bc-2", commitment_id: "c-partial-fail", bag_number: 2, kg: 60, amount_cents: 60000, payment_status: "payment_failed" as const, updated_at: "2026-04-20T00:00:00Z" },
+      ],
+    };
+    render(
+      <ContributionsTable
+        commitments={commitments}
+        bagChargesByCommitmentId={bagChargesByCommitmentId}
+      />
+    );
+    const row = screen.getByTestId("commitment-row-c-partial-fail");
+    expect(row.textContent).toContain("$600.00");
   });
 
   it("renders an empty-state message when only charge_failed commitments are passed", () => {

--- a/components/buyer-commitments/commitment-drawer/closed-body.tsx
+++ b/components/buyer-commitments/commitment-drawer/closed-body.tsx
@@ -92,7 +92,10 @@ export function ClosedDrawerBody({
           <div className="font-body text-[11px] font-extrabold uppercase tracking-[0.14em] text-espresso/60">
             Your contributions
           </div>
-          <ContributionsTable commitments={group.commitments} />
+          <ContributionsTable
+            commitments={group.commitments}
+            bagChargesByCommitmentId={group.bagChargesByCommitmentId}
+          />
         </div>
       </div>
     );
@@ -222,7 +225,10 @@ export function ClosedDrawerBody({
         <div className="font-body text-[11px] font-extrabold uppercase tracking-[0.14em] text-espresso/60">
           Your contributions
         </div>
-        <ContributionsTable commitments={group.commitments} />
+        <ContributionsTable
+            commitments={group.commitments}
+            bagChargesByCommitmentId={group.bagChargesByCommitmentId}
+          />
       </div>
     </div>
   );

--- a/components/buyer-commitments/commitment-drawer/contributions-table.tsx
+++ b/components/buyer-commitments/commitment-drawer/contributions-table.tsx
@@ -2,10 +2,22 @@ import { Fragment } from "react";
 import type { Commitment } from "@/lib/types";
 import { UnitWeightText } from "@/components/unit-value";
 import { commitmentDisplayKg } from "@/lib/commitment-kg";
+import { effectiveChargedCents } from "../bucket-by-lifecycle";
 import { refundDollarsFor } from "./refund-amount";
+import type { BagChargeRow } from "./bag-breakdown";
 
 export interface ContributionsTableProps {
   commitments: Commitment[];
+  /**
+   * Per-commitment bag-charge rows, keyed by `commitment_id`. Populated
+   * server-side at `/dashboard/buyer/commitments` (RLS-scoped to the
+   * buyer). Bag-aware commits use these rows as the authoritative
+   * "what was actually charged" source so the Total column reflects the
+   * sum of `charged` bag amount_cents — for a partial-fill commit that's
+   * less than the buyer's pre-settle pledge. Absent for legacy commits;
+   * the helper falls back to `commitment.charge_amount_cents`.
+   */
+  bagChargesByCommitmentId?: Record<string, BagChargeRow[]>;
 }
 
 const fmtMoney = (n: number) =>
@@ -28,6 +40,9 @@ const STATUS_LABELS: Record<string, string> = {
   setup_complete: "Authorized",
   cancelled: "Cancelled",
   refunded: "Refunded",
+  // Used by the "dropped" sub-row for a bag-aware partial-fill commit.
+  // Frames it as "we never charged for this kg" rather than "you owe it."
+  not_charged: "Not charged",
 };
 
 const STATUS_TONE: Record<string, string> = {
@@ -36,6 +51,7 @@ const STATUS_TONE: Record<string, string> = {
   setup_complete: "bg-sky/15 text-espresso border-sky/40",
   cancelled: "bg-fog text-espresso/60 border-fog",
   refunded: "bg-tomato/10 text-tomato border-tomato/30",
+  not_charged: "bg-espresso/5 text-espresso/55 border-espresso/20",
 };
 
 function statusFor(c: Commitment): string {
@@ -45,7 +61,10 @@ function statusFor(c: Commitment): string {
   return c.payment_status || "pending_setup";
 }
 
-export function ContributionsTable({ commitments }: ContributionsTableProps) {
+export function ContributionsTable({
+  commitments,
+  bagChargesByCommitmentId,
+}: ContributionsTableProps) {
   const rows = commitments.filter((c) => c.payment_status !== "charge_failed");
 
   if (rows.length === 0) {
@@ -78,16 +97,49 @@ export function ContributionsTable({ commitments }: ContributionsTableProps) {
         <tbody>
           {rows.map((c, idx) => {
             const status = statusFor(c);
-            const total =
-              c.charge_amount_cents != null
-                ? c.charge_amount_cents / 100
-                : Number(c.total_price || 0);
+            // Cancelled commits never had a card charged — show $0.
+            // Everything else sums the charged bag rows (bag-aware) and
+            // falls back to commitment.charge_amount_cents (legacy) via
+            // effectiveChargedCents. Without this fix a partial-fill commit
+            // showed the buyer's PRE-SETTLE pledge total even though only
+            // the settled bags were charged.
+            const isCancelled =
+              c.status === "cancelled" || c.payment_status === "cancelled";
+            const bags = bagChargesByCommitmentId?.[c.id];
+            const total = isCancelled
+              ? 0
+              : effectiveChargedCents(c, bags) / 100;
+
+            // Bag-aware partial-fill: render a separate "Not charged" sub-
+            // row for the kg the buyer pledged that didn't fill a bag, so
+            // the math (settled-kg × price = total) reads cleanly and the
+            // dropped portion is visible. `kg_locked_at_settlement` is the
+            // signal that bag-aware settlement has happened on this commit.
+            const lockedKg = c.kg_locked_at_settlement;
+            const pledgedKg = Number(c.quantity_kg || 0);
+            const droppedKg =
+              lockedKg != null
+                ? Math.max(0, pledgedKg - Number(lockedKg))
+                : 0;
+            const hasDroppedRow = droppedKg > 0 && !isCancelled;
+
             const refundDollars = refundDollarsFor(c);
             const refundedAt = c.refunded_at;
             const hasRefund = refundDollars > 0;
+
             const isLast = idx === rows.length - 1;
-            const parentBorder = hasRefund || !isLast ? "border-b border-espresso/15" : "";
+            // Borders cascade: each row in a commit's chain gets a bottom
+            // border iff another row follows (either this commit's
+            // sub-rows or the next commit). The last sub-row of the last
+            // commit stays borderless for a clean table bottom.
+            const parentBorder =
+              hasDroppedRow || hasRefund || !isLast
+                ? "border-b border-espresso/15"
+                : "";
+            const droppedBorder =
+              hasRefund || !isLast ? "border-b border-espresso/15" : "";
             const refundBorder = !isLast ? "border-b border-espresso/15" : "";
+
             return (
               <Fragment key={c.id}>
                 <tr
@@ -114,6 +166,32 @@ export function ContributionsTable({ commitments }: ContributionsTableProps) {
                     </span>
                   </td>
                 </tr>
+                {hasDroppedRow && (
+                  <tr
+                    data-testid={`commitment-dropped-${c.id}`}
+                    className={droppedBorder}
+                  >
+                    <td className="px-3 py-2 align-top text-[11px] italic text-espresso/55">
+                      Didn&apos;t fill a bag
+                    </td>
+                    <td className="px-3 py-2 text-right align-top tabular-nums text-espresso/65">
+                      <UnitWeightText
+                        kg={droppedKg}
+                        maximumFractionDigits={1}
+                      />
+                    </td>
+                    <td className="px-3 py-2 text-right align-top tabular-nums text-espresso/65">
+                      {fmtMoney(0)}
+                    </td>
+                    <td className="px-3 py-2 text-right align-top">
+                      <span
+                        className={`inline-block rounded-pill border-[1.5px] px-2 py-0.5 text-[9px] font-extrabold uppercase tracking-[0.1em] ${STATUS_TONE.not_charged}`}
+                      >
+                        {STATUS_LABELS.not_charged}
+                      </span>
+                    </td>
+                  </tr>
+                )}
                 {hasRefund && (
                   <tr
                     data-testid={`commitment-refund-${c.id}`}

--- a/components/buyer-commitments/commitment-drawer/in-motion-body.tsx
+++ b/components/buyer-commitments/commitment-drawer/in-motion-body.tsx
@@ -106,7 +106,10 @@ export function InMotionDrawerBody({ group }: InMotionDrawerBodyProps) {
         <div className="font-body text-[11px] font-extrabold uppercase tracking-[0.14em] text-espresso/60">
           Your contributions
         </div>
-        <ContributionsTable commitments={group.commitments} />
+        <ContributionsTable
+          commitments={group.commitments}
+          bagChargesByCommitmentId={group.bagChargesByCommitmentId}
+        />
       </div>
     </div>
   );

--- a/components/buyer-commitments/commitment-drawer/raising-body.tsx
+++ b/components/buyer-commitments/commitment-drawer/raising-body.tsx
@@ -235,7 +235,10 @@ export function RaisingDrawerBody({ group, tiers }: RaisingDrawerBodyProps) {
         <div className="font-body text-[11px] font-extrabold uppercase tracking-[0.14em] text-espresso/60">
           Your contributions
         </div>
-        <ContributionsTable commitments={group.commitments} />
+        <ContributionsTable
+          commitments={group.commitments}
+          bagChargesByCommitmentId={group.bagChargesByCommitmentId}
+        />
       </div>
 
       <Button asChild variant="default" size="default" className="self-start">


### PR DESCRIPTION
## Summary

Follow-up to PR #92. The "Your contributions" table now showed the right settled-kg quantity, but the **Total** column still read `commitment.charge_amount_cents ?? total_price` — which for bag-aware commits always falls through to `total_price`, the buyer's pre-settle pledge. A partial-fill commit rendered as `63 kg · $832` — math that doesn't add up at the lot's per-kg price.

User-facing semantic broken: the row should let the buyer verify `settled-kg × per-kg = total`. With the pre-settle total it didn't.

## Fix

**Total column** now reads via `effectiveChargedCents` (PR #87): sums charged bag rows for bag-aware commits, falls back to `commitment.charge_amount_cents` for legacy. Cancelled commits show `$0`.

**New "dropped" sub-row** appears under each commit whose `kg_locked_at_settlement < quantity_kg`. Renders the leftover kg, `$0`, and a soft "Not charged" pill:

```
parent  → 63 kg · $880  · Paid
dropped →  9 kg · $0    · Not charged
```

Now the math reads cleanly. Threads `bagChargesByCommitmentId` through `ContributionsTableProps` and the four drawer callsites (closed × 2, in-motion, raising). Page-level fetch already populates this from PR #87 — no DB change needed.

## Test plan

Five new test cases in `contributions-table.test.tsx`:

- [x] `charge_amount_cents` null + no bag rows → `$0` (was: pre-settle `total_price`, anomalous fallback).
- [x] Cancelled commit → `$0` regardless of `total_price`.
- [x] Bag-aware partial fill (1 of 2 bags charged): parent shows charged amount, dropped sub-row shows leftover kg + `$0`.
- [x] Clean fill (locked == pledged): no dropped sub-row.
- [x] Pre-settle (`kg_locked_at_settlement` null): no dropped sub-row.
- [x] Multi-bag commit: parent total sums charged bag amount_cents.
- [x] Partial-success (some bags `payment_failed`): parent total credits only charged bags, not the pledge.

One existing test's contract changed:
- "falls back to total_price when charge_amount_cents is null" → "shows $0 when no money has actually moved". The new contract is **Total = what Stripe actually moved**, not **Total = what the buyer agreed to**.

CI is the verifier (sandbox still can't auth to `@merninos/ui` on GitHub Packages).

---
_Generated by [Claude Code](https://claude.ai/code/session_01NLEJsqpZtVmEJZUCLNfNJ2)_