### PR TITLE
fix(shipments): populate weight_kg from settled bags + show settled kg on hub pickup

### DIFF
--- a/app/api/payments/settle-deadlines/__tests__/bag-aware-lifecycle.integration.test.ts
+++ b/app/api/payments/settle-deadlines/__tests__/bag-aware-lifecycle.integration.test.ts
@@ -134,8 +134,14 @@ vi.mock("@/lib/auth/admin", () => ({
   getConfiguredAdminEmails: () => ["admin@test.local"],
 }));
 
+// Surface a typed reference to the createShipmentForLot mock so we can
+// assert it was called with the right total kg (sum of
+// kg_locked_at_settlement across confirmed commits). Without that arg,
+// shipments.weight_kg stays NULL and the seller shipments tab + hub
+// pickup page render no weight at all.
+const createShipmentForLotMock = vi.fn().mockResolvedValue({ ok: true });
 vi.mock("@/lib/shipments", () => ({
-  createShipmentForLot: vi.fn().mockResolvedValue({ ok: true }),
+  createShipmentForLot: (...args: unknown[]) => createShipmentForLotMock(...args),
 }));
 
 vi.mock("@/lib/referrals/insert-attribution", () => ({
@@ -525,6 +531,18 @@ describe("settle-deadlines bag-aware lifecycle integration (Task 4.15)", () => {
       fn: "finalize_campaign",
       args: { p_campaign_id: "camp-1", p_outcome: "settled" },
     });
+
+    // createShipmentForLot must be called with the total settled kg
+    // (sum of kg_locked_at_settlement across the 3 confirmed commits =
+    // 60 + 30 + 30 = 120). Without this argument, shipments.weight_kg
+    // stays NULL and the seller shipments tab + hub pickup page render
+    // no weight at all.
+    expect(createShipmentForLotMock).toHaveBeenCalledWith(
+      "lot-1",
+      "hub-1",
+      "camp-1",
+      120
+    );
 
     // Per-commit stamp must set both kg_locked AND status='confirmed' so the
     // orphan-cancel pass on a re-entrant run skips them and the seller +

--- a/app/api/payments/settle-deadlines/route.ts
+++ b/app/api/payments/settle-deadlines/route.ts
@@ -1023,8 +1023,23 @@ async function settleDeadlines(request: Request) {
         backgroundTasks.push(
           sendLotSuccessNotifications(admin, lot.id, campaign.hub_id)
         );
+        // Total kg the seller needs to physically ship = sum of allocated
+        // bag kg across confirmed commits. Each entry in lockedKgByCommitment
+        // is a whole multiple of bag_size_kg (expandToBagPortions writes
+        // full-bag portions only), so the sum lines up with
+        // completed_bags × bag_size_kg. Without this, the shipment row's
+        // weight_kg stayed NULL and the seller shipments tab rendered no
+        // weight at all.
+        const totalShipmentKg = Array.from(
+          lockedKgByCommitment.values()
+        ).reduce((sum, kg) => sum + Number(kg || 0), 0);
         backgroundTasks.push(
-          createShipmentForLot(lot.id, campaign.hub_id, campaign.id)
+          createShipmentForLot(
+            lot.id,
+            campaign.hub_id,
+            campaign.id,
+            totalShipmentKg
+          )
         );
       }
 
@@ -1055,6 +1070,12 @@ async function settleDeadlines(request: Request) {
     let transferFailedCount = 0;
     let failedCount = 0;
     let succeededCount = 0;
+    // Sum kg of commits whose per-commit Stripe transfer succeeded.
+    // Mirrors the bag-aware branch's `lockedKgByCommitment` sum — used to
+    // stamp shipments.weight_kg so the seller shipments tab + hub pickup
+    // page can render the right weight. Without this, shipments stayed
+    // at weight_kg=NULL and the seller saw no weight at all.
+    let succeededKg = 0;
     const debugCommitments: Array<Record<string, unknown>> = [];
     const hubConnectAccountByHubId = new Map<string, string | null>();
     const transferCapabilityByAccount = new Map<string, boolean>();
@@ -1388,6 +1409,7 @@ async function settleDeadlines(request: Request) {
             },
           });
           succeededCount += 1;
+          succeededKg += Number(commitment.quantity_kg || 0);
           continue;
         }
 
@@ -1493,6 +1515,7 @@ async function settleDeadlines(request: Request) {
         }
 
         succeededCount += 1;
+        succeededKg += Number(commitment.quantity_kg || 0);
       } catch (transferError) {
         failedCount += 1;
         transferFailedCount += 1;
@@ -1570,7 +1593,14 @@ async function settleDeadlines(request: Request) {
     console.log("[settle-deadlines] campaign", campaign.id, "lot", lot.id, "— debug:", debug, "transferFailedCount:", transferFailedCount, "failedCount:", failedCount, "succeededCount:", succeededCount, "orphansCancelled:", orphansCancelled);
     if (!debug && transferFailedCount === 0) {
       backgroundTasks.push(sendLotSuccessNotifications(admin, lot.id, campaign.hub_id));
-      backgroundTasks.push(createShipmentForLot(lot.id, campaign.hub_id, campaign.id));
+      // Legacy: pass the sum of successfully-transferred commits' quantity_kg
+      // so the shipments row gets a populated weight_kg. The bag-aware
+      // branch above does the same with kg_locked_at_settlement; both arrive
+      // at the same source of truth — "what the seller actually needs to
+      // ship after this campaign settled."
+      backgroundTasks.push(
+        createShipmentForLot(lot.id, campaign.hub_id, campaign.id, succeededKg)
+      );
     } else {
       console.log("[settle-deadlines] skipping success emails and shipment creation — condition not met");
     }

--- a/app/dashboard/hub/shipments/[id]/page.tsx
+++ b/app/dashboard/hub/shipments/[id]/page.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent } from "@merninos/ui";
 import { Badge } from "@merninos/ui";
 import { UnitWeightText } from "@/components/unit-value";
 import { CommitmentPickupButton } from "@/components/commitment-pickup-button";
+import { commitmentDisplayKg } from "@/lib/commitment-kg";
 import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 
@@ -34,10 +35,16 @@ export default async function HubShipmentDetailPage({
   const lot = shipment.lot as { id: string; title: string } | null;
   if (!lot) redirect("/dashboard/hub/shipments");
 
-  // Fetch commitments for this lot (hub owner RLS policy grants access)
+  // Fetch commitments for this lot (hub owner RLS policy grants access).
+  // `kg_locked_at_settlement` is what the hub owner actually owes the
+  // buyer at pickup — for a bag-aware partial-fill commit it's strictly
+  // less than the buyer's pre-settle `quantity_kg`. Without it, the
+  // hub manager hands over the over-pledged amount.
   const { data: commitments } = await supabase
     .from("commitments")
-    .select("id, buyer_id, quantity_kg, status, picked_up_at")
+    .select(
+      "id, buyer_id, quantity_kg, kg_locked_at_settlement, status, picked_up_at"
+    )
     .eq("lot_id", shipment.lot_id)
     .eq("status", "confirmed")
     .order("created_at", { ascending: true });
@@ -140,7 +147,7 @@ export default async function HubShipmentDetailPage({
                     <div className="min-w-0 flex-1">
                       <p className="text-sm font-medium text-foreground">{name}</p>
                       <p className="text-xs text-muted-foreground mt-0.5">
-                        <UnitWeightText kg={Number(c.quantity_kg)} />
+                        <UnitWeightText kg={commitmentDisplayKg(c)} />
                       </p>
                     </div>
                     <div className="flex items-center gap-2 shrink-0">

--- a/lib/shipments.ts
+++ b/lib/shipments.ts
@@ -9,12 +9,25 @@ import { createAdminClient } from "@/lib/supabase/admin";
  * relisted after a prior cycle get a brand-new shipment for the new campaign,
  * even if the prior cycle left a shipment row behind.
  *
+ * `weightKg` (optional) is the total kilograms the seller needs to ship,
+ * computed by the caller from the campaign's settled state. For bag-aware
+ * campaigns this is the sum of `commitments.kg_locked_at_settlement`
+ * across confirmed commits (i.e. settled bags × bag_size_kg). For legacy
+ * payment-mode campaigns it's the sum of `quantity_kg` across the
+ * successfully-charged commits. Pre-fix this was always NULL and the
+ * seller shipments page just hid the "Weight" section.
+ *
+ * Idempotency note: when a shipment already exists for this (lot, campaign)
+ * we DO NOT overwrite the existing weight_kg — the seller may have edited
+ * it after creation, and a retry shouldn't clobber that.
+ *
  * Never throws. Returns null on error so callers can fire-and-forget safely.
  */
 export async function createShipmentForLot(
   lotId: string,
   hubId: string | null,
-  campaignId: string | null
+  campaignId: string | null,
+  weightKg?: number | null
 ): Promise<{ id: string } | null> {
   const admin = createAdminClient();
 
@@ -32,9 +45,19 @@ export async function createShipmentForLot(
       }
     }
 
+    const insertPayload: Record<string, unknown> = {
+      lot_id: lotId,
+      hub_id: hubId,
+      campaign_id: campaignId,
+      status: "pending",
+    };
+    if (typeof weightKg === "number" && Number.isFinite(weightKg) && weightKg > 0) {
+      insertPayload.weight_kg = weightKg;
+    }
+
     const { data, error } = await admin
       .from("shipments")
-      .insert({ lot_id: lotId, hub_id: hubId, campaign_id: campaignId, status: "pending" })
+      .insert(insertPayload)
       .select("id")
       .single();
 


### PR DESCRIPTION
## Summary

Two symptoms, one root cause: shipment-side surfaces (hub pickup management + seller shipments tab) were reading pre-settle pledged weights — or nothing at all — instead of the actually-settled weight from the bag-aware allocation.

### Bug 1 — seller shipments tab showed no weight

`createShipmentForLot` has never written `shipments.weight_kg`. **Every shipment in the DB has `weight_kg=NULL`** (confirmed via SQL). The seller shipments page renders the Weight section gated on `s.weight_kg`, so it just never showed up. Longstanding gap, made painful now that bag-aware partial fills make the right value non-trivial to compute on the fly.

**Fix:**
- `lib/shipments.ts` accepts an optional `weightKg` and includes it in the INSERT payload when positive. Idempotency preserved — on retry the existing row is returned untouched, so a seller-edited weight isn't clobbered.
- `app/api/payments/settle-deadlines/route.ts` passes the right value on both branches:
  - **Bag-aware:** sum of `lockedKgByCommitment.values()` — already in scope. Equals `completed_bags × bag_size_kg`.
  - **Legacy:** new running sum `succeededKg` that accumulates `commitment.quantity_kg` next to each `succeededCount += 1`.

### Bug 2 — hub pickup management page showed buyer's pre-settle pledge

`app/dashboard/hub/shipments/[id]/page.tsx:40,143` selected only `quantity_kg` and displayed it directly. A buyer who pledged 72.07583 kg against a 63-kg bag had the hub manager seeing 72.07583 kg at pickup — but they only get 1 bag = 63 kg.

**Fix:** select `kg_locked_at_settlement` too, render via `commitmentDisplayKg` (lib/commitment-kg.ts, from PR #92).

## Test plan

- [x] New assertion in `bag-aware-lifecycle.integration.test.ts` that `createShipmentForLot` is invoked with `('lot-1', 'hub-1', 'camp-1', 120)` — the total settled kg across the test's three commits (60 + 30 + 30).
- [x] Existing tests already mock `createShipmentForLot` without inspecting args, so they continue to pass — the new arg is additive.
- [ ] Verify on staging: a fresh bag-aware campaign settles → seller shipments tab shows the right weight, hub pickup page shows the locked kg per buyer.

## Backfill note

`createShipmentForLot` is idempotent — won't re-run for an existing `(lot, campaign)` pair. The in-flight stuck shipment for campaign `314bf1fc-…` (`weight_kg=NULL`, settled kg = 63) won't auto-heal on the next cron tick. Easy one-shot SQL fix:

```sql
UPDATE shipments SET weight_kg = 63
WHERE id = '7b6153d9-0201-4db1-a47c-eef6e80f6ae3'
  AND weight_kg IS NULL;
```

Let me know if you want me to run that. Everything settled going forward picks up the right weight automatically.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NLEJsqpZtVmEJZUCLNfNJ2)_