### PR TITLE
fix(seller-lots): "Needs Review" cards show settled kg, not pre-settle pledge

### DIFF
--- a/app/dashboard/seller/lots/page.tsx
+++ b/app/dashboard/seller/lots/page.tsx
@@ -14,6 +14,7 @@ import {
   SellerAwaitingRelistCard,
   type RelistOutcome,
 } from "@/components/seller-awaiting-relist-card";
+import { commitmentDisplayKg } from "@/lib/commitment-kg";
 
 const statusStyles: Record<string, string> = {
   active: "bg-emerald-50 text-emerald-700 border-emerald-200",
@@ -148,18 +149,30 @@ export default async function SellerLotsPage() {
       // Exclude cancelled commitments so failed and cancelled campaigns
       // don't over-count refunded buyers, and dedupe per-campaign by
       // buyer_id so the buyerCount reflects distinct buyers, not rows.
+      //
+      // Include `kg_locked_at_settlement` so a settled bag-aware campaign
+      // sums the actual locked kg (allocated bags × bag_size_kg) instead
+      // of the pre-settle pledge. `commitmentDisplayKg` resolves the
+      // fallback per commit: locked when set, pledge otherwise — matches
+      // the seller commitments page (PR #92) and the shipment weight
+      // (PR #94).
       const { data: commitmentRows } = await supabase
         .from("commitments")
-        .select("campaign_id, buyer_id, quantity_kg")
+        .select("campaign_id, buyer_id, quantity_kg, kg_locked_at_settlement")
         .in("campaign_id", terminalCampaignIds)
         .neq("status", "cancelled");
 
       const buyerSets = new Map<string, Set<string>>();
       const kgByCampaign = new Map<string, number>();
-      for (const row of (commitmentRows as { campaign_id: string; buyer_id: string; quantity_kg: number }[]) || []) {
+      for (const row of (commitmentRows as {
+        campaign_id: string;
+        buyer_id: string;
+        quantity_kg: number;
+        kg_locked_at_settlement: number | null;
+      }[]) || []) {
         kgByCampaign.set(
           row.campaign_id,
-          (kgByCampaign.get(row.campaign_id) ?? 0) + (Number(row.quantity_kg) || 0)
+          (kgByCampaign.get(row.campaign_id) ?? 0) + commitmentDisplayKg(row)
         );
         const buyers = buyerSets.get(row.campaign_id) ?? new Set<string>();
         if (row.buyer_id) buyers.add(row.buyer_id);


### PR DESCRIPTION
## Summary

Another instance of the same theme — a seller-facing surface still reading the pre-settle pledged kg instead of the bag-aware settled amount.

The seller "My Lots" page's **Needs Review** section (the `awaiting_relist` cards under `#needs-review`) shows a per-campaign **Committed** number. For a settled bag-aware campaign where a partial-fill commit was rounded down to a whole bag count, this overstated what actually settled (e.g. showed 72 kg pledged instead of 63 kg locked).

## Fix

In `app/dashboard/seller/lots/page.tsx`:

- Extend the SELECT against `commitments` to fetch `kg_locked_at_settlement` alongside `quantity_kg`.
- Sum via `commitmentDisplayKg` (the helper from PR #92) so the per-commit kg uses the standard fallback chain: **locked when set, pledge otherwise**.

For failed/cancelled campaigns, `kg_locked_at_settlement` is null and the card still shows the pledge — accurate framing of "what buyers had committed to before things fell through."

## Test plan

- [x] Pure data-plumbing change, no test changes needed.
- [ ] Verify on staging: a settled campaign with a partial-fill commit (72 kg pledged → 63 kg locked) shows **63 kg** in the Needs Review card, not 72.07 kg.
- [ ] Verify a failed campaign still shows the buyer's pledge (kg_locked is null, helper falls back).

---
_Generated by [Claude Code](https://claude.ai/code/session_01NLEJsqpZtVmEJZUCLNfNJ2)_