### PR TITLE
fix(settle-deadlines): store per-buyer bag kg as numeric, not integer

### DIFF
--- a/scripts/data-repair-campaign-14408907.sql
+++ b/scripts/data-repair-campaign-14408907.sql
@@ -1,0 +1,127 @@
+-- Data repair: campaign 14408907-a374-496d-8f07-1c6a6540ff8a
+-- ("Andres Martinez Geisha Washed", lot 22d96924-f19f-4255-887a-9536ea8e12cb)
+-- was stranded `active` past its deadline by the integer-kg wedge bug.
+--
+-- See: supabase/migrations/20240101000047_bag_kg_numeric.sql for the root
+-- cause. APPLY THAT MIGRATION FIRST — this script inserts a 0.02815 kg
+-- bag-charge row, which the pre-migration `integer` column would reject.
+--
+-- This script replays exactly what the bag-aware branch of
+-- app/api/payments/settle-deadlines/route.ts would have done for a 60 kg
+-- bag with three chronologically-ordered commitments:
+--
+--   C1 18585bc4 quantity 9.07185 kg  → bag 1 portion 9.07185 kg
+--   C2 9c0a3620 quantity 50.9    kg  → bag 1 portion 50.9    kg
+--   C3 53f6d802 quantity 9.07185 kg  → bag 1 portion 0.02815 kg
+--                                      (remaining 9.0437 kg is in the
+--                                       incomplete bag 2 → dropped, never
+--                                       charged — matches charge-on-fill)
+--
+--   total committed 69.0437 kg → floor(69.0437 / 60) = 1 completed bag
+--   bag 1 fills to exactly 9.07185 + 50.9 + 0.02815 = 60.00000 kg
+--   completed_bags (1) >= min_bags_to_succeed (1) → SETTLE
+--
+-- Tier resolution: the only pricing tier (min_bags = 2) does not apply at
+-- 1 completed bag, so price_per_kg = lot base 26.46. Buyer-paid amount =
+-- round(kg * 26.46 * 1.1 * 100) [price + 10% platform fee], same formula
+-- the route uses. Verified against prod: C1 26405, C2 148150, C3 82 cents
+-- (C1/C2 also match the commit-time estimates already on the rows).
+--
+-- After this runs, the rows sit in `awaiting_charge` exactly as a normal
+-- settlement would leave them. The existing process-bag-charges cron
+-- (02:00 UTC daily) then charges the three saved cards, transfers out to
+-- the seller + hub, and fires the per-commitment settlement emails — the
+-- normal post-settle flow, fully restored. (The settle-time lot-closed
+-- courtesy email is the one side effect this SQL path cannot reproduce;
+-- the functional money + shipment flow is unaffected.)
+--
+-- Run AFTER the migration is applied. Single transaction; idempotent.
+
+BEGIN;
+
+-- 1) Per-bag charge ledger rows (one per commitment, bag 1). ON CONFLICT
+--    mirrors the route's upsert(ignoreDuplicates) so a re-run is a no-op.
+INSERT INTO commitment_bag_charges
+  (commitment_id, bag_number, kg, amount_cents, stripe_idempotency_key, payment_status)
+VALUES
+  ('18585bc4-d2c8-44c7-9971-23949d0a9c88', 1, 9.07185, 26405,
+   'charge:campaign:14408907-a374-496d-8f07-1c6a6540ff8a:commitment:18585bc4-d2c8-44c7-9971-23949d0a9c88:bag:1',
+   'awaiting_charge'),
+  ('9c0a3620-20e3-4246-87ac-f9c4a368fa58', 1, 50.9, 148150,
+   'charge:campaign:14408907-a374-496d-8f07-1c6a6540ff8a:commitment:9c0a3620-20e3-4246-87ac-f9c4a368fa58:bag:1',
+   'awaiting_charge'),
+  ('53f6d802-d2d0-412d-9d21-d94c65e98ca6', 1, 0.02815, 82,
+   'charge:campaign:14408907-a374-496d-8f07-1c6a6540ff8a:commitment:53f6d802-d2d0-412d-9d21-d94c65e98ca6:bag:1',
+   'awaiting_charge')
+ON CONFLICT (commitment_id, bag_number) DO NOTHING;
+
+-- 2) Stamp kg_locked_at_settlement + flip to confirmed (route does exactly
+--    this per commitment after the upsert). payment_status is intentionally
+--    left 'setup_complete' — the charge worker reads commitment_bag_charges,
+--    not commitments.payment_status.
+UPDATE commitments SET kg_locked_at_settlement = 9.07185, status = 'confirmed',
+  payment_error = NULL, updated_at = NOW()
+WHERE id = '18585bc4-d2c8-44c7-9971-23949d0a9c88' AND status <> 'cancelled';
+
+UPDATE commitments SET kg_locked_at_settlement = 50.9, status = 'confirmed',
+  payment_error = NULL, updated_at = NOW()
+WHERE id = '9c0a3620-20e3-4246-87ac-f9c4a368fa58' AND status <> 'cancelled';
+
+UPDATE commitments SET kg_locked_at_settlement = 0.02815, status = 'confirmed',
+  payment_error = NULL, updated_at = NOW()
+WHERE id = '53f6d802-d2d0-412d-9d21-d94c65e98ca6' AND status <> 'cancelled';
+
+-- 3) Shipment row the seller works off of (route fires createShipmentForLot
+--    with the sum of locked kg = 60.0). Idempotent on (lot_id, campaign_id).
+INSERT INTO shipments (lot_id, hub_id, campaign_id, status, weight_kg)
+SELECT '22d96924-f19f-4255-887a-9536ea8e12cb',
+       'ccfcda91-1244-4d75-ab05-c7e444001d23',
+       '14408907-a374-496d-8f07-1c6a6540ff8a',
+       'pending', 60
+WHERE NOT EXISTS (
+  SELECT 1 FROM shipments
+  WHERE lot_id = '22d96924-f19f-4255-887a-9536ea8e12cb'
+    AND campaign_id = '14408907-a374-496d-8f07-1c6a6540ff8a'
+);
+
+-- 4) Atomically settle the campaign + recycle the lot (same RPC the route
+--    calls). No-ops if the campaign is no longer 'active'.
+SELECT public.finalize_campaign(
+  '14408907-a374-496d-8f07-1c6a6540ff8a'::uuid, 'settled');
+
+-- 5) Sanity checks — fail loudly inside the transaction if anything is off.
+DO $$
+DECLARE
+  v_campaign_status text;
+  v_lot_status text;
+  v_charge_rows int;
+  v_confirmed int;
+BEGIN
+  SELECT status INTO v_campaign_status FROM campaigns
+   WHERE id = '14408907-a374-496d-8f07-1c6a6540ff8a';
+  SELECT status INTO v_lot_status FROM lots
+   WHERE id = '22d96924-f19f-4255-887a-9536ea8e12cb';
+  SELECT count(*) INTO v_charge_rows FROM commitment_bag_charges
+   WHERE commitment_id IN (
+     '18585bc4-d2c8-44c7-9971-23949d0a9c88',
+     '9c0a3620-20e3-4246-87ac-f9c4a368fa58',
+     '53f6d802-d2d0-412d-9d21-d94c65e98ca6');
+  SELECT count(*) INTO v_confirmed FROM commitments
+   WHERE campaign_id = '14408907-a374-496d-8f07-1c6a6540ff8a'
+     AND status = 'confirmed';
+
+  IF v_campaign_status <> 'settled' THEN
+    RAISE EXCEPTION 'campaign status is % (expected settled)', v_campaign_status;
+  END IF;
+  IF v_lot_status <> 'awaiting_relist' THEN
+    RAISE EXCEPTION 'lot status is % (expected awaiting_relist)', v_lot_status;
+  END IF;
+  IF v_charge_rows <> 3 THEN
+    RAISE EXCEPTION 'expected 3 bag-charge rows, found %', v_charge_rows;
+  END IF;
+  IF v_confirmed <> 3 THEN
+    RAISE EXCEPTION 'expected 3 confirmed commitments, found %', v_confirmed;
+  END IF;
+END $$;
+
+COMMIT;

--- a/supabase/migrations/20240101000047_bag_kg_numeric.sql
+++ b/supabase/migrations/20240101000047_bag_kg_numeric.sql
@@ -1,0 +1,79 @@
+-- Bag-aware settlement: store per-buyer bag kg as numeric, not integer.
+--
+-- THE BUG
+-- Buyers commit in pounds; the commit form converts to kg with full
+-- precision, so `commitments.quantity_kg` is `numeric` and routinely
+-- fractional (e.g. 9.07185 kg = exactly 20 lb, 50.9 kg, ...).
+--
+-- Bag-aware settlement (`app/api/payments/settle-deadlines/route.ts`)
+-- splits each commitment's quantity into per-completed-bag portions via
+-- `expandToBagPortions` (lib/bag-assignment.ts) and writes one
+-- `commitment_bag_charges` row per (commitment, bag). Those portion kg are
+-- just as fractional as the source commitments — and the kg that completes
+-- a bag to exactly bag_size is whatever sliver is left over.
+--
+-- But three destination columns were declared `integer`:
+--   * commitment_bag_charges.kg           (+ CHECK (kg > 0))
+--   * commitments.kg_locked_at_settlement
+--   * commitments.kg_refunded_at_settlement
+--
+-- Two failure modes resulted:
+--
+--  1. HARD WEDGE (the reported bug). When a campaign's commitments sum to
+--     just over a bag boundary, the last buyer's portion that completes
+--     the bag can be a sub-1kg sliver. Example: 9.07185 + 50.9 + 9.07185
+--     = 69.0437 kg with a 60 kg bag → bag 1 fills to 60.0 with the third
+--     buyer contributing only 0.02815 kg. Postgres rounds 0.02815 → 0 on
+--     insert into the `integer` column, which violates
+--     `commitment_bag_charges_kg_check (kg > 0)`. Because settle-deadlines
+--     inserts every bag-charge row in ONE batched upsert, the whole insert
+--     is rejected. The route then skips kg_locked stamping, the
+--     unallocated-cancel pass, AND finalize_campaign (all gated on the
+--     insert succeeding), so the campaign is stranded `active` past its
+--     deadline forever: nobody is charged, nobody is refunded, every
+--     commitment shows "Funds Held" on the buyer dashboard indefinitely,
+--     and the lot never recycles.
+--
+--  2. SILENT DRIFT. Even when the sliver rounds to >= 1 (so the upsert
+--     succeeds), `integer` corrupts the real values — 9.07185 → 9,
+--     50.9 → 51 — so kg_locked_at_settlement, the per-row charge kg, and
+--     the derived shipment weight all diverge from the true bag math on
+--     campaigns that DO settle.
+--
+-- THE FIX
+-- Widen the three columns to `numeric` so they faithfully store the same
+-- precision as `commitments.quantity_kg`. The existing
+-- `commitment_bag_charges_kg_check (kg > 0)` survives an ALTER COLUMN TYPE
+-- and stays correct for numeric (0.02815 > 0 is true), so no
+-- drop/recreate is needed. `lots.bag_size_kg` is deliberately left
+-- `integer` — a bag's physical size is a whole number of kg; it is not
+-- part of this bug.
+--
+-- No views or generated columns depend on these columns (verified against
+-- prod before authoring), so the type change is mechanical and safe.
+--
+-- Historical rows: three commitments from previously-settled bag-aware
+-- campaigns already have integer-truncated kg_locked_at_settlement values.
+-- This migration does NOT backfill them — those campaigns already shipped
+-- and the drift is sub-kg cosmetic; reconstructing the exact pre-rounding
+-- value would require replaying bag assignment and is out of scope for the
+-- wedge fix. New settlements (and the data-repair for the stranded
+-- campaign) write full-precision values from here on.
+
+alter table public.commitment_bag_charges
+  alter column kg type numeric using kg::numeric;
+
+comment on column public.commitment_bag_charges.kg is
+  'Buyer''s kg contribution to this specific bag, from expandToBagPortions. numeric (not integer) because commitments.quantity_kg is fractional (lb→kg conversion); the bag-completing sliver can be well under 1 kg. Always > 0 (CHECK); rows are never created for zero-kg contributions or for incomplete bags.';
+
+alter table public.commitments
+  alter column kg_locked_at_settlement type numeric
+    using kg_locked_at_settlement::numeric,
+  alter column kg_refunded_at_settlement type numeric
+    using kg_refunded_at_settlement::numeric;
+
+comment on column public.commitments.kg_locked_at_settlement is
+  'kg the buyer actually purchased after bag-aware settlement (NULL pre-settlement). numeric to match the fractional precision of quantity_kg and commitment_bag_charges.kg.';
+
+comment on column public.commitments.kg_refunded_at_settlement is
+  'kg refunded to the buyer because they landed in an unfilled bag (NULL pre-settlement). numeric to match the fractional precision of quantity_kg.';


### PR DESCRIPTION
## Summary

- Bag-aware settlement wrote derived per-bag kg into `integer` columns, but `commitments.quantity_kg` is `numeric` (buyers commit in lb → converted to kg with full precision). When commitments summed to just over a bag boundary, the buyer whose portion completed the bag got a sub-1kg sliver (e.g. `0.02815 kg`). Postgres rounded it to `0`, violating `commitment_bag_charges_kg_check (kg > 0)`. Because the route inserts all bag-charge rows in **one batched upsert**, the whole insert failed — and kg-lock stamping, the unallocated-cancel pass, and `finalize_campaign` are all gated on that insert succeeding. The campaign was stranded `active` past deadline: no charges, no refunds, every commitment stuck on "Funds Held".
- A second latent bug: even when the sliver rounded to ≥1, `integer` silently corrupted the real values (9.07185 → 9, 50.9 → 51), drifting `kg_locked_at_settlement` / per-row charge kg / shipment weight on campaigns that *did* settle.
- **Fix:** widen `commitment_bag_charges.kg`, `commitments.kg_locked_at_settlement`, and `commitments.kg_refunded_at_settlement` from `integer` → `numeric` (migration `20240101000047`). The `CHECK (kg > 0)` survives the `ALTER COLUMN TYPE` and stays correct for numeric. `lots.bag_size_kg` stays `integer` — bag size is genuinely whole; not part of this bug. No code change needed — `expandToBagPortions` already produces correct fractional portions and the TS types already use `number`.
- Includes `scripts/data-repair-campaign-14408907.sql`, a transactional, idempotent replay of the correct settlement for the one stranded prod campaign ("Andres Martinez Geisha Washed").

The migration has already been applied to the prod database and the data-repair has been executed: campaign `14408907` is now `settled`, the lot recycled to `awaiting_relist`, all 3 commitments `confirmed` (locked kg 9.07185 / 50.9 / 0.02815 = 60.0), 3 `awaiting_charge` bag-charge rows created, and the shipment row created. The daily `process-bag-charges` cron will charge the saved cards and transfer out to seller + hub.

## Test plan

- [ ] CI green on the branch
- [x] Migration applied to prod; verified all 3 columns are `numeric`
- [x] Stranded campaign repaired and verified: campaign `settled`, lot `awaiting_relist`, 3 commitments `confirmed`, 3 bag-charge rows + shipment present
- [ ] Confirm `process-bag-charges` cron charges the 3 saved cards on its next 02:00 UTC tick and transfers out to seller/hub

https://claude.ai/code/session_01TKKmC5kiDJnEuoaq5zimPL

---
_Generated by [Claude Code](https://claude.ai/code/session_01TKKmC5kiDJnEuoaq5zimPL)_