### PR TITLE
fix(emails): lot-closed buyer + seller emails use settled bag amounts

### DIFF
--- a/app/api/payments/settle-deadlines/route.ts
+++ b/app/api/payments/settle-deadlines/route.ts
@@ -94,12 +94,40 @@ async function sendLotSuccessNotifications(admin: AdminClient, lotId: string, hu
       .single();
     console.log("[sendLotSuccessNotifications] seller fetch:", { seller: seller?.email, sellerError });
 
+    // Include bag-aware settlement fields so the email shows what was
+    // actually locked, not what was pledged pre-settle.
+    // - kg_locked_at_settlement: bag-aware "you got X kg out of your Y pledge"
+    // - charge_amount_cents: legacy "you were charged $X at commit time"
     const { data: commitments, error: commitmentsError } = await admin
       .from("commitments")
-      .select("id, buyer_id, quantity_kg, total_price")
+      .select(
+        "id, buyer_id, quantity_kg, kg_locked_at_settlement, total_price, charge_amount_cents"
+      )
       .eq("lot_id", lotId)
       .eq("status", "confirmed");
     console.log("[sendLotSuccessNotifications] confirmed commitments:", { count: commitments?.length, commitmentsError });
+
+    // For bag-aware commits, charge_amount_cents is NULL at this point —
+    // the charge worker hasn't run yet (this email fires from settle-deadlines
+    // at 00:00 UTC; the charge worker runs at 02:00 UTC). The planned dollar
+    // total per buyer lives on commitment_bag_charges.amount_cents, which
+    // we just inserted moments ago. Pull those rows so the buyer email can
+    // show the right "Total paid" number.
+    const commitIds = (commitments || []).map((c) => c.id);
+    const { data: bagCharges } = commitIds.length > 0
+      ? await admin
+          .from("commitment_bag_charges")
+          .select("commitment_id, amount_cents")
+          .in("commitment_id", commitIds)
+      : { data: [] };
+    const bagChargeCentsByCommitId = new Map<string, number>();
+    for (const row of bagCharges || []) {
+      bagChargeCentsByCommitId.set(
+        row.commitment_id,
+        (bagChargeCentsByCommitId.get(row.commitment_id) || 0) +
+          Number(row.amount_cents || 0)
+      );
+    }
 
     const buyerIds = [...new Set((commitments || []).map((c) => c.buyer_id).filter(Boolean))];
     const { data: buyers } =
@@ -140,7 +168,31 @@ async function sendLotSuccessNotifications(admin: AdminClient, lotId: string, hu
           console.log("[sendLotSuccessNotifications] skipping buyer — no email for buyer_id", commitment.buyer_id);
           return null;
         }
-        return { buyer: { email: buyer.email, contact_name: buyer.contact_name }, commitment };
+        // settledKg: bag-aware locked amount, with quantity_kg fallback for
+        // legacy commits (kg_locked_at_settlement is NULL pre-bag-aware).
+        const settledKg =
+          commitment.kg_locked_at_settlement != null &&
+          Number(commitment.kg_locked_at_settlement) > 0
+            ? Number(commitment.kg_locked_at_settlement)
+            : Number(commitment.quantity_kg || 0);
+        // settledTotalDollars: prefer the sum of bag-charge cents
+        // (bag-aware), then legacy charge_amount_cents, then total_price as
+        // last-resort fallback. Bag charges' amount_cents IS the planned
+        // buyer-side total (kg × tier price × 1 + platform fee), set by
+        // settle-deadlines moments before this email fires.
+        const bagCharCents = bagChargeCentsByCommitId.get(commitment.id);
+        const settledTotalDollars =
+          bagCharCents && bagCharCents > 0
+            ? bagCharCents / 100
+            : commitment.charge_amount_cents != null
+              ? Number(commitment.charge_amount_cents) / 100
+              : Number(commitment.total_price || 0);
+        return {
+          buyer: { email: buyer.email, contact_name: buyer.contact_name },
+          commitment: { id: commitment.id },
+          settledKg,
+          settledTotalDollars,
+        };
       })
       .filter((p): p is NonNullable<typeof p> => p !== null);
 
@@ -151,17 +203,19 @@ async function sendLotSuccessNotifications(admin: AdminClient, lotId: string, hu
       hub: hub?.id ?? "none",
     });
 
-    // Sum confirmed commitments rather than reading lot.committed_quantity_kg
-    // — by the time this runs, finalize_campaign has already reset the lot
-    // row to committed_quantity_kg=0 as part of the recycle.
-    const totalQuantityKg = (commitments || []).reduce(
-      (sum, c) => sum + Number(c.quantity_kg || 0),
+    // Sum settled kg across all confirmed commits — drives the seller
+    // email's "Total quantity sold" line and mirrors shipments.weight_kg
+    // (PR #94) so the seller's two surfaces (shipments tab + this email)
+    // show the same number.
+    const totalSettledKg = buyerPayloads.reduce(
+      (sum, p) => sum + p.settledKg,
       0
     );
 
     const result = await sendLotClosedEmailsBatch({
-      lot: { id: lot.id, title: lot.title, total_quantity_kg: totalQuantityKg },
+      lot: { id: lot.id, title: lot.title },
       buyers: buyerPayloads,
+      totalSettledKg,
       seller,
       hub,
       hubOwner,

--- a/lib/email/index.ts
+++ b/lib/email/index.ts
@@ -284,11 +284,35 @@ export async function sendLotClosedHubOwnerEmail(
 // ---------------------------------------------------------------------------
 
 export interface LotClosedBatchParams {
-  lot: Pick<Lot, "id" | "title" | "total_quantity_kg">;
+  lot: Pick<Lot, "id" | "title">;
   buyers: Array<{
     buyer: Pick<Profile, "email" | "contact_name">;
-    commitment: Pick<Commitment, "id" | "total_price" | "quantity_kg">;
+    commitment: Pick<Commitment, "id">;
+    /**
+     * Kg the buyer actually settled — for bag-aware that's
+     * `kg_locked_at_settlement` (allocated bags × bag_size_kg), which can
+     * be less than the buyer's pre-settle pledge when leftover kg didn't
+     * fill a bag. For legacy payment-mode commits it's `quantity_kg`.
+     * Caller resolves the fallback so this layer doesn't have to.
+     */
+    settledKg: number;
+    /**
+     * Total dollars on the buyer's card for this commit. For bag-aware
+     * that's the sum of `commitment_bag_charges.amount_cents / 100`
+     * (planned charges, since this email fires BEFORE the daily charge
+     * worker runs — so the cents haven't moved yet but the amount is
+     * locked). For legacy it's `charge_amount_cents / 100`. Falls back
+     * to `total_price` as a last resort.
+     */
+    settledTotalDollars: number;
   }>;
+  /**
+   * Total kg the seller needs to ship — sum of settledKg across all
+   * confirmed commits. Drives the seller email's "Total quantity sold"
+   * line. Mirrors `shipments.weight_kg` (PR #94) so the two surfaces
+   * agree.
+   */
+  totalSettledKg: number;
   seller?: Pick<Profile, "email" | "contact_name"> | null;
   hub?: Pick<Hub, "name" | "address" | "city" | "state" | "country"> | null;
   hubOwner?: Pick<Profile, "email" | "contact_name"> | null;
@@ -304,7 +328,7 @@ export async function sendLotClosedEmailsBatch(
 
   const payloads: { to: string; subject: string; html: string }[] = [];
 
-  for (const { buyer, commitment } of params.buyers) {
+  for (const { buyer, settledKg, settledTotalDollars } of params.buyers) {
     if (!buyer.email) continue;
     payloads.push({
       to: buyer.email,
@@ -312,8 +336,14 @@ export async function sendLotClosedEmailsBatch(
       html: await renderLotClosedBuyerHtml({
         buyerName: buyer.contact_name || "there",
         lotTitle: params.lot.title,
-        quantityKg: commitment.quantity_kg,
-        totalPrice: commitment.total_price,
+        // Settled kg, not the pre-settle pledge. For a bag-aware partial-fill
+        // commit (pledged 72 kg → locked 63 kg, leftover 9 kg dropped) the
+        // buyer sees 63 kg here.
+        quantityKg: settledKg,
+        // The dollar amount their card will be charged across the bags —
+        // sum of the just-created bag-charge amount_cents. Matches the
+        // CampaignSettled (AC10) per-bag email's `totalChargedCents`.
+        totalPrice: settledTotalDollars,
         currency: "USD",
         orderUrl,
       }),
@@ -330,7 +360,11 @@ export async function sendLotClosedEmailsBatch(
       html: await renderLotClosedSellerHtml({
         sellerName: params.seller.contact_name || "Seller",
         lotTitle: params.lot.title,
-        totalQuantityKg: params.lot.total_quantity_kg,
+        // Seller's "Total quantity sold" must mirror the actual shipment
+        // weight (shipments.weight_kg, set by PR #94 from the same source).
+        // Pre-fix this read `lot.total_quantity_kg` which the caller had
+        // overridden to be sum-of-pledges — wrong for bag-aware partials.
+        totalQuantityKg: params.totalSettledKg,
         hubAddress,
         fulfillmentUrl,
         relistReviewUrl,


### PR DESCRIPTION
## Audit summary

Walked every email template + caller and checked whether each kg-bearing field reads a settled or a pre-settle value.

| Template | Recipient | Shows kg? | Verdict |
|---|---|---|---|
| `LotClosedBuyer` | Buyer | Yes (Quantity + Total paid) | ❌ Pre-settle pledge → **fixed** |
| `LotClosedSeller` | Seller | Yes (Total quantity sold) | ❌ Pre-settle sum → **fixed** |
| `LotClosedHubOwner` | Hub owner | No | ✓ |
| `CampaignSettled` (AC10 per-buyer) | Buyer | Yes (per-bag table + totals) | ✓ already sums charged bag rows |
| `LotShipped`, `ReadyForPickup`, `LotClosedFailed`, `CardAuthFailed`, `PaymentUpdateRequired`, `DeadlineReminder`, digests | various | No kg displayed | ✓ |

The audit confirmed only the lot-closed-success batch (buyer + seller recipients) was still surfacing pledged amounts.

## Fix

**Caller** (`sendLotSuccessNotifications` in `app/api/payments/settle-deadlines/route.ts`):

- Extends commitments SELECT to include `kg_locked_at_settlement` + `charge_amount_cents`.
- New SELECT against `commitment_bag_charges` keyed by these commits to sum planned `amount_cents` per buyer. **Necessary** because this email fires from settle-deadlines (00:00 UTC) BEFORE the charge worker runs (02:00 UTC) — so `charge_amount_cents` is NULL for bag-aware commits at this moment, but `bag_charges.amount_cents` IS set (just inserted by settle-deadlines moments earlier).
- Resolves per-buyer settled values with the fallback chain:

```
settledKg            = kg_locked_at_settlement ?? quantity_kg
settledTotalDollars  = (Σ bag_charges.amount_cents) / 100
                     ?? charge_amount_cents / 100
                     ?? total_price
```

- Sums settledKg → `totalSettledKg` for the seller email.

**Batch shape** (`lib/email/index.ts`):

- `LotClosedBatchParams.buyers[].commitment` shrinks to `Pick<…,"id">` — no longer carries `quantity_kg`/`total_price`.
- New per-buyer `settledKg` + `settledTotalDollars` fields.
- New top-level `totalSettledKg` field drives the seller email.
- `lot` no longer requires `total_quantity_kg` (its only consumer was the seller email and that now reads `totalSettledKg`).

## Semantic note on "Total paid"

The buyer's existing email copy says **"Total paid"**. Pre-bag-aware that was accurate (card was charged at commit time). For bag-aware the charge actually happens on the next worker tick (~02:00 UTC), so the wording is a hair off — the number is correct, but technically nothing has been charged when the email lands. A copy refresh ("Total locked at settlement: $X — your card will be charged shortly") is a separate ticket. I prioritized getting the right NUMBER first since that's what was reported.

## Test plan

- [x] Existing tests in `app/api/payments/settle-deadlines/__tests__/*.ts` mock `sendLotClosedEmailsBatch` as a no-op, so they continue to pass — the new shape is additive.
- [x] `lib/email/__tests__/email-functions.test.ts` tests the *standalone* variants (`sendLotClosedBuyerEmail`, `sendLotClosedSellerEmail`), not the batch. Standalone signatures unchanged; tests continue to pass.
- [ ] Verify on staging: a fresh bag-aware campaign settles → buyer email shows their settled kg + bag-aware total; seller email shows the total settled kg matching the shipments tab.

## Standalone dead-code note

`sendLotClosedBuyerEmail` and `sendLotClosedSellerEmail` remain on their legacy `commitment.quantity_kg` / `total_price` signature. They're only invoked from `email-functions.test.ts` — no production caller. If anyone resurrects them, they need the same fallback-chain treatment.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NLEJsqpZtVmEJZUCLNfNJ2)_